### PR TITLE
Collapsed Nav, Mobile Bar, & More UX Tweaks

### DIFF
--- a/web2/src/App.tsx
+++ b/web2/src/App.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Divider,
   Drawer,
+  IconButton,
   Link,
   List,
   ListItemButton,
@@ -28,7 +29,10 @@ import { Outlet, Link as RouterLink } from 'react-router-dom';
 import './App.css';
 import ServerEvents from './components/ServerEvents.tsx';
 import VersionFooter from './components/VersionFooter.tsx';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import theme from './theme.tsx';
+import { ExpandMore } from '@mui/icons-material';
+
 interface NavItem {
   name: string;
   path: string;
@@ -37,50 +41,56 @@ interface NavItem {
   icon?: ReactNode;
 }
 
-const navItems: NavItem[] = [
-  { name: 'Guide', path: '/guide', visible: true, icon: <TvIcon /> },
-  {
-    name: 'Channels',
-    path: '/channels',
-    visible: true,
-    icon: <SettingsRemoteIcon />,
-  },
-  { name: 'Watch', path: '/watch', visible: false, icon: <LiveTvIcon /> },
-  {
-    name: 'Library',
-    path: '/library',
-    visible: true,
-    icon: <VideoLibraryIcon />,
-    children: [
-      {
-        name: 'Filler Lists',
-        path: '/library/filler',
-        visible: true,
-        icon: <PreviewIcon />,
-      },
-      {
-        name: 'Custom Shows',
-        path: '/library/custom-shows',
-        visible: true,
-        icon: <TheatersIcon />,
-      },
-    ],
-  },
-  {
-    name: 'Settings',
-    path: '/settings/xmltv',
-    visible: true,
-    icon: <SettingsIcon />,
-  },
-];
-
-const drawerWidth = 240;
-
 export function Root() {
   const [open, setOpen] = useState(false);
-  const toggleDrawer = () => {
-    setOpen(!open);
+  const toggleDrawerOpen = () => {
+    setOpen(true);
   };
+
+  const toggleDrawerClosed = () => {
+    setOpen(false);
+  };
+
+  const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const navItems: NavItem[] = [
+    { name: 'Guide', path: '/guide', visible: true, icon: <TvIcon /> },
+    {
+      name: 'Channels',
+      path: '/channels',
+      visible: true,
+      icon: <SettingsRemoteIcon />,
+    },
+    { name: 'Watch', path: '/watch', visible: false, icon: <LiveTvIcon /> },
+    {
+      name: 'Library',
+      path: '/library',
+      visible: true,
+      icon: <VideoLibraryIcon />,
+      children: [
+        {
+          name: 'Filler Lists',
+          path: '/library/filler',
+          visible: open,
+          icon: <PreviewIcon />,
+        },
+        {
+          name: 'Custom Shows',
+          path: '/library/custom-shows',
+          visible: open,
+          icon: <TheatersIcon />,
+        },
+      ],
+    },
+    {
+      name: 'Settings',
+      path: '/settings/general',
+      visible: true,
+      icon: <SettingsIcon />,
+    },
+  ];
+
+  const drawerWidth = open ? 240 : 60;
 
   return (
     <ThemeProvider theme={theme}>
@@ -88,14 +98,41 @@ export function Root() {
       <Box sx={{ display: 'flex' }}>
         <CssBaseline />
         <AppBar
-          position="absolute"
+          position="fixed"
           sx={{
-            width: `calc(100% - ${drawerWidth}px)`,
             ml: `${drawerWidth}px`,
             p: 0,
+            zIndex: theme.zIndex.drawer + 1,
           }}
         >
           <Toolbar>
+            <Link
+              underline="none"
+              color="inherit"
+              to="/guide"
+              component={RouterLink}
+            >
+              <img
+                style={{ width: '2rem', height: '2rem', marginTop: '0.4em' }}
+                src="/dizquetv.png"
+              />
+            </Link>
+            <Typography
+              variant="h6"
+              component="h1"
+              noWrap
+              color="inherit"
+              sx={{ flexGrow: 1, pl: 1 }}
+            >
+              <Link
+                underline="none"
+                color="inherit"
+                to="/guide"
+                component={RouterLink}
+              >
+                Tunarr
+              </Link>
+            </Typography>
             <Box flexGrow={1}></Box>
             <Button
               href="http://localhost:8000/api/xmltv.xml"
@@ -113,87 +150,102 @@ export function Root() {
             </Button>
           </Toolbar>
         </AppBar>
-        <Drawer
-          sx={{
-            width: drawerWidth,
-            flexShrink: 0,
-            '& .MuiDrawer-paper': {
-              width: drawerWidth,
-              boxSizing: 'border-box',
-              p: 0,
-            },
-          }}
-          variant="permanent"
-          anchor="left"
-        >
-          <Toolbar
+        {!smallViewport ? (
+          <Drawer
             sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              px: [1],
+              width: drawerWidth,
+              flexShrink: 0,
+              '& .MuiDrawer-paper': {
+                width: drawerWidth,
+                boxSizing: 'border-box',
+                p: 0,
+              },
+              WebkitTransitionDuration: '.15s',
+              WebkitTransitionTimingFunction: 'cubic-bezier(0.4,0,0.2,1)',
             }}
+            variant="permanent"
+            anchor="left"
+            onMouseEnter={toggleDrawerOpen}
+            onMouseLeave={toggleDrawerClosed}
           >
-            <img
-              style={{ width: '2rem', height: '2rem' }}
-              src="/dizquetv.png"
-            />
-            <Typography
-              variant="h6"
-              component="h1"
-              noWrap
-              color="inherit"
-              sx={{ flexGrow: 1, pl: 1 }}
-            >
-              <Link
-                underline="none"
-                color="inherit"
-                to="/guide"
-                component={RouterLink}
-              >
-                DizqueTV
-              </Link>
-            </Typography>
-          </Toolbar>
-          <Divider />
-          <List component="nav" sx={{ flex: '1 1 0%' }}>
-            {navItems
-              .filter((item) => item.visible)
-              .map((item) => (
-                <React.Fragment key={item.name}>
-                  <ListItemButton
-                    to={item.path}
-                    key={item.name}
-                    onClick={toggleDrawer}
-                    component={RouterLink}
-                  >
-                    {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
-                    <ListItemText primary={item.name} />
-                  </ListItemButton>
-                  {item.children ? (
-                    <List component="div" disablePadding>
-                      {item.children.map((child) => (
-                        <ListItemButton
-                          key={child.name}
-                          to={child.path}
-                          sx={{ pl: 4 }}
-                          onClick={toggleDrawer}
-                          component={RouterLink}
-                        >
-                          {child.icon && (
-                            <ListItemIcon>{child.icon}</ListItemIcon>
-                          )}
-                          <ListItemText primary={child.name} />
-                        </ListItemButton>
-                      ))}
-                    </List>
-                  ) : null}
-                </React.Fragment>
-              ))}
-            <Divider sx={{ my: 1 }} />
-          </List>
-          <VersionFooter />
-        </Drawer>
+            <Toolbar
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                px: [1],
+              }}
+            ></Toolbar>
+            <Divider />
+            <List component="nav" sx={{ flex: '1 1 0%' }}>
+              {navItems
+                .filter((item) => item.visible)
+                .map((item) => (
+                  <React.Fragment key={item.name}>
+                    <ListItemButton
+                      to={item.path}
+                      key={item.name}
+                      component={RouterLink}
+                    >
+                      {item.icon && (
+                        <ListItemIcon sx={{ minWidth: 45 }}>
+                          {item.icon}
+                        </ListItemIcon>
+                      )}
+                      <ListItemText primary={item.name} />
+                      {item.children ? (
+                        <ListItemIcon sx={{ justifyContent: 'right' }}>
+                          <ExpandMore />
+                        </ListItemIcon>
+                      ) : null}
+                    </ListItemButton>
+                    {item.children ? (
+                      <List component="div" disablePadding>
+                        {item.children
+                          .filter((item) => item.visible)
+                          .map((child) => (
+                            <ListItemButton
+                              key={child.name}
+                              to={child.path}
+                              sx={{ pl: 4 }}
+                              component={RouterLink}
+                            >
+                              {child.icon && (
+                                <ListItemIcon sx={{ minWidth: 45 }}>
+                                  {child.icon}
+                                </ListItemIcon>
+                              )}
+                              <ListItemText primary={child.name} />
+                            </ListItemButton>
+                          ))}
+                      </List>
+                    ) : null}
+                  </React.Fragment>
+                ))}
+              <Divider sx={{ my: 1 }} />
+            </List>
+            {!open || <VersionFooter />}
+          </Drawer>
+        ) : (
+          <AppBar position="fixed" sx={{ top: 'auto', bottom: 0 }}>
+            <Toolbar sx={{ display: 'flex', justifyContent: 'space-around' }}>
+              {navItems
+                .filter((item) => item.visible)
+                .map((item) => (
+                  <React.Fragment key={item.name}>
+                    <IconButton
+                      to={item.path}
+                      key={item.name}
+                      component={RouterLink}
+                      sx={{ display: 'inline-block', color: '#fff' }}
+                    >
+                      {item.icon}
+                    </IconButton>
+                  </React.Fragment>
+                ))}
+            </Toolbar>
+          </AppBar>
+        )}
         <Box
           component="main"
           sx={{

--- a/web2/src/pages/library/LibraryIndexPage.tsx
+++ b/web2/src/pages/library/LibraryIndexPage.tsx
@@ -1,40 +1,79 @@
-import { Box, Stack, Typography } from '@mui/material';
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Grid,
+  Typography,
+} from '@mui/material';
 import { Link } from 'react-router-dom';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
+import { ArrowForward } from '@mui/icons-material';
 
 export default function LibraryIndexPage() {
   return (
-    <Box sx={{ width: '100%' }}>
-      <Stack direction="column" spacing={2}>
-        <PaddedPaper
-          component={Link}
-          to="/library/filler"
-          sx={{ textDecoration: 'none' }}
-        >
-          <Typography variant="h5" mb={1}>
-            Filler&hellip;
-          </Typography>
-          <Typography variant="body1">
-            Filler lists are collections of videos that you may want to play
-            during 'flex' time segments. Flex is time within a channel that does
-            not have a program scheduled (usually used for padding).
-          </Typography>
-        </PaddedPaper>
-        <PaddedPaper
-          component={Link}
-          to="/library/custom-shows"
-          sx={{ textDecoration: 'none' }}
-        >
-          <Typography variant="h5" mb={1}>
-            Custom Shows&hellip;
-          </Typography>
-          <Typography variant="body1">
-            Custom Shows are sequences of videos that represent a episodes of a
-            virtual TV show. When you add these shows to a channel, the schedule
-            tools will treat the videos as if they belonged to a single TV show.
-          </Typography>
-        </PaddedPaper>
-      </Stack>
-    </Box>
+    <>
+      <Typography variant="h3" mb={2}>
+        Library
+      </Typography>
+      <Grid
+        container
+        columns={{ sm: 8, md: 16 }}
+        columnSpacing={2}
+        rowSpacing={2}
+      >
+        <Grid item sm={16} md={8}>
+          <Card sx={{ minWidth: 275, pb: 1, pr: 1 }}>
+            <CardContent>
+              <Typography variant="h5" component="div">
+                Filler
+              </Typography>
+              <Typography variant="body2">
+                Filler lists are collections of videos that you may want to play
+                during 'flex' time segments. Flex is time within a channel that
+                does not have a program scheduled (usually used for padding).
+              </Typography>
+            </CardContent>
+            <CardActions sx={{ justifyContent: 'right' }}>
+              <Button
+                size="small"
+                variant="contained"
+                component={Link}
+                to="/library/filler"
+                endIcon={<ArrowForward />}
+              >
+                Edit Fillers
+              </Button>
+            </CardActions>
+          </Card>
+        </Grid>
+        <Grid item sm={16} md={8}>
+          <Card sx={{ minWidth: 275, pb: 1, pr: 1 }}>
+            <CardContent>
+              <Typography variant="h5" component="div">
+                Custom Shows
+              </Typography>
+              <Typography variant="body2">
+                Custom Shows are sequences of videos that represent a episodes
+                of a virtual TV show. When you add these shows to a channel, the
+                schedule tools will treat the videos as if they belonged to a
+                single TV show.
+              </Typography>
+            </CardContent>
+            <CardActions sx={{ justifyContent: 'right' }}>
+              <Button
+                size="small"
+                variant="contained"
+                component={Link}
+                to="/library/custom-shows"
+                endIcon={<ArrowForward />}
+              >
+                Edit Custom Shows
+              </Button>
+            </CardActions>
+          </Card>
+        </Grid>
+      </Grid>
+    </>
   );
 }


### PR DESCRIPTION

Added gmail-style collapsable nav on hover:
<img width="1232" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/6b5d5e86-a133-4235-8051-68a71242a192">

<img width="1236" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/df688786-8196-4f00-b24f-87083dde2adf">

Added a mobile app bar for small viewports:
<img width="392" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/4e77f106-17ed-496a-a248-4b9df0d39980">


Re-did Library Page:
<img width="1237" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/01261619-f753-49c4-b34a-1812e6b27b9c">
