### PR TITLE
Fix Guide page rounding in calculations

### DIFF
--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -56,7 +56,6 @@ const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
 const calcProgress = (start: Dayjs, end: Dayjs): number => {
   const total = end.unix() - start.unix();
   const p = dayjs().unix() - start.unix();
-
   return round(100 * (p / total), 2);
 };
 

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -56,7 +56,8 @@ const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
 const calcProgress = (start: Dayjs, end: Dayjs): number => {
   const total = end.unix() - start.unix();
   const p = dayjs().unix() - start.unix();
-  return Math.round(100 * (p / total));
+
+  return round(100 * (p / total), 2);
 };
 
 const roundNearestMultiple = (num: number, multiple: number): number => {

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -16,7 +16,7 @@ import { useCallback, useState } from 'react';
 import { useInterval } from 'usehooks-ts';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import { useAllTvGuides } from '../../hooks/useTvGuide.ts';
-import { isEmpty } from 'lodash-es';
+import { isEmpty, round } from 'lodash-es';
 
 dayjs.extend(duration);
 
@@ -145,8 +145,9 @@ export default function GuidePage() {
       duration = duration.subtract(trimEnd, 'ms');
     }
 
-    const pct = Math.round(
+    const pct = round(
       (duration.asMilliseconds() / timelineDuration.asMilliseconds()) * 100.0,
+      2,
     );
 
     const grey = index % 2 === 0 ? 300 : 400;


### PR DESCRIPTION
Moved rounding to lodash to easily support rounding to 2 decimal places.

Previously rounded to whole integer e.g.

6.083111111111111  => 6

Now it's....

6.083111111111111 => 6.08

Screenshot before fix:
![image](https://github.com/chrisbenincasa/tunarr/assets/6005331/513d01a0-52e7-45d5-a463-d915d91f583b)


Screenshot after fix:
<img width="1528" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/8654da87-a874-4153-a5dd-f27fdcaf7183">


Fixes: https://github.com/chrisbenincasa/tunarr/issues/46