### PR TITLE
Add navigation to Guide page

### DIFF
--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -225,11 +225,11 @@ export default function GuidePage() {
         <IconButton onClick={zoomOut}>
           <ZoomOutIcon />
         </IconButton>
-        <IconButton disabled={navigationDisabled}>
-          <ArrowBackIos onClick={navigateBackward} />
+        <IconButton disabled={navigationDisabled} onClick={navigateBackward}>
+          <ArrowBackIos />
         </IconButton>
-        <IconButton>
-          <ArrowForwardIos onClick={navigateForward} />
+        <IconButton onClick={navigateForward}>
+          <ArrowForwardIos />
         </IconButton>
       </Stack>
       <PaddedPaper>

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -2,6 +2,7 @@ import ZoomInIcon from '@mui/icons-material/ZoomIn';
 import ZoomOutIcon from '@mui/icons-material/ZoomOut';
 import {
   Box,
+  Button,
   Color,
   Icon,
   IconButton,
@@ -206,6 +207,8 @@ export default function GuidePage() {
   const zoomDisabled =
     end.subtract(SubtractInterval).diff(start) < MinDurationMillis;
 
+  const navigationDisabled = now.isAfter(start);
+
   return (
     <>
       <Typography variant="h3" mb={2}>
@@ -222,7 +225,7 @@ export default function GuidePage() {
         <IconButton onClick={zoomOut}>
           <ZoomOutIcon />
         </IconButton>
-        <IconButton>
+        <IconButton disabled={navigationDisabled}>
           <ArrowBackIos onClick={navigateBackward} />
         </IconButton>
         <IconButton>

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -3,6 +3,7 @@ import ZoomOutIcon from '@mui/icons-material/ZoomOut';
 import {
   Box,
   Color,
+  Icon,
   IconButton,
   Stack,
   Tooltip,
@@ -17,6 +18,13 @@ import { useInterval } from 'usehooks-ts';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import { useAllTvGuides } from '../../hooks/useTvGuide.ts';
 import { isEmpty, round } from 'lodash-es';
+import {
+  ArrowBackIos,
+  ArrowCircleLeft,
+  ArrowCircleRight,
+  ArrowForward,
+  ArrowForwardIos,
+} from '@mui/icons-material';
 
 dayjs.extend(duration);
 
@@ -67,7 +75,7 @@ const roundNearestMultiple = (num: number, multiple: number): number => {
 
 export default function GuidePage() {
   const now = dayjs();
-  const [start] = useState(
+  const [start, setStart] = useState(
     dayjs()
       .minute(roundNearestMultiple(now.minute(), 15))
       .second(0)
@@ -102,6 +110,16 @@ export default function GuidePage() {
       setEnd((last) => last.subtract(SubtractInterval));
     }
   }, [end, start, setEnd]);
+
+  const navigateForward = useCallback(() => {
+    setEnd((last) => last.add(1, 'hours'));
+    setStart((start) => start.add(1, 'hours'));
+  }, [end, start, setEnd, setStart]);
+
+  const navigateBackward = useCallback(() => {
+    setEnd((last) => last.subtract(1, 'hours'));
+    setStart((start) => start.subtract(1, 'hours'));
+  }, [end, start, setEnd, setStart]);
 
   if (isPending) return 'Loading...';
 
@@ -197,12 +215,20 @@ export default function GuidePage() {
         {start.format('DD/MM/YYYY, h:mm A')} to{' '}
         {end.format('DD/MM/YYYY, h:mm A')}
       </p>
-      <IconButton disabled={zoomDisabled} onClick={zoomIn}>
-        <ZoomInIcon />
-      </IconButton>
-      <IconButton onClick={zoomOut}>
-        <ZoomOutIcon />
-      </IconButton>
+      <Stack justifyContent={'right'} direction={'row'}>
+        <IconButton disabled={zoomDisabled} onClick={zoomIn}>
+          <ZoomInIcon />
+        </IconButton>
+        <IconButton onClick={zoomOut}>
+          <ZoomOutIcon />
+        </IconButton>
+        <IconButton>
+          <ArrowBackIos onClick={navigateBackward} />
+        </IconButton>
+        <IconButton>
+          <ArrowForwardIos onClick={navigateForward} />
+        </IconButton>
+      </Stack>
       <PaddedPaper>
         <Box display="flex">
           <Box


### PR DESCRIPTION
Added the ability to navigate forwards and backwards in time within the Guide


<img width="1549" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/b8180ab4-48a9-495b-b0ce-c3ad4b3fe1e2">


With past nav disabled:
<img width="1521" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/aeb87dd5-b761-4f16-adae-9bb16866a195">
