### PR TITLE
Channel editing improvements

### DIFF
--- a/server/api/v2/channelsApiV2.ts
+++ b/server/api/v2/channelsApiV2.ts
@@ -266,7 +266,6 @@ export const channelsApiV2: RouterPluginAsyncCallback = async (fastify) => {
       const upsertedPrograms = flatten(
         await mapAsyncSeq(chunk(programsToPersist, 10), undefined, (programs) =>
           em.upsertMany(Program, programs, {
-            batchSize: 1,
             onConflictAction: 'merge',
             onConflictFields: ['sourceType', 'externalSourceId', 'externalKey'],
             onConflictExcludeFields: ['uuid'],
@@ -373,9 +372,7 @@ export const channelsApiV2: RouterPluginAsyncCallback = async (fastify) => {
         async (channel) => {
           const actualEndTime = req.query.to
             ? endTime
-            : dayjs(
-                startTime.add(channel.guideMinimumDurationSeconds, 'seconds'),
-              );
+            : dayjs(startTime.add(channel.guideMinimumDuration, 'seconds'));
           return req.serverCtx.guideService.getChannelLineup(
             channel.uuid,
             startTime.toDate(),

--- a/server/api/v2/settingsApiV2.ts
+++ b/server/api/v2/settingsApiV2.ts
@@ -1,0 +1,5 @@
+// import { RouterPluginAsyncCallback } from "../../types/serverType.js";
+
+// export const settingsApiV2: RouterPluginAsyncCallback = async (fastify) => {
+//   fastify.get('')
+// }

--- a/server/dao/channelDb.ts
+++ b/server/dao/channelDb.ts
@@ -32,12 +32,12 @@ dayjs.extend(duration);
 function updateRequestToChannel(
   updateReq: SaveChannelRequest,
 ): Partial<Channel> {
-  return omitBy(
+  return omitBy<Partial<Channel>>(
     {
       number: updateReq.number,
       watermark: updateReq.watermark,
       icon: updateReq.icon,
-      guideMinimumDurationSeconds: updateReq.guideMinimumDurationSeconds,
+      guideMinimumDuration: updateReq.guideMinimumDuration,
       groupTitle: updateReq.groupTitle,
       disableFillerOverlay: updateReq.disableFillerOverlay,
       startTime: updateReq.startTime,
@@ -61,7 +61,7 @@ function createRequestToChannel(
     number: saveReq.number,
     watermark: saveReq.watermark,
     icon: saveReq.icon,
-    guideMinimumDurationSeconds: saveReq.guideMinimumDurationSeconds,
+    guideMinimumDuration: saveReq.guideMinimumDuration,
     groupTitle: saveReq.groupTitle,
     disableFillerOverlay: saveReq.disableFillerOverlay,
     startTime: saveReq.startTime,

--- a/server/dao/entities/Channel.ts
+++ b/server/dao/entities/Channel.ts
@@ -2,7 +2,6 @@ import {
   Collection,
   Entity,
   ManyToMany,
-  OptionalProps,
   Property,
   Unique,
 } from '@mikro-orm/core';
@@ -54,7 +53,7 @@ export class Channel extends BaseEntity {
     const entity = new Channel();
     entity.number = channel.number;
     entity.icon = channel.icon;
-    entity.guideMinimumDurationSeconds = channel.guideMinimumDurationSeconds;
+    entity.guideMinimumDuration = channel.guideMinimumDuration;
     entity.name = channel.name;
     entity.duration = channel.duration;
     entity.stealth = channel.stealth;
@@ -72,8 +71,6 @@ export class Channel extends BaseEntity {
     } as Partial<Channel>;
   }
 
-  [OptionalProps]?: 'guideMinimumDurationSeconds' | 'durationMs';
-
   @Property()
   number!: number;
 
@@ -83,8 +80,9 @@ export class Channel extends BaseEntity {
   @ManyToMany(() => Program, 'channels', { owner: true })
   programs = new Collection<Program>(this);
 
+  // Stored in millis
   @Property({ type: 'int', name: 'guide_minimum_duration' })
-  guideMinimumDurationSeconds: number;
+  guideMinimumDuration: number;
 
   @Property({ default: false })
   disableFillerOverlay: boolean = false;
@@ -149,7 +147,7 @@ export class Channel extends BaseEntity {
         position: '',
         width: 0,
       },
-      guideMinimumDurationSeconds: this.guideMinimumDurationSeconds,
+      guideMinimumDuration: this.guideMinimumDuration,
       groupTitle: this.groupTitle || '',
       disableFillerOverlay: this.disableFillerOverlay,
       startTime: this.startTime,

--- a/server/dao/legacy_migration/channelMigrator.ts
+++ b/server/dao/legacy_migration/channelMigrator.ts
@@ -1,6 +1,5 @@
 import { Channel, Program } from '@tunarr/types';
 import dayjs from 'dayjs';
-import { fs } from 'file-system-cache/lib/common/libs.js';
 import {
   attempt,
   chain,
@@ -12,6 +11,7 @@ import {
   map,
   values,
 } from 'lodash-es';
+import fs from 'node:fs/promises';
 import path from 'path';
 import { v4 } from 'uuid';
 import createLogger from '../../logger.js';
@@ -42,10 +42,10 @@ import {
 import {
   JSONArray,
   JSONObject,
+  convertProgram,
   tryParseResolution,
   uniqueProgramId,
 } from './migrationUtil.js';
-import { convertProgram } from './migrationUtil.js';
 
 const logger = createLogger(import.meta);
 
@@ -237,9 +237,8 @@ export async function migrateChannel(fullPath: string): Promise<{
     // convertProgram,
     // ),
     groupTitle: parsed['groupTitle'] as string,
-    guideMinimumDurationSeconds: parsed[
-      'guideMinimumDurationSeconds'
-    ] as number,
+    guideMinimumDuration:
+      (parsed['guideMinimumDurationSeconds'] as number) * 1000,
     icon: {
       path: parsed['icon'] as string,
       duration: parsed['iconDuration'] as number,
@@ -317,7 +316,7 @@ export async function migrateChannel(fullPath: string): Promise<{
       transcoding: channel.transcoding,
       watermark: channel.watermark,
       offline: { mode: 'clip' },
-      guideMinimumDurationSeconds: channel.guideMinimumDurationSeconds,
+      guideMinimumDuration: channel.guideMinimumDuration,
     });
   } else {
     channelEntity = em.create(ChannelEntity, {
@@ -332,7 +331,7 @@ export async function migrateChannel(fullPath: string): Promise<{
       transcoding: channel.transcoding,
       watermark: channel.watermark,
       offline: { mode: 'clip' },
-      guideMinimumDurationSeconds: channel.guideMinimumDurationSeconds,
+      guideMinimumDuration: channel.guideMinimumDuration,
     });
   }
 

--- a/server/services/tvGuideService.ts
+++ b/server/services/tvGuideService.ts
@@ -669,8 +669,8 @@ export class TVGuideService {
 }
 
 function getChannelStealthDuration(channel: Partial<EntityDTO<Channel>>) {
-  if (!isUndefined(channel.guideMinimumDurationSeconds)) {
-    return channel.guideMinimumDurationSeconds * 1000;
+  if (!isUndefined(channel.guideMinimumDuration)) {
+    return channel.guideMinimumDuration;
   } else {
     return constants.DEFAULT_GUIDE_STEALTH_DURATION;
   }

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -41,7 +41,7 @@ export const ChannelSchema = z.object({
   fillerRepeatCooldown: z.number().optional(),
   groupTitle: z.string(),
   guideFlexPlaceholder: z.string().optional(),
-  guideMinimumDurationSeconds: z.number(),
+  guideMinimumDuration: z.number(),
   icon: ChannelIconSchema,
   id: z.string(),
   name: z.string(),

--- a/web2/src/components/channel_config/ChannelEditActions.tsx
+++ b/web2/src/components/channel_config/ChannelEditActions.tsx
@@ -2,23 +2,41 @@ import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import { useContext } from 'react';
 import { ChannelEditContext } from '../../pages/channels/EditChannelContext.ts';
+import { useFormContext } from 'react-hook-form';
+import { SaveChannelRequest } from '@tunarr/types';
 
 export default function ChannelEditActions() {
   const { channelEditorState } = useContext(ChannelEditContext)!;
+  const {
+    formState: { isValid, isDirty },
+    reset,
+  } = useFormContext<SaveChannelRequest>();
+
+  console.log(isValid, isDirty);
 
   return (
     <Stack spacing={2} direction="row" justifyContent="right" sx={{ mt: 2 }}>
       {!channelEditorState.isNewChannel ? (
         <>
-          <Button variant="outlined">Reset Options</Button>
-          <Button variant="contained" type="submit">
+          <Button onClick={() => reset()} variant="outlined">
+            Reset Options
+          </Button>
+          <Button
+            disabled={!isValid || !isDirty}
+            variant="contained"
+            type="submit"
+          >
             Save
           </Button>
         </>
       ) : (
         <>
           <Button variant="contained">Next</Button>
-          <Button variant="contained" type="submit">
+          <Button
+            disabled={!isValid || !isDirty}
+            variant="contained"
+            type="submit"
+          >
             Save
           </Button>
         </>

--- a/web2/src/components/channel_config/ChannelEpgConfig.tsx
+++ b/web2/src/components/channel_config/ChannelEpgConfig.tsx
@@ -6,60 +6,69 @@ import FormGroup from '@mui/material/FormGroup';
 import FormHelperText from '@mui/material/FormHelperText';
 import TextField from '@mui/material/TextField';
 import { Channel } from '@tunarr/types';
+import { isInteger, omit } from 'lodash-es';
 import { Controller, useFormContext } from 'react-hook-form';
+import ChannelEditActions from './ChannelEditActions.tsx';
 
 export default function ChannelEpgConfig() {
   const { control } = useFormContext<Channel>();
 
   return (
-    <Box>
-      <FormGroup>
-        <Controller
-          name="stealth"
-          control={control}
-          render={({ field }) => (
-            <FormControl>
-              <FormControlLabel
-                control={<Checkbox {...field} />}
-                label="Stealth Mode"
+    <>
+      <Box>
+        <FormGroup>
+          <Controller
+            name="stealth"
+            control={control}
+            render={({ field }) => (
+              <FormControl>
+                <FormControlLabel
+                  control={<Checkbox {...field} />}
+                  label="Stealth Mode"
+                />
+                <FormHelperText>
+                  This will hide the channel from TV guides, spoofed HDHR, m3u
+                  playlist, etc. The channel can still be streamed directly or
+                  be used as a redirect target.
+                </FormHelperText>
+              </FormControl>
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="guideFlexPlaceholder"
+            render={({ field }) => (
+              <TextField
+                helperText="This is the name of the fake program that will appear in the TV guide when there are no programs to display in that time slot guide. E.g when a large Flex block is scheduled."
+                label="Placeholder Program Title"
+                margin="normal"
+                {...field}
               />
-              <FormHelperText>
-                This will hide the channel from TV guides, spoofed HDHR, m3u
-                playlist, etc. The channel can still be streamed directly or be
-                used as a redirect target.
-              </FormHelperText>
-            </FormControl>
-          )}
-        />
+            )}
+          />
 
-        <Controller
-          control={control}
-          name="guideFlexPlaceholder"
-          render={({ field }) => (
-            <TextField
-              helperText="This is the name of the fake program that will appear in the TV guide when there are no programs to display in that time slot guide. E.g when a large Flex block is scheduled.
-"
-              label="Placeholder Program Title"
-              margin="normal"
-              {...field}
-            />
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="guideMinimumDurationSeconds"
-          render={({ field }) => (
-            <TextField
-              label="Min. Visible in Guide Duration Program (seconds)"
-              helperText='Programs shorter than this value will be treated the same as Flex time. Meaning that the TV Guide will try to meld them with the previous program or display the block of programs as the "place holder program" if they make a large continuous group. Use 0 to disable this feature or use a large value to make the channel report only the placeholder program and not the real programming.
-          '
-              margin="normal"
-              {...field}
-            />
-          )}
-        />
-      </FormGroup>
-    </Box>
+          <Controller
+            control={control}
+            name="guideMinimumDuration"
+            rules={{
+              validate: (v) => (isInteger(v) ? true : 'Value must be a number'),
+            }}
+            render={({ field, formState: { errors } }) => (
+              <TextField
+                label="Min. Visible in Guide Duration Program (seconds)"
+                helperText={`Programs shorter than this value will be treated the same as Flex time. Meaning that the TV Guide will try to meld them with the previous program or display the block of programs as the "place holder program" if they make a large continuous group. Use 0 to disable this feature or use a large value to make the channel report only the placeholder program and not the real programming.\n${
+                  errors?.guideMinimumDuration?.message ?? ''
+                }`}
+                margin="normal"
+                {...omit(field, 'onChange')}
+                onChange={(e) => field.onChange(parseInt(e.target.value))}
+              />
+            )}
+          />
+        </FormGroup>
+      </Box>
+      <ChannelEditActions />
+    </>
   );
 }

--- a/web2/src/components/channel_config/ChannelFlexConfig.tsx
+++ b/web2/src/components/channel_config/ChannelFlexConfig.tsx
@@ -14,6 +14,7 @@ import { isNumber } from 'lodash-es';
 import { Controller, useFormContext } from 'react-hook-form';
 import useStore from '../../store/index.ts';
 import { useFillerLists } from '../../hooks/useFillerLists.ts';
+import ChannelEditActions from './ChannelEditActions.tsx';
 
 export function ChannelFlexConfig() {
   const channel = useStore((s) => s.channelEditor.currentEntity);
@@ -25,98 +26,101 @@ export function ChannelFlexConfig() {
 
   return (
     channel && (
-      <Box>
-        <Typography variant="h5" sx={{ mb: 1 }}>
-          Channel Fallback
-        </Typography>
-        <Typography variant="body1" sx={{ mb: 2 }}>
-          Configure what appears on your channel when there is no suitable
-          filler content available. Using channel fallbacks requires ffmpeg
-          transcoding.
-        </Typography>
-        <Stack spacing={2} direction="row" sx={{ pb: 1 }}>
-          {offlineMode === 'pic' && (
-            <Box sx={{ flexBasis: '33%' }}>
-              <Box
-                component="img"
-                width="100%"
-                src={
-                  channel.offline.picture ??
-                  'http://localhost:8000/images/generic-offline-screen.png'
-                }
-                sx={{ mr: 1 }}
-              />
-            </Box>
-          )}
-          <Stack direction="column" sx={{ flexGrow: 1 }}>
-            <Controller
-              name="offline.mode"
-              control={control}
-              render={({ field }) => (
-                <FormControl fullWidth sx={{ mb: 1 }}>
-                  <InputLabel>Fallback Mode</InputLabel>
-                  <Select fullWidth label="Fallback Mode" {...field}>
-                    <MenuItem value={'pic'}>Picture</MenuItem>
-                    <MenuItem value={'clip'}>Library Clip</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
-            />
-            <Controller
-              name="offline.picture"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  fullWidth
-                  sx={{ mb: 1 }}
-                  label="Picture"
-                  {...field}
-                />
-              )}
-            />
-            <Controller
-              name="offline.soundtrack"
-              control={control}
-              render={({ field }) => (
-                <TextField fullWidth label="Soundtrack" {...field} />
-              )}
-            />
-          </Stack>
-        </Stack>
-        <Divider sx={{ my: 1 }} />
+      <>
         <Box>
           <Typography variant="h5" sx={{ mb: 1 }}>
-            Filler
+            Channel Fallback
           </Typography>
-          <Typography variant="body1">
-            Select content to use as filler content in between programs on the
-            channel's schedule.
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            Configure what appears on your channel when there is no suitable
+            filler content available. Using channel fallbacks requires ffmpeg
+            transcoding.
           </Typography>
-          <Controller
-            name="fillerRepeatCooldown"
-            control={control}
-            rules={{ validate: isNumber }}
-            render={({ field, formState: { errors } }) => (
-              <>
-                <TextField
-                  fullWidth
-                  label="Filler Cooldown"
-                  margin="normal"
-                  helperText={
-                    errors.fillerRepeatCooldown?.type === 'validate'
-                      ? 'Filler cooldown must be a number'
-                      : null
+          <Stack spacing={2} direction="row" sx={{ pb: 1 }}>
+            {offlineMode === 'pic' && (
+              <Box sx={{ flexBasis: '33%' }}>
+                <Box
+                  component="img"
+                  width="100%"
+                  src={
+                    channel.offline.picture ??
+                    'http://localhost:8000/images/generic-offline-screen.png'
                   }
-                  {...field}
+                  sx={{ mr: 1 }}
                 />
-                <Typography variant="caption" sx={{ ml: 1 }}>
-                  Minimum time (minutes) before replaying a filler
-                </Typography>
-              </>
+              </Box>
             )}
-          />
+            <Stack direction="column" sx={{ flexGrow: 1 }}>
+              <Controller
+                name="offline.mode"
+                control={control}
+                render={({ field }) => (
+                  <FormControl fullWidth sx={{ mb: 1 }}>
+                    <InputLabel>Fallback Mode</InputLabel>
+                    <Select fullWidth label="Fallback Mode" {...field}>
+                      <MenuItem value={'pic'}>Picture</MenuItem>
+                      <MenuItem value={'clip'}>Library Clip</MenuItem>
+                    </Select>
+                  </FormControl>
+                )}
+              />
+              <Controller
+                name="offline.picture"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    fullWidth
+                    sx={{ mb: 1 }}
+                    label="Picture"
+                    {...field}
+                  />
+                )}
+              />
+              <Controller
+                name="offline.soundtrack"
+                control={control}
+                render={({ field }) => (
+                  <TextField fullWidth label="Soundtrack" {...field} />
+                )}
+              />
+            </Stack>
+          </Stack>
+          <Divider sx={{ my: 1 }} />
+          <Box>
+            <Typography variant="h5" sx={{ mb: 1 }}>
+              Filler
+            </Typography>
+            <Typography variant="body1">
+              Select content to use as filler content in between programs on the
+              channel's schedule.
+            </Typography>
+            <Controller
+              name="fillerRepeatCooldown"
+              control={control}
+              rules={{ validate: isNumber }}
+              render={({ field, formState: { errors } }) => (
+                <>
+                  <TextField
+                    fullWidth
+                    label="Filler Cooldown"
+                    margin="normal"
+                    helperText={
+                      errors.fillerRepeatCooldown?.type === 'validate'
+                        ? 'Filler cooldown must be a number'
+                        : null
+                    }
+                    {...field}
+                  />
+                  <Typography variant="caption" sx={{ ml: 1 }}>
+                    Minimum time (minutes) before replaying a filler
+                  </Typography>
+                </>
+              )}
+            />
+          </Box>
         </Box>
-      </Box>
+        <ChannelEditActions />
+      </>
     )
   );
 }

--- a/web2/src/components/channel_config/ChannelPropertiesEditor.tsx
+++ b/web2/src/components/channel_config/ChannelPropertiesEditor.tsx
@@ -70,7 +70,6 @@ export default function ChannelPropertiesEditor() {
   }, [imgRef]);
 
   const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log(e.target.files);
     if (e.target.files && e.target.files.length > 0) {
       const file = e.target.files[0];
       setChannelIcon(`http://localhost:8000/images/uploads/${file.name}`); // Placeholder

--- a/web2/src/external/api.ts
+++ b/web2/src/external/api.ts
@@ -211,6 +211,10 @@ export const api = makeApi([
     status: 201,
     response: z.object({ id: z.string() }),
   },
+  // {
+  //   method: 'put',
+  //   path: '/api/v2/'
+  // }
 ]);
 
 export const createApiClient = once((uri: string) => {

--- a/web2/src/pages/channels/loaders.ts
+++ b/web2/src/pages/channels/loaders.ts
@@ -105,7 +105,7 @@ function defaultNewChannel(num: number): Channel {
       position: 'bottom',
       width: 0,
     },
-    guideMinimumDurationSeconds: 300,
+    guideMinimumDuration: 300,
     groupTitle: 'tv',
     stealth: false,
     disableFillerOverlay: false,

--- a/web2/src/store/index.ts
+++ b/web2/src/store/index.ts
@@ -53,35 +53,26 @@ const createChannelsState: StateCreator<ChannelsState> = () => ({
   channels: undefined,
 });
 
-const middleware = <T>(
-  f: StateCreator<
-    T,
-    [
-      ['zustand/immer', never],
-      ['zustand/devtools', never],
-      ['zustand/persist', unknown],
-    ]
-  >,
-) =>
+const useStore = create<State>()(
   immer(
     devtools(
-      persist(f, {
-        name: 'tunarr',
-        partialize: (state: any) => ({
-          theme: state['theme'],
+      persist(
+        (...set) => ({
+          ...createSettingsSlice(...set),
+          ...createChannelsState(...set),
+          ...createProgrammingListingsState(...set),
+          ...createChannelEditorState(...set),
+          ...createThemeEditorState(...set),
         }),
-      }),
+        {
+          name: 'tunarr',
+          partialize: (state: State) => ({
+            theme: state.theme,
+          }),
+        },
+      ),
     ),
-  );
-
-const useStore = create<State>()(
-  middleware((...set) => ({
-    ...createSettingsSlice(...set),
-    ...createChannelsState(...set),
-    ...createProgrammingListingsState(...set),
-    ...createChannelEditorState(...set),
-    ...createThemeEditorState(...set),
-  })),
+  ),
 );
 
 export const setChannels = (channels: Channel[]) =>


### PR DESCRIPTION
* Log a console error if the form is invalid, eventually we will want to surface these on the form field fields
* Show an error badge dot on any tabs that have invalid values, this way the user will know which tab they have to fix up if they are editing multiple Channel values across tabs
* Fix for guideMinimumDuration -- we are going to start treating this as milliseconds in the DB (all durations should be millis) but in the form, the user will input this value as seconds (because it's just easier to reason about). This should fix #44
* Disables save button if the form is invalid
* Hooks up the reset button for editing

Screens:
![image](https://github.com/chrisbenincasa/tunarr/assets/1640671/5b31450a-d712-4b40-b1cb-6becca461324)
![image](https://github.com/chrisbenincasa/tunarr/assets/1640671/62e180ce-803b-41bb-bed4-6e9c5979dcb6)
