### PR TITLE
Style guide page and fix dark mode

### DIFF
--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -47,8 +47,8 @@ const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
       theme.palette.mode === 'light'
         ? theme.palette.grey[grey]
         : grey === 300
-        ? theme.palette.grey[800]
-        : theme.palette.grey[700],
+        ? theme.palette.grey[700]
+        : theme.palette.grey[800],
     borderCollapse: 'collapse',
     borderStyle: 'solid',
     borderWidth: '2px 5px 2px 5px',


### PR DESCRIPTION
Some styling for the Guide page

Dark Mode:
![image](https://github.com/chrisbenincasa/tunarr/assets/6005331/db4deb51-0d4c-4912-a1d4-fd7f6cd78368)


Light Mode:
<img width="1568" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/5695c0b4-d8c9-4c31-abe1-14a1b0dfd019">
