### PR TITLE
Rewrite to save programs API

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       node-ssdp:
         specifier: ^4.0.0
         version: 4.0.0
+      p-queue:
+        specifier: ^8.0.1
+        version: 8.0.1
       random-js:
         specifier: 2.1.0
         version: 2.1.0
@@ -4277,6 +4280,10 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+    dev: false
+
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -6343,12 +6350,25 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
+  /p-queue@8.0.1:
+    resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
+    engines: {node: '>=18'}
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.2
+    dev: false
+
   /p-timeout@2.0.1:
     resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
     engines: {node: '>=4'}
     dependencies:
       p-finally: 1.0.0
     dev: true
+
+  /p-timeout@6.1.2:
+    resolution: {integrity: sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}

--- a/server/dao/derived_types/Lineup.ts
+++ b/server/dao/derived_types/Lineup.ts
@@ -1,8 +1,11 @@
 import { Program as ProgramDTO } from '@tunarr/types';
 import { Program } from '../entities/Program.js';
+import { LineupSchedule } from '@tunarr/types/api';
 
 export type Lineup = {
   items: LineupItem[];
+  // Unsure if we want this DB type to reference the
+  // API type, but for now it will work.
   schedule?: LineupSchedule;
 };
 
@@ -36,97 +39,6 @@ function isItemOfType<T extends LineupItem>(discrim: string) {
 export const isContentItem = isItemOfType<ContentItem>('content');
 export const isOfflineItem = isItemOfType<OfflineItem>('offline');
 export const isRedirectItem = isItemOfType<RedirectItem>('redirect');
-
-export type MovieProgrammingTimeSlot = {
-  type: 'movie';
-  sortType: '';
-};
-
-export type ShowProgrammingTimeSlot = {
-  type: 'show';
-  showId: string; // grandparent id
-};
-
-export type FlexProgrammingTimeSlot = {
-  type: 'flex';
-};
-
-export function slotProgrammingId(slot: TimeSlotProgramming) {
-  if (slot.type === 'movie' || slot.type === 'flex') {
-    return slot.type;
-  } else {
-    return `show.${slot.showId}`;
-  }
-}
-
-export type TimeSlotProgramming =
-  | MovieProgrammingTimeSlot
-  | ShowProgrammingTimeSlot
-  | FlexProgrammingTimeSlot;
-
-export type TimeSlot = {
-  order: 'next' | 'shuffle';
-  programming: TimeSlotProgramming;
-  startTime: number; // Offset from midnight in millis
-};
-
-// Zod these up
-export type TimeSlotSchedule = {
-  type: 'time';
-  flexPreference: 'distribute' | 'end';
-  latenessMs: number; // max lateness in millis
-  maxDays: number; // days to pregenerate schedule for
-  padMs: number; // Pad time in millis
-  period: 'day' | 'week' | 'month';
-  slots: TimeSlot[];
-  timeZoneOffset: number; // tz offset in...minutes, i think?
-  startTomorrow?: boolean;
-};
-
-export type MovieProgrammingRandomSlot = {
-  type: 'movie';
-};
-
-export type ShowProgrammingRandomSlot = {
-  type: 'show';
-  showId: string;
-};
-
-export type FlexProgrammingRandomSlot = {
-  type: 'flex';
-};
-
-export type RandomSlotProgramming =
-  | MovieProgrammingRandomSlot
-  | ShowProgrammingRandomSlot
-  | FlexProgrammingRandomSlot;
-
-export type RandomSlot = {
-  order: string;
-  startTime?: number; // Offset from midnight millis
-  cooldown: number;
-  periodMs?: string;
-  durationMs: number;
-  weight?: number;
-  weightPercentage?: string; // Frontend specific?
-  programming: RandomSlotProgramming;
-};
-
-// This is used on the frontend too, we will move common
-// types eventually.
-export type RandomSlotSchedule = {
-  type: 'random';
-  flexPreference: 'distribute' | 'end'; // distribute or end
-  maxDays: number; // days
-  padMs: number; // Pad time in millis
-  padStyle: 'slot' | 'episode';
-  slots: RandomSlot[];
-  timeZoneOffset?: number; // tz offset in...minutes, i think?
-  randomDistribution: 'uniform' | 'weighted';
-  periodMs?: number;
-};
-
-export type LineupSchedule = TimeSlotSchedule | RandomSlotSchedule;
 
 export function contentItemToProgramDTO(
   backingItem: Program,

--- a/server/dao/entities/Program.ts
+++ b/server/dao/entities/Program.ts
@@ -141,7 +141,7 @@ export class Program extends BaseEntity {
   }
 
   uniqueId(): string {
-    return `${this.sourceType}_${this.externalSourceId}_${this.externalKey}`;
+    return `${this.sourceType}|${this.externalSourceId}|${this.externalKey}`;
   }
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
     "node-graceful-shutdown": "1.1.0",
     "node-schedule": "^2.1.1",
     "node-ssdp": "^4.0.0",
+    "p-queue": "^8.0.1",
     "random-js": "2.1.0",
     "reflect-metadata": "^0.1.13",
     "serve-static": "^1.15.0",

--- a/server/services/tvGuideService.ts
+++ b/server/services/tvGuideService.ts
@@ -29,7 +29,6 @@ import { XmlTvWriter } from '../xmltv.js';
 import { CacheImageService } from './cacheImageService.js';
 import { EventService } from './eventService.js';
 import throttle from './throttle.js';
-import { inspect } from 'node:util';
 
 const logger = createLogger(import.meta);
 
@@ -630,7 +629,6 @@ export class TVGuideService {
     await this.get();
     const beginningTimeMs = dateFrom.getTime();
     const endTimeMs = dateTo.getTime();
-    console.log(inspect(this.cached, false, null));
 
     const { channel, programs } = this.cached[channelId];
     if (isNil(channel)) {

--- a/server/util.ts
+++ b/server/util.ts
@@ -1,5 +1,6 @@
 import {
   chain,
+  concat,
   identity,
   isArray,
   isEmpty,
@@ -116,6 +117,18 @@ export async function mapAsyncSeq<T, U>(
   );
 
   return Promise.all(all);
+}
+
+export async function flatMapAsyncSeq<T, U>(
+  seq: readonly T[],
+  itemFn: (item: T) => Promise<U[]>,
+): Promise<U[]> {
+  return mapReduceAsyncSeq(
+    seq,
+    itemFn,
+    (prev, next) => concat(prev, next),
+    [] as U[],
+  );
 }
 
 export async function mapReduceAsyncSeq<T, U, Res>(

--- a/server/util/runWorker.ts
+++ b/server/util/runWorker.ts
@@ -1,0 +1,37 @@
+import { cpus } from 'os';
+import PQueue from 'p-queue';
+import { Worker } from 'worker_threads';
+
+const queue = new PQueue({ concurrency: cpus().length });
+
+export function runWorker<T>(
+  filenameWithoutExtension: URL,
+  workerData?: unknown,
+): Promise<T> {
+  return queue.add<T>(
+    async () => {
+      const worker =
+        process.env.NODE_ENV !== 'production'
+          ? new Worker(new URL(`${filenameWithoutExtension.toString()}.ts`), {
+              workerData,
+              execArgv: ['--loader', 'ts-node/esm/transpile-only'],
+            })
+          : new Worker(new URL(`${filenameWithoutExtension.toString()}.js`), {
+              workerData,
+            });
+
+      const result = await new Promise<T>((resolve, reject) => {
+        worker.on('message', resolve);
+        worker.on('error', reject);
+        worker.on('exit', (code) => {
+          if (code !== 0) {
+            reject(new Error(`Worker stopped with exit code ${code}`));
+          }
+        });
+      });
+
+      return result;
+    },
+    { throwOnTimeout: true },
+  );
+}

--- a/server/util/scheduleTimeSlotsWorker.ts
+++ b/server/util/scheduleTimeSlotsWorker.ts
@@ -1,0 +1,11 @@
+import { scheduleTimeSlots } from '@tunarr/shared';
+import { ChannelProgram } from '@tunarr/types';
+import { TimeSlotSchedule } from '@tunarr/types/api';
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { schedule, programs } = workerData as {
+  schedule: TimeSlotSchedule;
+  programs: ChannelProgram[];
+};
+
+parentPort?.postMessage(await scheduleTimeSlots(schedule, programs));

--- a/shared/common/services/timeSlotService.ts
+++ b/shared/common/services/timeSlotService.ts
@@ -302,12 +302,12 @@ export async function scheduleTimeSlots(
   const upperLimit = t0.add(schedule.maxDays + 1, 'day');
 
   let timeCursor = t0;
-  let ChannelPrograms: ChannelProgram[] = [];
+  let channelPrograms: ChannelProgram[] = [];
 
   const pushFlex = (flexDuration: Duration) => {
-    const [inc, newPrograms] = pushOrExtendFlex(ChannelPrograms, flexDuration);
+    const [inc, newPrograms] = pushOrExtendFlex(channelPrograms, flexDuration);
     timeCursor = timeCursor.add(inc);
-    ChannelPrograms = newPrograms;
+    channelPrograms = newPrograms;
   };
 
   // if (t0.isAfter(startOfCurrentPeriod)) {
@@ -392,7 +392,7 @@ export async function scheduleTimeSlots(
 
     // Program longer than we have left? Add it and move on...
     if (program && program.duration > remaining) {
-      ChannelPrograms.push(program);
+      channelPrograms.push(program);
       advanceIterator(currSlot, programmingIteratorsById);
       timeCursor = timeCursor.add(program.duration);
       continue;
@@ -435,14 +435,14 @@ export async function scheduleTimeSlots(
     }
 
     forEach(paddedPrograms, ({ program, padMs }) => {
-      ChannelPrograms.push(program);
+      channelPrograms.push(program);
       timeCursor = timeCursor.add(program.duration);
       pushFlex(dayjs.duration(padMs));
     });
   }
 
   return {
-    programs: ChannelPrograms,
+    programs: channelPrograms,
     startTime: t0.unix() * 1000,
   };
 }

--- a/web2/src/components/channel_config/AddSelectedMediaButton.tsx
+++ b/web2/src/components/channel_config/AddSelectedMediaButton.tsx
@@ -1,14 +1,11 @@
 import Button, { ButtonProps } from '@mui/material/Button';
 import { flattenDeep } from 'lodash-es';
 import { sequentialPromises } from '../../helpers/util.ts';
-import {
-  PlexMediaWithServerName,
-  enumeratePlexItem,
-} from '../../hooks/plexHooks.ts';
+import { EnrichedPlexMedia, enumeratePlexItem } from '../../hooks/plexHooks.ts';
 import useStore from '../../store/index.ts';
 
 type Props = {
-  onAdd: (items: PlexMediaWithServerName[]) => void;
+  onAdd: (items: EnrichedPlexMedia[]) => void;
   onSuccess: () => void;
 } & ButtonProps;
 

--- a/web2/src/external/api.ts
+++ b/web2/src/external/api.ts
@@ -3,6 +3,7 @@ import {
   BatchLookupExternalProgrammingSchema,
   CreateCustomShowRequestSchema,
   CreateFillerListRequestSchema,
+  UpdateChannelProgrammingRequestSchema,
 } from '@tunarr/types/api';
 import {
   ChannelLineupSchema,
@@ -62,7 +63,7 @@ export const api = makeApi([
     requestFormat: 'json',
     parameters: parametersBuilder()
       .addPath('id', z.string())
-      .addBody(z.array(ChannelProgramSchema))
+      .addBody(UpdateChannelProgrammingRequestSchema)
       .build(),
     response: ChannelProgrammingSchema,
   },
@@ -92,7 +93,7 @@ export const api = makeApi([
     parameters: parametersBuilder()
       .addBody(BatchLookupExternalProgrammingSchema)
       .build(),
-    response: z.array(ProgramSchema.partial().required({ id: true })),
+    response: z.record(ProgramSchema.partial().required({ id: true })),
   },
   {
     method: 'get',

--- a/web2/src/helpers/util.ts
+++ b/web2/src/helpers/util.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import { Resolution } from '@tunarr/types';
+import { ChannelProgram, Resolution } from '@tunarr/types';
 
 dayjs.extend(duration);
 
@@ -53,4 +53,17 @@ export const fromStringResolution = (
 
 export const hasOnlyDigits = (value: string) => {
   return /^-?\d+$/g.test(value);
+};
+
+export const channelProgramUniqueId = (program: ChannelProgram): string => {
+  switch (program.type) {
+    case 'custom':
+      return `custom.${program.id}`;
+    case 'content':
+      return `content.${program.uniqueId}`;
+    case 'redirect':
+      return `redirect.${program.channel}`;
+    case 'flex':
+      return 'flex';
+  }
 };

--- a/web2/src/hooks/usePreloadedChannel.ts
+++ b/web2/src/hooks/usePreloadedChannel.ts
@@ -16,6 +16,7 @@ export const usePreloadedChannel = () => {
       isUndefined(channelEditor.originalEntity) ||
       preloadChannel.number !== channelEditor.originalEntity.number
     ) {
+      console.log(preloadChannel, preloadLineup);
       setCurrentChannel(preloadChannel, preloadLineup);
     }
   }, [channelEditor, preloadChannel, preloadLineup]);

--- a/web2/src/store/channelEditor/actions.ts
+++ b/web2/src/store/channelEditor/actions.ts
@@ -9,9 +9,9 @@ import {
   FillerListProgramming,
 } from '@tunarr/types';
 import { isPlexEpisode } from '@tunarr/types/plex';
-import { isUndefined, sumBy } from 'lodash-es';
+import { isNil, isUndefined, sumBy } from 'lodash-es';
 import useStore from '../index.ts';
-import { PlexMediaWithServerName } from '../../hooks/plexHooks.ts';
+import { EnrichedPlexMedia } from '../../hooks/plexHooks.ts';
 import { initialChannelEditorState } from './store.ts';
 
 export const resetChannelEditorState = () =>
@@ -112,14 +112,13 @@ export const clearSlotSchedulePreview = () =>
     channelEditor.schedulePreviewList = [];
   });
 
-const generatePrograms = (
-  programs: PlexMediaWithServerName[],
-): ContentProgram[] => {
+const generatePrograms = (programs: EnrichedPlexMedia[]): ContentProgram[] => {
   return programs.map((program) => {
     let ephemeralProgram: ContentProgram;
     if (isPlexEpisode(program)) {
       ephemeralProgram = {
-        persisted: false,
+        id: program.id,
+        persisted: !isNil(program.id),
         originalProgram: program,
         duration: program.duration,
         externalSourceName: program.serverName,
@@ -135,7 +134,8 @@ const generatePrograms = (
       };
     } else {
       ephemeralProgram = {
-        persisted: false,
+        id: program.id,
+        persisted: !isNil(program.id),
         originalProgram: program,
         duration: program.duration,
         externalSourceName: program.serverName,
@@ -151,9 +151,7 @@ const generatePrograms = (
   });
 };
 
-export const addPlexMediaToCurrentChannel = (
-  programs: PlexMediaWithServerName[],
-) =>
+export const addPlexMediaToCurrentChannel = (programs: EnrichedPlexMedia[]) =>
   useStore.setState(({ channelEditor }) => {
     if (channelEditor.currentEntity && programs.length > 0) {
       channelEditor.dirty.programs = true;
@@ -207,7 +205,7 @@ export const setCurrentCustomShow = (
   });
 
 export const addPlexMediaToCurrentCustomShow = (
-  programs: PlexMediaWithServerName[],
+  programs: EnrichedPlexMedia[],
 ) =>
   useStore.setState(({ customShowEditor }) => {
     if (customShowEditor.currentEntity && programs.length > 0) {
@@ -231,7 +229,7 @@ export const setCurrentFillerList = (
   });
 
 export const addPlexMediaToCurrentFillerList = (
-  programs: PlexMediaWithServerName[],
+  programs: EnrichedPlexMedia[],
 ) =>
   useStore.setState(({ fillerListEditor }) => {
     if (fillerListEditor.currentEntity && programs.length > 0) {


### PR DESCRIPTION
* Supports saving lineups generated by time-slot algo
* "Manually" built lineups are sent without program repeats - saves on
  upload bandwidth to server
* "Time slot" built lineups are regenerated server-side based on the
  schedule so we're not serializing/sending 1000s of programs to the
server at once
* Still some weird logic around updating channel/program associations
  that we should look at
* DB files are now saved in 'minified' JSON format
