### PR TITLE
Add Modal & Auto Refetch to Guide Page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^4.0.0-rc.2
         version: 4.0.0-rc.2
       nodemon:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.3
+        version: 3.0.3
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -3698,7 +3698,7 @@ packages:
       ms: 2.0.0
     dev: false
 
-  /debug@3.2.7(supports-color@5.5.0):
+  /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
@@ -3707,7 +3707,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 5.5.0
+    dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -6043,29 +6043,12 @@ packages:
     dependencies:
       async: 2.6.4
       bluebird: 3.7.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       extend: 3.0.2
       ip: 1.1.8
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /nodemon@3.0.1:
-    resolution: {integrity: sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      chokidar: 3.5.3
-      debug: 3.2.7(supports-color@5.5.0)
-      ignore-by-default: 1.0.1
-      minimatch: 3.1.2
-      pstree.remy: 1.1.8
-      semver: 7.5.4
-      simple-update-notifier: 2.0.0
-      supports-color: 5.5.0
-      touch: 3.1.0
-      undefsafe: 2.0.5
-    dev: true
 
   /nodemon@3.0.2:
     resolution: {integrity: sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==}

--- a/web2/src/hooks/useTvGuide.ts
+++ b/web2/src/hooks/useTvGuide.ts
@@ -20,7 +20,11 @@ export const useTvGuide = (params: {
     },
   });
 
-export const useAllTvGuides = (params: { from: Dayjs; to: Dayjs }) =>
+export const useAllTvGuides = (params: {
+  from: Dayjs;
+  to: Dayjs;
+  refetchInterval: number;
+}) =>
   useQuery({
     queryKey: ['channels', 'all', 'guide', params] as const,
     queryFn: async () => {
@@ -31,6 +35,7 @@ export const useAllTvGuides = (params: { from: Dayjs; to: Dayjs }) =>
         },
       });
     },
+    refetchInterval: params.refetchInterval,
   });
 
 export const prefetchAllTvGuides = (params: { from: Dayjs; to: Dayjs }) => {

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -198,7 +198,7 @@ export default function GuidePage() {
     setEnd(newStart.add(guideDuration, 'ms'));
 
     setCurrentTime(dayjs().format('h:mm'));
-  }, [guideDuration, now]);
+  }, [guideDuration]);
 
   const handleDayChange = (event: SelectChangeEvent<string>) => {
     const day = event.target.value;

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -43,11 +43,13 @@ const GridParent = styled(Box)({
   borderWidth: '1px 0 0 1px',
 });
 
-const GridChild = styled(Box)({
+const GridChild = styled(Box)<{ width: number }>(({ width }) => ({
   borderStyle: 'solid',
   borderColor: 'transparent',
   borderWidth: '0 1px 0 0',
-});
+  width: `${width}%`,
+  transition: 'width 0.5s ease-in',
+}));
 
 const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
   ({ theme, grey, width }) => ({
@@ -237,6 +239,7 @@ export default function GuidePage() {
     const programStart = dayjs(program.start);
     const programEnd = dayjs(program.stop);
     let duration = dayjs.duration(programEnd.diff(programStart));
+    let endOfAvailableProgramming = false;
 
     // Trim any time that has already played in the current program
     if (index === 0) {
@@ -248,6 +251,11 @@ export default function GuidePage() {
     if (index === lineup.length - 1) {
       const trimEnd = programEnd.diff(end);
       duration = duration.subtract(trimEnd, 'ms');
+
+      if (programEnd.isBefore(end)) {
+        endOfAvailableProgramming = true;
+        console.log('this is the end');
+      }
     }
 
     const pct = round(
@@ -258,20 +266,35 @@ export default function GuidePage() {
     const grey = index % 2 === 0 ? 300 : 400;
 
     return (
-      <Tooltip
-        key={key}
-        title={`Starts at ${programStart.format(
-          'h:mm A',
-        )} and ends at ${programEnd.format('h:mm A')}`}
-        placement="top"
-      >
-        <GuideItem width={pct} grey={grey} key={key}>
-          <Box sx={{ fontSize: '14px', fontWeight: '600' }}>{title}</Box>
-          <Box sx={{ fontSize: '13px', fontStyle: 'italic' }}>
-            {episodeTitle}
-          </Box>
-        </GuideItem>
-      </Tooltip>
+      <>
+        <Tooltip
+          key={key}
+          title={`Starts at ${programStart.format(
+            'h:mm A',
+          )} and ends at ${programEnd.format('h:mm A')}`}
+          placement="top"
+        >
+          <GuideItem width={pct} grey={grey} key={key}>
+            <Box sx={{ fontSize: '14px', fontWeight: '600' }}>{title}</Box>
+            <Box sx={{ fontSize: '13px', fontStyle: 'italic' }}>
+              {episodeTitle}
+            </Box>
+          </GuideItem>
+        </Tooltip>
+        {endOfAvailableProgramming ? (
+          <Tooltip
+            key={`${key}-unavailable`}
+            title={'Unavailable'}
+            placement="top"
+          >
+            <GuideItem width={pct} grey={grey} key={`${key}-unavailable`}>
+              <Box sx={{ fontSize: '14px', fontWeight: '600' }}>
+                No Programming
+              </Box>
+            </GuideItem>
+          </Tooltip>
+        ) : null}
+      </>
     );
   };
 
@@ -447,8 +470,8 @@ export default function GuidePage() {
             >
               {intervalArray.map((slot) => (
                 <GridChild
+                  width={100 / intervalArray.length}
                   sx={{
-                    width: `${100 / intervalArray.length}%`,
                     height: '2rem',
                   }}
                   key={slot}

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -77,6 +77,9 @@ const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
     flexDirection: 'column',
     justifyContent: 'flex-start',
     cursor: 'pointer',
+    '&:hover': {
+      background: theme.palette.primary.main,
+    },
   }),
 );
 
@@ -118,7 +121,7 @@ export default function GuidePage() {
     isPending,
     error,
     data: channelLineup,
-  } = useAllTvGuides({ from: start, to: end });
+  } = useAllTvGuides({ from: start, to: end, refetchInterval: guideDuration });
 
   prefetchAllTvGuides({
     from: start.add(1, 'hour'),
@@ -254,7 +257,6 @@ export default function GuidePage() {
 
       if (programEnd.isBefore(end)) {
         endOfAvailableProgramming = true;
-        console.log('this is the end');
       }
     }
 
@@ -316,6 +318,7 @@ export default function GuidePage() {
           <Tooltip
             title={'No programming available for this time period'}
             placement="top"
+            key={`${lineup.number}-unavailable`}
           >
             <GuideItem
               display={'flex'}


### PR DESCRIPTION
- Added Modal to Guide page
- Added React Query cached refetch so we prefetch the next query when a user navigates on the Guide page.  This allows us to animate the navigation transition without seeing a hard component remount
- Updated UseInterval to refetch the query when it reaches half of the guide duration.  This allows users to stay on the page and have it refresh automatically.  This also solves the issue where a user would close their laptop and come back the next day to stale data because the 'start' state would not update.
- Added initial work for 'program unavailable' block.  This needs to be firmed up still.