### PR TITLE
Remove refetchInterval & other Guide fixes

### DIFF
--- a/web2/index.html
+++ b/web2/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.svg"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DizqueTV</title>
+    <title>Tunarr</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web2/src/hooks/useTvGuide.ts
+++ b/web2/src/hooks/useTvGuide.ts
@@ -20,11 +20,7 @@ export const useTvGuide = (params: {
     },
   });
 
-export const useAllTvGuides = (params: {
-  from: Dayjs;
-  to: Dayjs;
-  refetchInterval: number;
-}) =>
+export const useAllTvGuides = (params: { from: Dayjs; to: Dayjs }) =>
   useQuery({
     queryKey: ['channels', 'all', 'guide', params] as const,
     queryFn: async () => {
@@ -35,7 +31,6 @@ export const useAllTvGuides = (params: {
         },
       });
     },
-    refetchInterval: params.refetchInterval,
   });
 
 export const prefetchAllTvGuides = (params: { from: Dayjs; to: Dayjs }) => {

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -141,7 +141,7 @@ export default function GuidePage() {
     isPending,
     error,
     data: channelLineup,
-  } = useAllTvGuides({ from: start, to: end, refetchInterval: guideDuration });
+  } = useAllTvGuides({ from: start, to: end });
 
   const smallViewport = useMediaQuery(theme.breakpoints.down('md'));
 

--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -21,6 +21,7 @@ import {
   Tooltip,
   Typography,
   styled,
+  useMediaQuery,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { ChannelProgram, TvGuideProgram } from '@tunarr/types';
@@ -125,9 +126,8 @@ export default function GuidePage() {
   const [start, setStart] = useState(roundCurrentTime(15));
   const [end, setEnd] = useState(start.add(guideDuration, 'ms'));
   const [currentTime, setCurrentTime] = useState(dayjs().format('h:mm'));
-  const [progress, setProgress] = useState(() => {
-    return calcProgress(start, end);
-  });
+  const [progress, setProgress] = useState(calcProgress(start, end));
+
   const [modalProgram, setModalProgram] = useState<
     TvGuideProgram | undefined
   >();
@@ -142,6 +142,8 @@ export default function GuidePage() {
     error,
     data: channelLineup,
   } = useAllTvGuides({ from: start, to: end, refetchInterval: guideDuration });
+
+  const smallViewport = useMediaQuery(theme.breakpoints.down('md'));
 
   prefetchAllTvGuides({
     from: start.add(1, 'hour'),
@@ -164,19 +166,17 @@ export default function GuidePage() {
       setEnd((prevEnd) => {
         const newEnd = prevEnd.subtract(SubtractInterval);
         setGuideDurationState(Math.abs(start.diff(newEnd)));
+        setProgress(calcProgress(start, newEnd));
         return newEnd;
       });
     }
   }, [start, end]);
 
-  const navigateForward = useCallback(() => {
-    setEnd((last) => last.add(1, 'hour'));
-    setStart((start) => start.add(1, 'hour'));
-  }, [setEnd, setStart]);
   const zoomOut = useCallback(() => {
     setEnd((prevEnd) => {
       const newEnd = prevEnd.add(1, 'hour');
       setGuideDurationState(Math.abs(start.diff(newEnd)));
+      setProgress(calcProgress(start, newEnd));
       return newEnd;
     });
   }, [start]);
@@ -187,6 +187,11 @@ export default function GuidePage() {
   const navigateBackward = useCallback(() => {
     setEnd((last) => last.subtract(1, 'hour'));
     setStart((start) => start.subtract(1, 'hour'));
+  }, [setEnd, setStart]);
+
+  const navigateForward = useCallback(() => {
+    setEnd((last) => last.add(1, 'hour'));
+    setStart((start) => start.add(1, 'hour'));
   }, [setEnd, setStart]);
 
   const navigationDisabled = dayjs().isAfter(start);
@@ -552,7 +557,7 @@ export default function GuidePage() {
             display="flex"
             position="relative"
             flexDirection="column"
-            sx={{ width: '15%' }}
+            sx={{ width: `${smallViewport ? '10%' : '15%'}` }}
           >
             <Box sx={{ height: '4.5rem' }}></Box>
             {channelLineup?.map((channel) => (
@@ -560,21 +565,23 @@ export default function GuidePage() {
                 direction={{ sm: 'column', md: 'row' }}
                 key={`img-${channel.id}`}
               >
-                <Box
-                  sx={{ height: '4rem' }}
-                  display={'flex'}
-                  alignItems={'center'}
-                  justifyContent={'center'}
-                >
-                  <img
-                    style={{ maxHeight: '40px' }}
-                    src={
-                      isEmpty(channel.icon?.path)
-                        ? '/dizquetv.png'
-                        : channel.icon?.path
-                    }
-                  />
-                </Box>
+                {!smallViewport ? (
+                  <Box
+                    sx={{ height: '4rem' }}
+                    display={'flex'}
+                    alignItems={'center'}
+                    justifyContent={'center'}
+                  >
+                    <img
+                      style={{ maxHeight: '40px' }}
+                      src={
+                        isEmpty(channel.icon?.path)
+                          ? '/dizquetv.png'
+                          : channel.icon?.path
+                      }
+                    />
+                  </Box>
+                ) : null}
                 <Box
                   sx={{ height: '4rem' }}
                   key={channel.number}
@@ -583,7 +590,7 @@ export default function GuidePage() {
                   flexGrow={1}
                   marginLeft={1}
                 >
-                  {channel.name}
+                  {smallViewport ? channel.number : channel.name}
                 </Box>
               </Stack>
             ))}
@@ -594,7 +601,7 @@ export default function GuidePage() {
               position: 'relative',
               flexDirection: 'column',
               width: '100%',
-              overflowX: 'hidden',
+              overflow: 'hidden',
             }}
           >
             <Box


### PR DESCRIPTION
- Remove refetchInterval to fix cache issue.  No longer needed to set the interval as the fetch happens automatically within useInterval once 1/2 guide duration has expired.  This allows the query to use the updated start/end state.
- Updated DizqueTV => Tunarr in Title
- Added some more mobile styles to guide page
- Fixed https://github.com/chrisbenincasa/tunarr/issues/66 
- Fixed https://github.com/chrisbenincasa/tunarr/issues/63