### PR TITLE
Rewrite plex servers API

### DIFF
--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -5,6 +5,7 @@ import {
   CustomProgramSchema,
 } from '../schemas/programmingSchema.js';
 import { TimeSlotScheduleSchema } from './Scheduling.js';
+import { PlexServerSettingsSchema } from '../schemas/settingsSchemas.js';
 
 export * from './Scheduling.js';
 
@@ -93,4 +94,26 @@ export const UpdateChannelProgrammingRequestSchema = z.discriminatedUnion(
 
 export type UpdateChannelProgrammingRequest = Alias<
   z.infer<typeof UpdateChannelProgrammingRequestSchema>
+>;
+
+export const UpdatePlexServerRequestSchema = PlexServerSettingsSchema.partial({
+  sendChannelUpdates: true,
+  sendGuideUpdates: true,
+  id: true,
+});
+
+export type UpdatePlexServerRequest = Alias<
+  z.infer<typeof UpdatePlexServerRequestSchema>
+>;
+
+export const InsertPlexServerRequestSchema = PlexServerSettingsSchema.partial({
+  sendChannelUpdates: true,
+  sendGuideUpdates: true,
+  index: true,
+}).omit({
+  id: true,
+});
+
+export type InsertPlexServerRequest = Alias<
+  z.infer<typeof InsertPlexServerRequestSchema>
 >;

--- a/types/src/schemas/eventSchema.ts
+++ b/types/src/schemas/eventSchema.ts
@@ -30,6 +30,7 @@ export const SettingsUpdateEventSchema = BaseEventSchema.extend({
     ]),
     error: z.string().optional(),
     serverName: z.string().optional(),
+    serverId: z.string().optional(),
   }),
 });
 

--- a/web2/src/external/api.ts
+++ b/web2/src/external/api.ts
@@ -19,6 +19,12 @@ import {
 import { Zodios, makeApi, makeErrors, parametersBuilder } from '@zodios/core';
 import { once } from 'lodash-es';
 import { z } from 'zod';
+import settingsApi, {
+  createPlexServerEndpoint,
+  deletePlexServerEndpoint,
+  getPlexServersEndpoint,
+  updatePlexServerEndpoint,
+} from './settingsApi.ts';
 
 export const api = makeApi([
   {
@@ -211,10 +217,10 @@ export const api = makeApi([
     status: 201,
     response: z.object({ id: z.string() }),
   },
-  // {
-  //   method: 'put',
-  //   path: '/api/v2/'
-  // }
+  getPlexServersEndpoint,
+  createPlexServerEndpoint,
+  updatePlexServerEndpoint,
+  deletePlexServerEndpoint,
 ]);
 
 export const createApiClient = once((uri: string) => {

--- a/web2/src/external/settingsApi.ts
+++ b/web2/src/external/settingsApi.ts
@@ -1,0 +1,47 @@
+import {
+  InsertPlexServerRequestSchema,
+  UpdatePlexServerRequestSchema,
+} from '@tunarr/types/api';
+import { PlexServerSettingsSchema } from '@tunarr/types/schemas';
+import { makeEndpoint, parametersBuilder } from '@zodios/core';
+import { z } from 'zod';
+
+export const getPlexServersEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/api/plex-servers',
+  response: z.array(PlexServerSettingsSchema),
+  alias: 'getPlexServers',
+});
+
+export const createPlexServerEndpoint = makeEndpoint({
+  method: 'post',
+  path: '/api/plex-servers',
+  parameters: parametersBuilder()
+    .addBody(InsertPlexServerRequestSchema)
+    .build(),
+  alias: 'createPlexServer',
+  status: 201,
+  response: z.object({ id: z.string() }),
+});
+
+export const updatePlexServerEndpoint = makeEndpoint({
+  method: 'put',
+  path: '/api/plex-servers/:id',
+  parameters: parametersBuilder()
+    .addPath('id', z.string())
+    .addBody(UpdatePlexServerRequestSchema)
+    .build(),
+  alias: 'updatePlexServer',
+  response: z.void(),
+});
+
+export const deletePlexServerEndpoint = makeEndpoint({
+  method: 'delete',
+  path: '/api/plex-servers/:id',
+  parameters: parametersBuilder()
+    .addPath('id', z.string())
+    .addBody(z.null())
+    .build(),
+  alias: 'deletePlexServer',
+  response: z.void(),
+});


### PR DESCRIPTION
* Zod API defintions for all endpoints
* Make delete by ID
* Option at the backend level to not clear out programs (need to expose
  this on API, if we think it is useful)
* Fix on server deletion to not clear program associations if the server
  delete fails
* Use zodios client on frontend for new Plex server endpoint defs
* Other random cleanup as I saw it
