### PR TITLE
Add confirmation modal when deleting Plex server

### DIFF
--- a/web2/src/pages/settings/PlexSettingsPage.tsx
+++ b/web2/src/pages/settings/PlexSettingsPage.tsx
@@ -5,6 +5,11 @@ import {
   Button,
   Checkbox,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormControl,
   FormControlLabel,
   FormHelperText,
@@ -89,6 +94,10 @@ export default function PlexSettingsPage() {
   } = usePlexStreamSettings();
 
   const queryClient = useQueryClient();
+
+  const [deletePlexConfirmation, setDeletePlexConfirmation] = useState<
+    string | undefined
+  >(undefined);
 
   const [showSubtitles, setShowSubtitles] = useState<boolean>(
     defaultPlexStreamSettings.enableSubtitles,
@@ -259,6 +268,42 @@ export default function PlexSettingsPage() {
     },
   });
 
+  const renderConfirmationDialog = () => {
+    return (
+      <Dialog
+        open={!!deletePlexConfirmation}
+        onClose={() => setDeletePlexConfirmation(undefined)}
+        aria-labelledby="delete-plex-server-title"
+        aria-describedby="delete-plex-server-description"
+      >
+        <DialogTitle id="delete-plex-server-title">
+          {'Delete Plex Server?'}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="delete-plex-server-description">
+            Deleting a Plex server will remove all programming from your
+            channels associated with this plex server. Missing programming will
+            be replaced with Flex time. This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeletePlexConfirmation(undefined)}
+            autoFocus
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => removePlexServer(deletePlexConfirmation!)}
+            variant="contained"
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  };
+
   const removePlexServerMutation = useMutation({
     mutationFn: (id: string) => {
       return apiClient.deletePlexServer(null, { params: { id } });
@@ -365,6 +410,7 @@ export default function PlexSettingsPage() {
 
   const removePlexServer = (id: string) => {
     removePlexServerMutation.mutate(id);
+    setDeletePlexConfirmation(undefined);
   };
 
   const getTableRows = () => {
@@ -392,7 +438,7 @@ export default function PlexSettingsPage() {
           </IconButton>
           <IconButton
             color="primary"
-            onClick={() => removePlexServer(server.id)}
+            onClick={() => setDeletePlexConfirmation(server.id)}
           >
             <Delete />
           </IconButton>
@@ -768,6 +814,7 @@ export default function PlexSettingsPage() {
         onClose={handleSnackClose}
         message="Settings Saved!"
       />
+      {renderConfirmationDialog()}
       <Box>
         <Box mb={2}>
           <Box sx={{ display: 'flex', mb: 2 }}>


### PR DESCRIPTION
- Added a confirmation dialog when you attempt to delete a Plex Server.  Given that all associated programming gets deleted from channels when a Plex server is deleted, I wanted to avoid any fat finger situations.

<img width="1462" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/f71e70d3-0069-4bb7-a558-c213fd63af2d">
