### PR TITLE
Updated Channels Page UX

### DIFF
--- a/web2/src/pages/channels/ChannelProgrammingPage.tsx
+++ b/web2/src/pages/channels/ChannelProgrammingPage.tsx
@@ -1,7 +1,9 @@
 import {
   Box,
+  Breadcrumbs,
   Button,
   CircularProgress,
+  Link,
   Snackbar,
   Typography,
 } from '@mui/material';
@@ -11,7 +13,7 @@ import { UpdateChannelProgrammingRequest } from '@tunarr/types/api';
 import { ZodiosError } from '@zodios/core';
 import { chain, findIndex, first, isUndefined, map } from 'lodash-es';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { ChannelProgrammingConfig } from '../../components/channel_config/ChannelProgrammingConfig.tsx';
 import { apiClient } from '../../external/api.ts';
 import { channelProgramUniqueId } from '../../helpers/util.ts';
@@ -121,6 +123,17 @@ export default function ChannelProgrammingPage() {
         message={snackStatus.message}
         sx={{ backgroundColor: snackStatus.color }}
       />
+      <Breadcrumbs sx={{ mb: 2 }} separator="›" aria-label="channel-breadcrumb">
+        <Link
+          underline="hover"
+          color="inherit"
+          component={RouterLink}
+          to="/channels"
+        >
+          Channels
+        </Link>
+        <Box>Manage Programming</Box>
+      </Breadcrumbs>
       <Typography variant="h4" sx={{ mb: 2 }}>
         Channel {channel.number} Programming
       </Typography>

--- a/web2/src/pages/channels/ChannelsPage.tsx
+++ b/web2/src/pages/channels/ChannelsPage.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   IconButton,
   Paper,
-  Stack,
   Table,
   TableBody,
   TableCell,
@@ -21,7 +20,7 @@ import { useTheme } from '@mui/material/styles';
 import { Channel } from '@tunarr/types';
 import dayjs from 'dayjs';
 import { isEmpty } from 'lodash-es';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import { useChannels } from '../../hooks/useChannels.ts';
 
@@ -34,6 +33,14 @@ export default function ChannelsPage() {
   } = useChannels();
   const theme = useTheme();
   const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
+  const navigate = useNavigate();
+
+  const handleChannelNavigation = (
+    event: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    id: string,
+  ) => {
+    navigate(`/channels/${id}/programming`);
+  };
 
   if (channelsLoading) return 'Loading...';
 
@@ -43,7 +50,12 @@ export default function ChannelsPage() {
   const getDataTableRow = (channel: Channel) => {
     const startTime = dayjs(channel.startTime);
     return (
-      <TableRow key={channel.number}>
+      <TableRow
+        key={channel.number}
+        onClick={(event) => handleChannelNavigation(event, channel.id)}
+        sx={{ cursor: 'pointer' }}
+        hover={true}
+      >
         <TableCell width="10%">{channel.number}</TableCell>
         {!smallViewport && (
           <TableCell width="10%">
@@ -58,52 +70,17 @@ export default function ChannelsPage() {
         <TableCell>{channel.name}</TableCell>
         <TableCell>{startTime.isBefore(now) ? 'Yes' : 'No'}</TableCell>
         <TableCell>{channel.stealth ? 'Yes' : 'No'}</TableCell>
-        <TableCell width={smallViewport ? '15%' : undefined}>
-          <Stack direction={'row'} justifyContent={'flex-end'}>
-            <Tooltip title="Edit Channel Settings" placement="top">
-              {smallViewport ? (
-                <IconButton
-                  to={`/channels/${channel.id}/edit`}
-                  component={RouterLink}
-                  color={'primary'}
-                >
-                  <EditIcon />
-                </IconButton>
-              ) : (
-                <Button
-                  variant="contained"
-                  startIcon={<EditIcon />}
-                  to={`/channels/${channel.id}/edit`}
-                  component={RouterLink}
-                  sx={{ marginRight: 1 }}
-                  color={'primary'}
-                >
-                  Edit
-                </Button>
-              )}
-            </Tooltip>
-            <Tooltip title="Add/Edit Programming" placement="top">
-              {smallViewport ? (
-                <IconButton
-                  to={`/channels/${channel.id}/programming`}
-                  component={RouterLink}
-                  color={'primary'}
-                >
-                  <SettingsRemoteIcon />
-                </IconButton>
-              ) : (
-                <Button
-                  variant="contained"
-                  startIcon={<SettingsRemoteIcon />}
-                  to={`/channels/${channel.id}/programming`}
-                  component={RouterLink}
-                  color={'primary'}
-                >
-                  Add Programs
-                </Button>
-              )}
-            </Tooltip>
-          </Stack>
+        <TableCell sx={{ textAlign: 'right' }}>
+          <Tooltip title="Edit Channel Settings" placement="top">
+            <IconButton
+              to={`/channels/${channel.id}/edit`}
+              component={RouterLink}
+              color={'primary'}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <EditIcon />
+            </IconButton>
+          </Tooltip>
         </TableCell>
       </TableRow>
     );

--- a/web2/src/pages/channels/EditChannelPage.tsx
+++ b/web2/src/pages/channels/EditChannelPage.tsx
@@ -214,15 +214,16 @@ export default function EditChannelPage({ isNew }: Props) {
     <ChannelEditContext.Provider
       value={{ channelEditorState, setChannelEditorState }}
     >
-      <Breadcrumbs sx={{ mb: 2 }}>
+      <Breadcrumbs sx={{ mb: 2 }} separator="›" aria-label="channel-breadcrumb">
         <Link
           underline="hover"
           color="inherit"
           component={RouterLink}
           to="/channels"
         >
-          Back
+          Channels
         </Link>
+        <Box>Edit Channel</Box>
       </Breadcrumbs>
       {workingChannel && (
         <div>


### PR DESCRIPTION
- Made Channel TableRows a link that navigated to the programming since that is likely the primary action users are looking for. 
- Removed the 'Edit Channel' button and replaced with just the icon
- Updated the breadcrumbs to make navigation back and forth between Channels, Editing Channels, & Editing Programming


Screenshots:

<img width="1564" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/8770503f-c8ca-4e76-80c8-047ec7ed70fc">

<img width="601" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/445ce199-5852-4b73-bfd6-0fdcd07d91c4">

<img width="544" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/4a4336ec-ce60-4757-8965-06175a3fb51c">
