### PR TITLE
Hardcode % width of remainder of guide container to make sure everything fits. Fixes #78

### DIFF
--- a/web2/src/pages/guide/GuidePage.tsx
+++ b/web2/src/pages/guide/GuidePage.tsx
@@ -85,7 +85,7 @@ const GuideItem = styled(GridChild)<{ grey: keyof Color; width: number }>(
 );
 
 const modalStyle = {
-  position: 'absolute' as 'absolute',
+  position: 'absolute' as const,
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
@@ -602,7 +602,7 @@ export default function GuidePage() {
               display: 'flex',
               position: 'relative',
               flexDirection: 'column',
-              width: '100%',
+              width: `${smallViewport ? '90%' : '85%'}`,
             }}
           >
             <Box


### PR DESCRIPTION
![image](https://github.com/chrisbenincasa/tunarr/assets/1640671/0f48c813-a9e6-4aba-9699-1d48d00738fc)
