### PR TITLE
Programming Page Revamp + Basic search

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,13 +307,13 @@ importers:
         version: 5.14.17(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
       '@mui/x-date-pickers':
         specifier: ^6.19.2
-        version: 6.19.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.14.17)(@mui/system@5.14.17)(@types/react@18.2.15)(dayjs@1.11.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.19.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.14.17)(@mui/system@5.15.9)(@types/react@18.2.15)(dayjs@1.11.10)(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query':
-        specifier: ^5.8.1
-        version: 5.8.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^5.18.1
+        version: 5.20.5(react@18.2.0)
       '@tanstack/react-query-devtools':
         specifier: ^5.18.1
-        version: 5.18.1(@tanstack/react-query@5.8.1)(react@18.2.0)
+        version: 5.18.1(@tanstack/react-query@5.20.5)(react@18.2.0)
       '@tunarr/shared':
         specifier: workspace:*
         version: link:../shared
@@ -372,8 +372,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       usehooks-ts:
-        specifier: ^2.9.1
-        version: 2.9.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.14.0
+        version: 2.14.0(react@18.2.0)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -662,6 +662,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: false
+
+  /@babel/runtime@7.23.9:
+    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
     dev: false
 
   /@babel/template@7.22.15:
@@ -1708,6 +1715,23 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@mui/private-theming@5.15.9(@types/react@18.2.15)(react@18.2.0):
+    resolution: {integrity: sha512-/aMJlDOxOTAXyp4F2rIukW1O0anodAMCkv1DfBh/z9vaKHY3bd5fFf42wmP+0GRmwMinC5aWPpNfHXOED1fEtg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@mui/utils': 5.15.9(@types/react@18.2.15)(react@18.2.0)
+      '@types/react': 18.2.15
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
   /@mui/styled-engine@5.14.17(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0):
     resolution: {integrity: sha512-AqpVjBEA7wnBvKPW168bNlqB6EN7HxTjLOY7oi275AzD/b1C7V0wqELy6NWoJb2yya5sRf7ENf4iNi3+T5cOgw==}
     engines: {node: '>=12.0.0'}
@@ -1726,6 +1750,28 @@ packages:
       '@emotion/react': 11.11.1(@types/react@18.2.15)(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.15)(react@18.2.0)
       csstype: 3.1.2
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/styled-engine@5.15.9(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0):
+    resolution: {integrity: sha512-NRKtYkL5PZDH7dEmaLEIiipd3mxNnQSO+Yo8rFNBNptY8wzQnQ+VjayTq39qH7Sast5cwHKYFusUrQyD+SS4Og==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.1(@types/react@18.2.15)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.15)(react@18.2.0)
+      csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
@@ -1760,6 +1806,47 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@mui/system@5.15.9(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react@18.2.0):
+    resolution: {integrity: sha512-SxkaaZ8jsnIJ77bBXttfG//LUf6nTfOcaOuIgItqfHv60ZCQy/Hu7moaob35kBb+guxVJnoSZ+7vQJrA/E7pKg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/react': 11.11.1(@types/react@18.2.15)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.15)(react@18.2.0)
+      '@mui/private-theming': 5.15.9(@types/react@18.2.15)(react@18.2.0)
+      '@mui/styled-engine': 5.15.9(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
+      '@mui/types': 7.2.13(@types/react@18.2.15)
+      '@mui/utils': 5.15.9(@types/react@18.2.15)(react@18.2.0)
+      '@types/react': 18.2.15
+      clsx: 2.1.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
+  /@mui/types@7.2.13(@types/react@18.2.15):
+    resolution: {integrity: sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.15
+    dev: false
+
   /@mui/types@7.2.8(@types/react@18.2.15):
     resolution: {integrity: sha512-9u0ji+xspl96WPqvrYJF/iO+1tQ1L5GTaDOeG3vCR893yy7VcWwRNiVMmPdPNpMDqx0WV1wtEW9OMwK9acWJzQ==}
     peerDependencies:
@@ -1789,7 +1876,25 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /@mui/x-date-pickers@6.19.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.14.17)(@mui/system@5.14.17)(@types/react@18.2.15)(dayjs@1.11.10)(react-dom@18.2.0)(react@18.2.0):
+  /@mui/utils@5.15.9(@types/react@18.2.15)(react@18.2.0):
+    resolution: {integrity: sha512-yDYfr61bCYUz1QtwvpqYy/3687Z8/nS4zv7lv/ih/6ZFGMl1iolEvxRmR84v2lOYxlds+kq1IVYbXxDKh8Z9sg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@types/prop-types': 15.7.11
+      '@types/react': 18.2.15
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 18.2.0
+    dev: false
+
+  /@mui/x-date-pickers@6.19.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.14.17)(@mui/system@5.15.9)(@types/react@18.2.15)(dayjs@1.11.10)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/bdWZabexuz+1rKG15XryxiMGb5D0XVx65NU7CZYKm/1+HuUzc0FX9smKEa/YVZnLSNsAp6SULIyPZtAKE+3AA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1831,7 +1936,7 @@ packages:
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.15)(react@18.2.0)
       '@mui/base': 5.0.0-beta.23(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
       '@mui/material': 5.14.17(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/system': 5.14.17(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react@18.2.0)
+      '@mui/system': 5.15.9(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react@18.2.0)
       '@mui/utils': 5.14.17(@types/react@18.2.15)(react@18.2.0)
       '@types/react-transition-group': 4.4.9
       clsx: 2.0.0
@@ -2140,40 +2245,32 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
-  /@tanstack/query-core@5.8.1:
-    resolution: {integrity: sha512-Y0enatz2zQXBAsd7XmajlCs+WaitdR7dIFkqz9Xd7HL4KV04JOigWVreYseTmNH7YFSBSC/BJ9uuNp1MAf+GfA==}
+  /@tanstack/query-core@5.20.5:
+    resolution: {integrity: sha512-T1W28gGgWn0A++tH3lxj3ZuUVZZorsiKcv+R50RwmPYz62YoDEkG4/aXHZELGkRp4DfrW07dyq2K5dvJ4Wl1aA==}
     dev: false
 
   /@tanstack/query-devtools@5.18.1:
     resolution: {integrity: sha512-U8bDnDGuwdVMT4ndegPTcjOHOmX/UOjjB7o7UalRIq3DMHLRf8Ufh4+xoAvk3LNK5GBmUBfFSw4osYe5l9n7Lw==}
     dev: false
 
-  /@tanstack/react-query-devtools@5.18.1(@tanstack/react-query@5.8.1)(react@18.2.0):
+  /@tanstack/react-query-devtools@5.18.1(@tanstack/react-query@5.20.5)(react@18.2.0):
     resolution: {integrity: sha512-IrzAsodabSkEVBP0DHkuzcmqKFZ0EgG9ocuD/fRIrjYmbqqdHxzNmp2WmAZlkVo7hamA0ZdzvL5sjo1koFzjHA==}
     peerDependencies:
       '@tanstack/react-query': ^5.18.1
       react: ^18.0.0
     dependencies:
       '@tanstack/query-devtools': 5.18.1
-      '@tanstack/react-query': 5.8.1(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-query': 5.20.5(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@tanstack/react-query@5.8.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-YMagxS8iNPOLg0pK6WOjdSDlAvWKOf69udLOwQrBVmkC2SRLNLko7elo5Ro3ptlJkXvTVHidxC/h5KGi5bH1XQ==}
+  /@tanstack/react-query@5.20.5(react@18.2.0):
+    resolution: {integrity: sha512-6MHwJ8G9cnOC/XKrwt56QMc91vN7hLlAQNUA0ubP7h9Jj3a/CmkUwT6ALdFbnVP+PsYdhW3WONa8WQ4VcTaSLQ==}
     peerDependencies:
       react: ^18.0.0
-      react-dom: ^18.0.0
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
     dependencies:
-      '@tanstack/query-core': 5.8.1
+      '@tanstack/query-core': 5.20.5
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@ts-morph/common@0.22.0:
@@ -2355,6 +2452,10 @@ packages:
 
   /@types/prop-types@15.7.10:
     resolution: {integrity: sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==}
+
+  /@types/prop-types@15.7.11:
+    resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
+    dev: false
 
   /@types/qs@6.9.10:
     resolution: {integrity: sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==}
@@ -2852,7 +2953,7 @@ packages:
   /assert@1.5.1:
     resolution: {integrity: sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==}
     dependencies:
-      object.assign: 4.1.4
+      object.assign: 4.1.5
       util: 0.10.4
     dev: true
 
@@ -2883,8 +2984,8 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /available-typed-arrays@1.0.5:
-    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+  /available-typed-arrays@1.0.6:
+    resolution: {integrity: sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -3264,12 +3365,15 @@ packages:
     resolution: {integrity: sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==}
     dev: true
 
-  /call-bind@1.0.5:
-    resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+  /call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
     dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.2
-      set-function-length: 1.1.1
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.1
     dev: true
 
   /call-me-maybe@1.0.2:
@@ -3435,6 +3539,11 @@ packages:
 
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /clsx@2.1.0:
+    resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
     engines: {node: '>=6'}
     dev: false
 
@@ -3669,6 +3778,10 @@ packages:
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    dev: false
+
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
     engines: {node: '>=0.10.0'}
@@ -3831,21 +3944,21 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /define-data-property@1.1.1:
-    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.2
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
     dev: true
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
-      has-property-descriptors: 1.0.1
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
       object-keys: 1.1.1
     dev: true
 
@@ -4073,6 +4186,18 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+
+  /es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: true
 
   /esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -4713,13 +4838,15 @@ packages:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
-  /get-intrinsic@1.2.2:
-    resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
+  /get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
+      es-errors: 1.3.0
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: true
 
   /get-package-type@0.1.0:
@@ -4846,7 +4973,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
     dev: true
 
   /got@11.8.6:
@@ -4924,10 +5051,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /has-property-descriptors@1.0.1:
-    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
-      get-intrinsic: 1.2.2
+      es-define-property: 1.0.0
     dev: true
 
   /has-proto@1.0.1:
@@ -4950,8 +5077,8 @@ packages:
       has-symbol-support-x: 1.4.2
     dev: true
 
-  /has-tostringtag@1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
+  /has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
@@ -4983,6 +5110,13 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+
+  /hasown@2.0.1:
+    resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
 
   /hls.js@1.4.12:
     resolution: {integrity: sha512-1RBpx2VihibzE3WE9kGoVCtrhhDWTzydzElk/kyRbEOLnb1WIE+3ZabM/L8BqKFTCL3pUy4QzhXgD1Q6Igr1JA==}
@@ -5169,8 +5303,8 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      has-tostringtag: 1.0.0
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
     dev: true
 
   /is-arrayish@0.2.1:
@@ -5218,7 +5352,7 @@ packages:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
     dev: true
 
   /is-glob@4.0.3:
@@ -5274,11 +5408,11 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /is-typed-array@1.1.12:
-    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
+  /is-typed-array@1.1.13:
+    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      which-typed-array: 1.1.13
+      which-typed-array: 1.1.14
     dev: true
 
   /is-utf8@0.2.1:
@@ -5584,6 +5718,10 @@ packages:
 
   /lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
+  /lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: false
 
   /lodash.memoize@3.0.4:
@@ -6164,11 +6302,11 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /object.assign@4.1.4:
-    resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
+  /object.assign@4.1.5:
+    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
@@ -6770,7 +6908,7 @@ packages:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
     dependencies:
-      side-channel: 1.0.4
+      side-channel: 1.0.5
     dev: true
 
   /qs@6.7.0:
@@ -7068,6 +7206,10 @@ packages:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: false
 
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+    dev: false
+
   /remove-accents@0.4.2:
     resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
     dev: false
@@ -7298,14 +7440,16 @@ packages:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: false
 
-  /set-function-length@1.1.1:
-    resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
+  /set-function-length@1.2.1:
+    resolution: {integrity: sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
-      get-intrinsic: 1.2.2
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
+      has-property-descriptors: 1.0.2
     dev: true
 
   /setprototypeof@1.1.1:
@@ -7346,11 +7490,13 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
-  /side-channel@1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+  /side-channel@1.0.5:
+    resolution: {integrity: sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
       object-inspect: 1.13.1
     dev: true
 
@@ -8141,15 +8287,14 @@ packages:
       react: 18.2.0
     dev: false
 
-  /usehooks-ts@2.9.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==}
-    engines: {node: '>=16.15.0', npm: '>=8'}
+  /usehooks-ts@2.14.0(react@18.2.0):
+    resolution: {integrity: sha512-jnhrjTRJoJS7cFxz63tRYc5mzTKf/h+Ii8P0PDHymT9qDe4ZA2/gzDRmDR4WGausg5X8wMIdghwi3BBCN9JKow==}
+    engines: {node: '>=16.15.0'}
     peerDependencies:
-      react: ^16.8.0  || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+      react: ^16.8.0  || ^17 || ^18
     dependencies:
+      lodash.debounce: 4.0.8
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /util-deprecate@1.0.2:
@@ -8167,8 +8312,8 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.12
-      which-typed-array: 1.1.13
+      is-typed-array: 1.1.13
+      which-typed-array: 1.1.14
     dev: true
 
   /uuid@9.0.1:
@@ -8363,15 +8508,15 @@ packages:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
     dev: true
 
-  /which-typed-array@1.1.13:
-    resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
+  /which-typed-array@1.1.14:
+    resolution: {integrity: sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.5
+      available-typed-arrays: 1.0.6
+      call-bind: 1.0.7
       for-each: 0.3.3
       gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
     dev: true
 
   /which@1.3.1:

--- a/web2/package.json
+++ b/web2/package.json
@@ -17,7 +17,7 @@
     "@mui/icons-material": "^5.14.16",
     "@mui/material": "^5.14.17",
     "@mui/x-date-pickers": "^6.19.2",
-    "@tanstack/react-query": "^5.8.1",
+    "@tanstack/react-query": "^5.18.1",
     "@tanstack/react-query-devtools": "^5.18.1",
     "@tunarr/shared": "workspace:*",
     "@tunarr/types": "workspace:*",
@@ -38,7 +38,7 @@
     "react-router-dom": "^6.18.0",
     "react-window": "^1.8.9",
     "sort-by": "^1.2.0",
-    "usehooks-ts": "^2.9.1",
+    "usehooks-ts": "^2.14.0",
     "uuid": "^9.0.1",
     "zod": "^3.22.4",
     "zustand": "^4.4.6"

--- a/web2/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web2/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -258,7 +258,9 @@ export function ChannelProgrammingConfig() {
           </Button>
           <Button
             variant="contained"
-            onClick={() => setProgrammingModalOpen(true)}
+            component={Link}
+            to="add"
+            // onClick={() => setProgrammingModalOpen(true)}
           >
             Add
           </Button>

--- a/web2/src/components/channel_config/PlexListItem.tsx
+++ b/web2/src/components/channel_config/PlexListItem.tsx
@@ -25,9 +25,14 @@ import {
   addKnownMediaForServer,
   addSelectedMedia,
 } from '../../store/programmingSelector/actions.ts';
-import { PlexListItemProps } from './ProgrammingSelectorDialog.tsx';
 
-// function extractPlexItemChildren<T extends PlexMedia>()
+export interface PlexListItemProps<T extends PlexMedia> {
+  item: T;
+  style?: React.CSSProperties;
+  index?: number;
+  length?: number;
+  parent?: string;
+}
 
 export function PlexListItem<T extends PlexMedia>(props: PlexListItemProps<T>) {
   const server = useStore((s) => s.currentServer!); // We have to have a server at this point

--- a/web2/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web2/src/components/channel_config/ProgrammingSelector.tsx
@@ -1,9 +1,11 @@
 import {
+  Divider,
   FormControl,
   InputLabel,
   List,
   MenuItem,
   Select,
+  TextField,
   Typography,
 } from '@mui/material';
 import {
@@ -11,17 +13,20 @@ import {
   PlexMedia,
   isPlexDirectory,
 } from '@tunarr/types/plex';
-import { isEmpty, isUndefined, keys } from 'lodash-es';
+import { isEmpty, isNil, isUndefined, keys } from 'lodash-es';
 import React, { useEffect } from 'react';
 import { usePlex } from '../../hooks/plexHooks.ts';
 import { usePlexServerSettings } from '../../hooks/settingsHooks.ts';
 import useStore from '../../store/index.ts';
 import {
   addKnownMediaForServer,
+  setProgrammingListLibrary,
   setProgrammingListingServer,
 } from '../../store/programmingSelector/actions.ts';
 import { PlexDirectoryListItem } from './PlexDirectoryListItem.tsx';
 import SelectedProgrammingList from './SelectedProgrammingList.tsx';
+import useDebouncedState from '../../hooks/useDebouncedState.ts';
+import { useQuery } from '@tanstack/react-query';
 
 export interface PlexListItemProps<T extends PlexMedia> {
   item: T;
@@ -34,6 +39,7 @@ export interface PlexListItemProps<T extends PlexMedia> {
 export default function ProgrammingSelector() {
   const { data: plexServers } = usePlexServerSettings();
   const selectedServer = useStore((s) => s.currentServer);
+  const selectedLibrary = useStore((s) => s.currentLibrary);
   // const listingsByServer = useStore((s) => s.listingsByServer);
   const knownMedia = useStore((s) => s.knownMediaByServer);
   const hierarchyByServer = useStore((s) => s.contentHierarchyByServer);
@@ -55,11 +61,45 @@ export default function ProgrammingSelector() {
 
   useEffect(() => {
     if (directoryChildren) {
+      if (directoryChildren.size > 0) {
+        setProgrammingListLibrary(directoryChildren.Directory[0].key);
+      }
       addKnownMediaForServer(selectedServer!.name, [
         ...directoryChildren.Directory,
       ]);
     }
   }, [selectedServer, directoryChildren]);
+
+  const [search, debounceSearch, setSearch] = useDebouncedState('', 300);
+
+  const { isLoading: searchLoading, data: searchData } = useQuery({
+    queryKey: ['plex-search', selectedServer, selectedLibrary, debounceSearch],
+    enabled:
+      !isNil(selectedServer) &&
+      !isNil(selectedLibrary) &&
+      !isNil(debounceSearch) &&
+      debounceSearch.length > 0,
+    queryFn: async () => {
+      const plexQuery = new URLSearchParams({
+        'Plex-Container-Start': '0',
+        'Plex-Container-Size': '10',
+        'title<': debounceSearch,
+      });
+      const query = new URLSearchParams({
+        name: selectedServer!.name,
+        path: `/library/sections/${selectedLibrary}/all?${plexQuery.toString()}`,
+      });
+      return await fetch(
+        `http://localhost:8000/api/plex?${query.toString()}`,
+      ).then((r) => r.json());
+    },
+  });
+
+  useEffect(() => {
+    if (debounceSearch && debounceSearch.length > 0) {
+      console.log(debounceSearch);
+    }
+  }, [debounceSearch]);
 
   const renderListItems = () => {
     const directoryIds = keys(hierarchyByServer[selectedServer!.name]);
@@ -78,24 +118,46 @@ export default function ProgrammingSelector() {
 
   return (
     <>
-      <FormControl fullWidth size="small">
-        {selectedServer && (
-          <>
-            <InputLabel>Media Source</InputLabel>
-            <Select label="Media Source" value={selectedServer?.name}>
-              {plexServers?.map((server) => (
-                <MenuItem key={server.name} value={server.name}>
-                  Plex: {server.name}
+      {selectedServer && (
+        <FormControl fullWidth size="small" margin="dense">
+          <InputLabel>Media Source</InputLabel>
+          <Select label="Media Source" value={selectedServer?.name}>
+            {plexServers?.map((server) => (
+              <MenuItem key={server.name} value={server.name}>
+                Plex: {server.name}
+              </MenuItem>
+            ))}
+            <MenuItem value="custom-shows">Custom Shows</MenuItem>
+          </Select>
+        </FormControl>
+      )}
+      {directoryChildren && directoryChildren.size > 0 && (
+        <>
+          <FormControl fullWidth size="small" margin="normal">
+            <InputLabel>Library</InputLabel>
+            <Select label="Library" value={directoryChildren.Directory[0].key}>
+              {directoryChildren.Directory.map((dir) => (
+                <MenuItem key={dir.key} value={dir.key}>
+                  {dir.title}
                 </MenuItem>
               ))}
               <MenuItem value="custom-shows">Custom Shows</MenuItem>
             </Select>
-          </>
-        )}
-      </FormControl>
-      <List component="nav" sx={{ width: '100%' }}>
+          </FormControl>
+          <TextField
+            size="small"
+            label="Search"
+            margin="dense"
+            fullWidth
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </>
+      )}
+      {/* <List component="nav" sx={{ width: '100%' }}>
         {selectedServer && renderListItems()}
-      </List>
+      </List> */}
+      <Divider sx={{ mt: 3, mb: 2 }} />
       <Typography>Selected Items</Typography>
       <SelectedProgrammingList />
     </>

--- a/web2/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web2/src/components/channel_config/ProgrammingSelector.tsx
@@ -1,4 +1,11 @@
-import { FormControl, List, MenuItem, Select, Typography } from '@mui/material';
+import {
+  FormControl,
+  InputLabel,
+  List,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
 import {
   PlexLibrarySection,
   PlexMedia,
@@ -73,13 +80,17 @@ export default function ProgrammingSelector() {
     <>
       <FormControl fullWidth size="small">
         {selectedServer && (
-          <Select value={selectedServer?.name}>
-            {plexServers?.map((server) => (
-              <MenuItem key={server.name} value={server.name}>
-                {server.name}
-              </MenuItem>
-            ))}
-          </Select>
+          <>
+            <InputLabel>Media Source</InputLabel>
+            <Select label="Media Source" value={selectedServer?.name}>
+              {plexServers?.map((server) => (
+                <MenuItem key={server.name} value={server.name}>
+                  Plex: {server.name}
+                </MenuItem>
+              ))}
+              <MenuItem value="custom-shows">Custom Shows</MenuItem>
+            </Select>
+          </>
         )}
       </FormControl>
       <List component="nav" sx={{ width: '100%' }}>

--- a/web2/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web2/src/components/channel_config/ProgrammingSelector.tsx
@@ -1,32 +1,43 @@
+import { Clear } from '@mui/icons-material';
 import {
   Divider,
   FormControl,
+  IconButton,
+  InputAdornment,
   InputLabel,
+  LinearProgress,
   List,
   MenuItem,
   Select,
   TextField,
   Typography,
 } from '@mui/material';
+import { DataTag, useInfiniteQuery } from '@tanstack/react-query';
 import {
-  PlexLibrarySection,
+  PlexLibraryMovies,
+  PlexLibraryShows,
   PlexMedia,
+  PlexMovie,
+  PlexTvShow,
   isPlexDirectory,
 } from '@tunarr/types/plex';
-import { isEmpty, isNil, isUndefined, keys } from 'lodash-es';
-import React, { useEffect } from 'react';
-import { usePlex } from '../../hooks/plexHooks.ts';
+import { chain, first, isEmpty, isNil, isUndefined } from 'lodash-es';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useIntersectionObserver } from 'usehooks-ts';
+import { fetchPlexPath, usePlex } from '../../hooks/plexHooks.ts';
 import { usePlexServerSettings } from '../../hooks/settingsHooks.ts';
+import useDebouncedState from '../../hooks/useDebouncedState.ts';
+import { addPlexMediaToCurrentChannel } from '../../store/channelEditor/actions.ts';
 import useStore from '../../store/index.ts';
 import {
   addKnownMediaForServer,
   setProgrammingListLibrary,
   setProgrammingListingServer,
 } from '../../store/programmingSelector/actions.ts';
-import { PlexDirectoryListItem } from './PlexDirectoryListItem.tsx';
+import AddSelectedMediaButton from './AddSelectedMediaButton.tsx';
+import { PlexListItem } from './PlexListItem.tsx';
 import SelectedProgrammingList from './SelectedProgrammingList.tsx';
-import useDebouncedState from '../../hooks/useDebouncedState.ts';
-import { useQuery } from '@tanstack/react-query';
 
 export interface PlexListItemProps<T extends PlexMedia> {
   item: T;
@@ -42,7 +53,8 @@ export default function ProgrammingSelector() {
   const selectedLibrary = useStore((s) => s.currentLibrary);
   // const listingsByServer = useStore((s) => s.listingsByServer);
   const knownMedia = useStore((s) => s.knownMediaByServer);
-  const hierarchyByServer = useStore((s) => s.contentHierarchyByServer);
+  // const hierarchyByServer = useStore((s) => s.contentHierarchyByServer);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const server =
@@ -53,6 +65,9 @@ export default function ProgrammingSelector() {
     setProgrammingListingServer(server);
   }, [plexServers]);
 
+  const [scrollParams, setScrollParams] = useState({ limit: 0, max: -1 });
+  const [search, debounceSearch, setSearch] = useDebouncedState('', 300);
+
   const { data: directoryChildren } = usePlex(
     selectedServer?.name ?? '',
     '/library/sections',
@@ -62,7 +77,7 @@ export default function ProgrammingSelector() {
   useEffect(() => {
     if (directoryChildren) {
       if (directoryChildren.size > 0) {
-        setProgrammingListLibrary(directoryChildren.Directory[0].key);
+        setProgrammingListLibrary(directoryChildren.Directory[0]);
       }
       addKnownMediaForServer(selectedServer!.name, [
         ...directoryChildren.Directory,
@@ -70,50 +85,108 @@ export default function ProgrammingSelector() {
     }
   }, [selectedServer, directoryChildren]);
 
-  const [search, debounceSearch, setSearch] = useDebouncedState('', 300);
-
-  const { isLoading: searchLoading, data: searchData } = useQuery({
-    queryKey: ['plex-search', selectedServer, selectedLibrary, debounceSearch],
-    enabled:
-      !isNil(selectedServer) &&
-      !isNil(selectedLibrary) &&
-      !isNil(debounceSearch) &&
-      debounceSearch.length > 0,
-    queryFn: async () => {
+  const { isLoading: searchLoading, data: searchData } = useInfiniteQuery({
+    queryKey: [
+      'plex-search',
+      selectedServer?.name,
+      selectedLibrary?.key,
+      debounceSearch,
+    ] as DataTag<
+      ['plex-search', string, string, string],
+      PlexLibraryMovies | PlexLibraryShows
+    >,
+    enabled: !isNil(selectedServer) && !isNil(selectedLibrary),
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => {
       const plexQuery = new URLSearchParams({
-        'Plex-Container-Start': '0',
+        'Plex-Container-Start': pageParam.toString(),
         'Plex-Container-Size': '10',
-        'title<': debounceSearch,
       });
-      const query = new URLSearchParams({
-        name: selectedServer!.name,
-        path: `/library/sections/${selectedLibrary}/all?${plexQuery.toString()}`,
-      });
-      return await fetch(
-        `http://localhost:8000/api/plex?${query.toString()}`,
-      ).then((r) => r.json());
+
+      if (!isNil(debounceSearch) && !isEmpty(debounceSearch)) {
+        plexQuery.set('title<', debounceSearch);
+      }
+
+      return fetchPlexPath<PlexLibraryMovies | PlexLibraryShows>(
+        selectedServer!.name,
+        `/library/sections/${selectedLibrary!.key}/all?${plexQuery.toString()}`,
+      )();
+    },
+    getNextPageParam: (res, _, last) => {
+      if (res.size < 10) {
+        return null;
+      }
+
+      return last + 10;
     },
   });
 
   useEffect(() => {
-    if (debounceSearch && debounceSearch.length > 0) {
-      console.log(debounceSearch);
+    if (searchData) {
+      // We're using this as an analogue for detecting the start of a new 'query'
+      if (searchData.pages.length === 1) {
+        setScrollParams({
+          limit: 10,
+          max: first(searchData.pages)!.size,
+        });
+      }
+
+      // We probably wouldn't have made it this far if we didnt have a server, but
+      // putting this here to prevent crashes
+      if (selectedServer) {
+        const allMedia = chain(searchData.pages)
+          .reject((page) => page.size === 0)
+          .map((page) => page.Metadata)
+          .flatten()
+          .value();
+        addKnownMediaForServer(selectedServer.name, allMedia);
+      }
     }
-  }, [debounceSearch]);
+  }, [selectedServer, searchData, setScrollParams]);
+
+  const onLibraryChange = useCallback(
+    (libraryUuid: string) => {
+      if (selectedServer) {
+        const known = knownMedia[selectedServer.name] ?? {};
+        const library = known[libraryUuid];
+        if (library && isPlexDirectory(library)) {
+          setProgrammingListLibrary(library);
+        }
+      }
+    },
+    [knownMedia, selectedServer],
+  );
+
+  const { ref } = useIntersectionObserver({
+    onChange: (_, entry) => {
+      if (entry.isIntersecting && scrollParams.limit < scrollParams.max) {
+        setScrollParams(({ limit: prevLimit, max }) => ({
+          max,
+          limit: prevLimit + 10,
+        }));
+      }
+    },
+    threshold: 0.5,
+  });
+
+  const clearSearchInput = useCallback(() => {
+    setSearch('');
+  }, [setSearch]);
 
   const renderListItems = () => {
-    const directoryIds = keys(hierarchyByServer[selectedServer!.name]);
-    const mediaForServer = knownMedia[selectedServer!.name] ?? {};
+    if (!searchData) {
+      return null;
+    }
 
-    return directoryIds
-      .filter((id) => isPlexDirectory(mediaForServer[id]))
-      .map((id) => (
-        <PlexDirectoryListItem
-          server={selectedServer!}
-          key={id}
-          item={mediaForServer[id] as PlexLibrarySection}
-        />
-      ));
+    return chain(searchData.pages)
+      .reject((page) => page.size === 0)
+      .map((page) => page.Metadata)
+      .flatten()
+      .take(scrollParams.limit)
+      .map((item: PlexMovie | PlexTvShow) => {
+        return <PlexListItem key={item.guid} item={item} />;
+      })
+      .value();
   };
 
   return (
@@ -131,35 +204,67 @@ export default function ProgrammingSelector() {
           </Select>
         </FormControl>
       )}
-      {directoryChildren && directoryChildren.size > 0 && (
-        <>
-          <FormControl fullWidth size="small" margin="normal">
-            <InputLabel>Library</InputLabel>
-            <Select label="Library" value={directoryChildren.Directory[0].key}>
-              {directoryChildren.Directory.map((dir) => (
-                <MenuItem key={dir.key} value={dir.key}>
-                  {dir.title}
-                </MenuItem>
-              ))}
-              <MenuItem value="custom-shows">Custom Shows</MenuItem>
-            </Select>
-          </FormControl>
-          <TextField
-            size="small"
-            label="Search"
-            margin="dense"
-            fullWidth
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </>
-      )}
-      {/* <List component="nav" sx={{ width: '100%' }}>
+      {!isNil(directoryChildren) &&
+        directoryChildren.size > 0 &&
+        selectedLibrary && (
+          <>
+            <FormControl fullWidth size="small" margin="normal">
+              <InputLabel>Library</InputLabel>
+              <Select
+                label="Library"
+                value={selectedLibrary.uuid}
+                onChange={(e) => onLibraryChange(e.target.value)}
+              >
+                {directoryChildren.Directory.map((dir) => (
+                  <MenuItem key={dir.key} value={dir.uuid}>
+                    {dir.title}
+                  </MenuItem>
+                ))}
+                <MenuItem value="custom-shows">Custom Shows</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              size="small"
+              label="Search"
+              margin="dense"
+              variant="outlined"
+              fullWidth
+              value={search}
+              disabled={searchLoading}
+              onChange={(e) => setSearch(e.target.value)}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      onClick={clearSearchInput}
+                      onMouseDown={(e) => e.preventDefault()}
+                      edge="end"
+                    >
+                      <Clear />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </>
+        )}
+      <LinearProgress
+        sx={{ visibility: searchLoading ? 'visible' : 'hidden' }}
+      />
+      <List
+        component="nav"
+        sx={{ mt: 2, width: '100%', maxHeight: 400, overflowY: 'scroll' }}
+      >
         {selectedServer && renderListItems()}
-      </List> */}
+        <div style={{ height: 40 }} ref={ref}></div>
+      </List>
       <Divider sx={{ mt: 3, mb: 2 }} />
       <Typography>Selected Items</Typography>
       <SelectedProgrammingList />
+      <AddSelectedMediaButton
+        onAdd={addPlexMediaToCurrentChannel}
+        onSuccess={() => navigate('..', { relative: 'path' })}
+      />
     </>
   );
 }

--- a/web2/src/components/channel_config/ProgrammingSelectorDialog.tsx
+++ b/web2/src/components/channel_config/ProgrammingSelectorDialog.tsx
@@ -5,11 +5,11 @@ import {
   DialogContent,
   DialogTitle,
 } from '@mui/material';
-import { PlexMedia } from '@tunarr/types/plex';
 import { isEmpty, isUndefined } from 'lodash-es';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { usePlex } from '../../hooks/plexHooks.ts';
 import { usePlexServerSettings } from '../../hooks/settingsHooks.ts';
+import { addPlexMediaToCurrentChannel } from '../../store/channelEditor/actions.ts';
 import useStore from '../../store/index.ts';
 import {
   addKnownMediaForServer,
@@ -17,15 +17,6 @@ import {
 } from '../../store/programmingSelector/actions.ts';
 import AddSelectedMediaButton from './AddSelectedMediaButton.tsx';
 import ProgrammingSelector from './ProgrammingSelector.tsx';
-import { addPlexMediaToCurrentChannel } from '../../store/channelEditor/actions.ts';
-
-export interface PlexListItemProps<T extends PlexMedia> {
-  item: T;
-  style?: React.CSSProperties;
-  index?: number;
-  length: number;
-  parent?: string;
-}
 
 export default function ProgrammingSelectorDialog(props: {
   open: boolean;

--- a/web2/src/external/api.ts
+++ b/web2/src/external/api.ts
@@ -24,6 +24,7 @@ import {
   deletePlexServerEndpoint,
   getPlexBackendStatus,
   getPlexServersEndpoint,
+  getXmlTvSettings,
   updatePlexServerEndpoint,
 } from './settingsApi.ts';
 
@@ -223,6 +224,7 @@ export const api = makeApi([
   updatePlexServerEndpoint,
   deletePlexServerEndpoint,
   getPlexBackendStatus,
+  getXmlTvSettings,
 ]);
 
 export const createApiClient = once((uri: string) => {

--- a/web2/src/external/api.ts
+++ b/web2/src/external/api.ts
@@ -22,8 +22,11 @@ import { z } from 'zod';
 import {
   createPlexServerEndpoint,
   deletePlexServerEndpoint,
+  getFffmpegSettings,
+  getHdhrSettings,
   getPlexBackendStatus,
   getPlexServersEndpoint,
+  getPlexStreamSettings,
   getXmlTvSettings,
   updatePlexServerEndpoint,
 } from './settingsApi.ts';
@@ -225,6 +228,9 @@ export const api = makeApi([
   deletePlexServerEndpoint,
   getPlexBackendStatus,
   getXmlTvSettings,
+  getHdhrSettings,
+  getPlexStreamSettings,
+  getFffmpegSettings,
 ]);
 
 export const createApiClient = once((uri: string) => {

--- a/web2/src/external/settingsApi.ts
+++ b/web2/src/external/settingsApi.ts
@@ -2,7 +2,10 @@ import {
   InsertPlexServerRequestSchema,
   UpdatePlexServerRequestSchema,
 } from '@tunarr/types/api';
-import { PlexServerSettingsSchema } from '@tunarr/types/schemas';
+import {
+  PlexServerSettingsSchema,
+  XmlTvSettingsSchema,
+} from '@tunarr/types/schemas';
 import { makeEndpoint, parametersBuilder } from '@zodios/core';
 import { z } from 'zod';
 
@@ -63,4 +66,11 @@ export const getPlexBackendStatus = makeEndpoint({
     // TODO Change this, this is very stupid
     status: z.union([z.literal(1), z.literal(-1)]),
   }),
+});
+
+export const getXmlTvSettings = makeEndpoint({
+  method: 'get',
+  path: '/api/xmltv-settings',
+  response: XmlTvSettingsSchema,
+  alias: 'getXmlTvSettings',
 });

--- a/web2/src/external/settingsApi.ts
+++ b/web2/src/external/settingsApi.ts
@@ -3,7 +3,10 @@ import {
   UpdatePlexServerRequestSchema,
 } from '@tunarr/types/api';
 import {
+  FfmpegSettingsSchema,
+  HdhrSettingsSchema,
   PlexServerSettingsSchema,
+  PlexStreamSettingsSchema,
   XmlTvSettingsSchema,
 } from '@tunarr/types/schemas';
 import { makeEndpoint, parametersBuilder } from '@zodios/core';
@@ -73,4 +76,25 @@ export const getXmlTvSettings = makeEndpoint({
   path: '/api/xmltv-settings',
   response: XmlTvSettingsSchema,
   alias: 'getXmlTvSettings',
+});
+
+export const getFffmpegSettings = makeEndpoint({
+  method: 'get',
+  path: '/api/ffmpeg-settings',
+  response: FfmpegSettingsSchema,
+  alias: 'getFfmpegSettings',
+});
+
+export const getHdhrSettings = makeEndpoint({
+  method: 'get',
+  path: '/api/hdhr-settings',
+  response: HdhrSettingsSchema,
+  alias: 'getHdhrSettings',
+});
+
+export const getPlexStreamSettings = makeEndpoint({
+  method: 'get',
+  path: '/api/plex-settings',
+  response: PlexStreamSettingsSchema,
+  alias: 'getPlexStreamSettings',
 });

--- a/web2/src/hooks/plexHooks.ts
+++ b/web2/src/hooks/plexHooks.ts
@@ -18,7 +18,7 @@ type PlexPathMappings = {
   '/library/sections': PlexLibrarySections;
 };
 
-const fetchPlexPath = <T>(serverName: string, path: string) => {
+export const fetchPlexPath = <T>(serverName: string, path: string) => {
   return async () => {
     return apiClient
       .getPlexPath({
@@ -51,16 +51,21 @@ type PlexQueryArgs<T> = {
   [plexQueryArgsSymbol]?: T;
 };
 
+export const plexQueryOptions = <T>(
+  serverName: string,
+  path: string,
+  enabled: boolean = true,
+) => ({
+  queryKey: ['plex', serverName, path],
+  queryFn: fetchPlexPath<T>(serverName, path),
+  enabled,
+});
+
 export const usePlexTyped = <T>(
   serverName: string,
   path: string,
   enabled: boolean = true,
-) =>
-  useQuery({
-    queryKey: ['plex', serverName, path],
-    queryFn: fetchPlexPath<T>(serverName, path),
-    enabled,
-  });
+) => useQuery(plexQueryOptions<T>(serverName, path, enabled));
 
 export const usePlexTyped2 = <T = unknown, U = unknown>(
   args: [PlexQueryArgs<T>, PlexQueryArgs<U>],

--- a/web2/src/hooks/settingsHooks.ts
+++ b/web2/src/hooks/settingsHooks.ts
@@ -1,47 +1,41 @@
-import { UseQueryOptions, useQueries, useQuery } from '@tanstack/react-query';
-import {
-  FfmpegSettings,
-  HdhrSettings,
-  PlexServerSettings,
-  PlexStreamSettings,
-  XmlTvSettings,
-} from '@tunarr/types';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { apiClient } from '../external/api.ts';
-import {
-  ApiAliases,
-  RequestMethodForAlias,
-  ZodiosAliasReturnType,
-} from '../types/index.ts';
 
-// function getQuerySettings<Path extends ApiAliases>(
-//   settings: string,
-//   method: Path,
-//   params: Parameters<RequestMethodForAlias<Path>>,
-// ): UseQueryOptions<ZodiosAliasReturnType<Path>> {
-//   return {
-//     queryKey: ['settings', settings],
-//     queryFn: () => {
-//       return apiClient[method](params);
-//     },
-//   };
-// }
-
-export const useXmlTvSettings = () => useQuery({});
+export const useXmlTvSettings = () =>
+  useQuery({
+    queryKey: ['settings', 'xmltv'],
+    queryFn: () => apiClient.getXmlTvSettings(),
+  });
 
 export const useFfmpegSettings = () =>
-  useSettings<FfmpegSettings>('ffmpeg', 'ffmpeg-settings');
+  useQuery({
+    queryKey: ['settings', 'ffmpeg'],
+    queryFn: () => apiClient.getFfmpegSettings(),
+  });
 
 export const usePlexServerSettings = () =>
-  useSettings<PlexServerSettings[]>('plex-servers', 'plex-servers');
+  useQuery({
+    queryKey: ['settings', 'plex-servers'],
+    queryFn: () => apiClient.getPlexServers(),
+  });
 
 export const usePlexStreamSettings = () =>
-  useSettings<PlexStreamSettings>('plex', 'plex-settings');
+  useQuery({
+    queryKey: ['settings', 'plex-stream'],
+    queryFn: () => apiClient.getPlexStreamSettings(),
+  });
 
 export const usePlexSettings = () =>
   useQueries({
     queries: [
-      getQuerySettings<PlexServerSettings[]>('plex-servers', 'plex-servers'),
-      getQuerySettings<PlexStreamSettings>('plex', 'plex-settings'),
+      {
+        queryKey: ['settings', 'plex-servers'],
+        queryFn: () => apiClient.getPlexServers(),
+      },
+      {
+        queryKey: ['settings', 'plex-stream'],
+        queryFn: () => apiClient.getPlexStreamSettings(),
+      },
     ],
     combine: (result) => {
       const [serversResult, streamResult] = result;
@@ -64,4 +58,7 @@ export const usePlexSettings = () =>
   });
 
 export const useHdhrSettings = () =>
-  useSettings<HdhrSettings>('hdhr', 'hdhr-settings');
+  useQuery({
+    queryKey: ['settings', 'hdhr'],
+    queryFn: () => apiClient.getHdhrSettings(),
+  });

--- a/web2/src/hooks/settingsHooks.ts
+++ b/web2/src/hooks/settingsHooks.ts
@@ -1,25 +1,32 @@
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { UseQueryOptions, useQueries, useQuery } from '@tanstack/react-query';
 import {
   FfmpegSettings,
+  HdhrSettings,
   PlexServerSettings,
   PlexStreamSettings,
   XmlTvSettings,
-  HdhrSettings,
 } from '@tunarr/types';
+import { apiClient } from '../external/api.ts';
+import {
+  ApiAliases,
+  RequestMethodForAlias,
+  ZodiosAliasReturnType,
+} from '../types/index.ts';
 
-const getQuerySettings = <T>(settings: string, path: string) => ({
-  queryKey: ['settings', settings],
-  queryFn: async () => {
-    const res = await fetch('http://localhost:8000/api/' + path);
-    return res.json() as Promise<T>;
-  },
-});
+// function getQuerySettings<Path extends ApiAliases>(
+//   settings: string,
+//   method: Path,
+//   params: Parameters<RequestMethodForAlias<Path>>,
+// ): UseQueryOptions<ZodiosAliasReturnType<Path>> {
+//   return {
+//     queryKey: ['settings', settings],
+//     queryFn: () => {
+//       return apiClient[method](params);
+//     },
+//   };
+// }
 
-const useSettings = <T>(settings: string, path: string) =>
-  useQuery(getQuerySettings<T>(settings, path));
-
-export const useXmlTvSettings = () =>
-  useSettings<XmlTvSettings>('xmltv', 'xmltv-settings');
+export const useXmlTvSettings = () => useQuery({});
 
 export const useFfmpegSettings = () =>
   useSettings<FfmpegSettings>('ffmpeg', 'ffmpeg-settings');

--- a/web2/src/hooks/useRouteName.ts
+++ b/web2/src/hooks/useRouteName.ts
@@ -1,0 +1,26 @@
+import { memoize, find } from 'lodash-es';
+
+type Route = { matcher: RegExp; name: string };
+
+const namedRoutes: Route[] = [
+  {
+    matcher: /^\/channels$/g,
+    name: 'Channels',
+  },
+  {
+    matcher:
+      /^\/channels\/[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g,
+    name: 'Channel Edit',
+  },
+];
+
+const getRouteName = memoize((path: string) => {
+  console.log(path);
+  return find(namedRoutes, ({ matcher }) => {
+    return matcher.test(path);
+  })?.name;
+});
+
+export const useGetRouteName = () => {
+  return (path: string) => getRouteName(path);
+};

--- a/web2/src/pages/channels/ProgrammingSelectorPage.tsx
+++ b/web2/src/pages/channels/ProgrammingSelectorPage.tsx
@@ -1,10 +1,34 @@
+import { Breadcrumbs, Link, Typography } from '@mui/material';
+import { isEmpty, map, reject } from 'lodash-es';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import ProgrammingSelector from '../../components/channel_config/ProgrammingSelector.tsx';
+import { useGetRouteName } from '../../hooks/useRouteName.ts';
 
 export default function ProgrammingSelectorPage() {
+  const location = useLocation();
+  const pathnames = reject(location.pathname.split('/'), isEmpty);
+  const getRouteName = useGetRouteName();
   return (
-    <PaddedPaper>
-      <ProgrammingSelector />
-    </PaddedPaper>
+    <>
+      <Breadcrumbs sx={{ mb: 2 }} separator="›" aria-label="channel-breadcrumb">
+        {map(pathnames, (_, index) => {
+          const isLast = index === pathnames.length - 1;
+          const to = `/${pathnames.slice(0, index + 1).join('/')}`;
+          return isLast ? (
+            <Typography color="text.primary" key={to}>
+              {getRouteName(to) ?? 'null'}
+            </Typography>
+          ) : (
+            <Link component={RouterLink} to={to} key={to}>
+              {getRouteName(to) ?? 'null'}
+            </Link>
+          );
+        })}
+      </Breadcrumbs>
+      <PaddedPaper>
+        <ProgrammingSelector />
+      </PaddedPaper>
+    </>
   );
 }

--- a/web2/src/pages/channels/ProgrammingSelectorPage.tsx
+++ b/web2/src/pages/channels/ProgrammingSelectorPage.tsx
@@ -1,0 +1,10 @@
+import PaddedPaper from '../../components/base/PaddedPaper.tsx';
+import ProgrammingSelector from '../../components/channel_config/ProgrammingSelector.tsx';
+
+export default function ProgrammingSelectorPage() {
+  return (
+    <PaddedPaper>
+      <ProgrammingSelector />
+    </PaddedPaper>
+  );
+}

--- a/web2/src/router.tsx
+++ b/web2/src/router.tsx
@@ -4,6 +4,7 @@ import { Root } from './App.tsx';
 import ChannelProgrammingPage from './pages/channels/ChannelProgrammingPage.tsx';
 import ChannelsPage from './pages/channels/ChannelsPage.tsx';
 import EditChannelPage from './pages/channels/EditChannelPage.tsx';
+import ProgrammingSelectorPage from './pages/channels/ProgrammingSelectorPage.tsx';
 import TimeSlotEditorPage from './pages/channels/TimeSlotEditorPage.tsx';
 import {
   customShowsLoader,
@@ -28,9 +29,8 @@ import SettingsLayout from './pages/settings/SettingsLayout.tsx';
 import TaskSettingsPage from './pages/settings/TaskSettingsPage.tsx';
 import XmlTvSettingsPage from './pages/settings/XmlTvSettingsPage.tsx';
 import WatchPage from './pages/watch/WatchPage.tsx';
-import { queryCache } from './queryClient.ts';
 import WelcomePage from './pages/welcome/WelcomePage.tsx';
-import ProgrammingSelectorPage from './pages/channels/ProgrammingSelectorPage.tsx';
+import { queryCache } from './queryClient.ts';
 
 const queryClient = new QueryClient({ queryCache });
 

--- a/web2/src/router.tsx
+++ b/web2/src/router.tsx
@@ -30,6 +30,7 @@ import XmlTvSettingsPage from './pages/settings/XmlTvSettingsPage.tsx';
 import WatchPage from './pages/watch/WatchPage.tsx';
 import { queryCache } from './queryClient.ts';
 import WelcomePage from './pages/welcome/WelcomePage.tsx';
+import ProgrammingSelectorPage from './pages/channels/ProgrammingSelectorPage.tsx';
 
 const queryClient = new QueryClient({ queryCache });
 
@@ -67,6 +68,10 @@ export const router = createBrowserRouter([
         path: '/channels/:id/programming',
         element: <ChannelProgrammingPage />,
         loader: editProgrammingLoader(queryClient),
+      },
+      {
+        path: '/channels/:id/programming/add',
+        element: <ProgrammingSelectorPage />,
       },
       {
         path: '/channels/:id/programming/time-slot-editor',

--- a/web2/src/store/programmingSelector/actions.ts
+++ b/web2/src/store/programmingSelector/actions.ts
@@ -16,6 +16,11 @@ export const setProgrammingListingServer = (
     state.currentServer = server;
   });
 
+export const setProgrammingListLibrary = (key: string) =>
+  useStore.setState((state) => {
+    state.currentLibrary = key;
+  });
+
 function uniqueId(item: PlexLibrarySection | PlexMedia): string {
   if (isPlexDirectory(item)) {
     return item.uuid;

--- a/web2/src/store/programmingSelector/actions.ts
+++ b/web2/src/store/programmingSelector/actions.ts
@@ -16,9 +16,9 @@ export const setProgrammingListingServer = (
     state.currentServer = server;
   });
 
-export const setProgrammingListLibrary = (key: string) =>
+export const setProgrammingListLibrary = (library: PlexLibrarySection) =>
   useStore.setState((state) => {
-    state.currentLibrary = key;
+    state.currentLibrary = library;
   });
 
 function uniqueId(item: PlexLibrarySection | PlexMedia): string {
@@ -96,6 +96,15 @@ export const addSelectedMedia = (
           guid: isPlexDirectory(m) ? m.uuid : m.guid,
         }) as SelectedMedia,
     );
+    state.selectedMedia = [...state.selectedMedia, ...newSelectedMedia];
+  });
+
+export const addSelectedMediaById = (serverName: string, ids: string[]) =>
+  useStore.setState((state) => {
+    const newSelectedMedia: SelectedMedia[] = map(ids, (m) => ({
+      server: serverName,
+      guid: m,
+    }));
     state.selectedMedia = [...state.selectedMedia, ...newSelectedMedia];
   });
 

--- a/web2/src/store/programmingSelector/store.ts
+++ b/web2/src/store/programmingSelector/store.ts
@@ -12,6 +12,7 @@ export interface SelectedMedia {
 
 export interface ProgrammingListingsState {
   currentServer?: PlexServerSettings;
+  currentLibrary?: string; // This is the key
   // Tracks the parent-child mappings of library items
   contentHierarchyByServer: Record<
     ServerName,

--- a/web2/src/store/programmingSelector/store.ts
+++ b/web2/src/store/programmingSelector/store.ts
@@ -12,7 +12,7 @@ export interface SelectedMedia {
 
 export interface ProgrammingListingsState {
   currentServer?: PlexServerSettings;
-  currentLibrary?: string; // This is the key
+  currentLibrary?: PlexLibrarySection;
   // Tracks the parent-child mappings of library items
   contentHierarchyByServer: Record<
     ServerName,


### PR DESCRIPTION
Large changes here:
* Move add programming from a dialog to its own page
* Rough impl of what dynamic breadcrumps might look like
* New search bar for quickly filtering down media options
* Removal of one level of collapsing lists - library selection is now in
  a dropdown

Some TODOs:
* Figure out how to present collections again
* Introduce more search/filter parameters against Plex - they
  have very powerful search capabilities
* Bring back the 'Add All' button at the library level for those who
  want to quickly add all of their programs to a channel (idk who does
this but we should support it)
* Of course, this whole thing needs to be styled!
* And I'm sure there are edge cases I've missed here.

I did test adding media on the page, then adding it to the working
programming for the current channel. I _think_ that should imply that
saving the new programs will work, but I did not test this.