### PR TITLE
Replace native browser datetime picker with Material X date picker.

### DIFF
--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -32,7 +32,7 @@ export function ChannelProgrammingConfig() {
 
   const handleStartTimeChange = (value: Dayjs | null) => {
     if (value) {
-      setChannelStartTime(dayjs(value).unix() * 1000);
+      setChannelStartTime(value.unix() * 1000);
     }
   };
 

--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -1,14 +1,6 @@
-import {
-  Box,
-  Button,
-  FormControl,
-  Input,
-  InputLabel,
-  Paper,
-  Stack,
-  Typography,
-} from '@mui/material';
-import dayjs from 'dayjs';
+import { Box, Button, Paper, Stack, Typography } from '@mui/material';
+import { DateTimePicker } from '@mui/x-date-pickers';
+import dayjs, { Dayjs } from 'dayjs';
 import { createContext, useState } from 'react';
 import {
   resetLineup,
@@ -38,8 +30,10 @@ export function ChannelProgrammingConfig() {
 
   const programsDirty = useStore((s) => s.channelEditor.dirty.programs);
 
-  const handleStartTimeChange = (value: string) => {
-    setChannelStartTime(dayjs(value).unix() * 1000);
+  const handleStartTimeChange = (value: Dayjs | null) => {
+    if (value) {
+      setChannelStartTime(dayjs(value).unix() * 1000);
+    }
   };
 
   const startTime = channel ? dayjs(channel.startTime) : dayjs();
@@ -58,22 +52,13 @@ export function ChannelProgrammingConfig() {
       <Box display="flex" flexDirection="column">
         <Paper sx={{ p: 2 }}>
           <Box display="flex" justifyContent={'flex-start'}>
-            <FormControl margin="normal" sx={{ flex: 1, mr: 2, maxWidth: 350 }}>
-              <InputLabel>Programming Start</InputLabel>
-              <Input
-                type="datetime-local"
-                value={startTime.format('YYYY-MM-DDTHH:mm')}
-                onChange={(e) => handleStartTimeChange(e.target.value)}
-              />
-            </FormControl>
-            <FormControl margin="normal" sx={{ flex: 1, maxWidth: 350 }}>
-              <InputLabel>Programming End</InputLabel>
-              <Input
-                disabled
-                type="datetime-local"
-                value={endTime.format('YYYY-MM-DDTHH:mm')}
-              />
-            </FormControl>
+            <DateTimePicker
+              label="Programming Start"
+              value={startTime}
+              onChange={(newDateTime) => handleStartTimeChange(newDateTime)}
+              sx={{ mr: 2 }}
+            />
+            <DateTimePicker label="Programming End" value={endTime} disabled />
             <Stack
               direction={{ xs: 'column', sm: 'row' }}
               sx={{

--- a/web/src/pages/welcome/WelcomePage.tsx
+++ b/web/src/pages/welcome/WelcomePage.tsx
@@ -2,7 +2,6 @@ import { ArrowBack, CheckBox, CheckBoxOutlineBlank } from '@mui/icons-material';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import dayjs from 'dayjs';
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import ConnectPlex from '../../components/settings/ConnectPlex.tsx';
 import { usePlexServerSettings } from '../../hooks/settingsHooks.ts';
@@ -10,10 +9,7 @@ import { useChannels } from '../../hooks/useChannels.ts';
 import { useAllTvGuides } from '../../hooks/useTvGuide.ts';
 import { useVersion } from '../../hooks/useVersion.ts';
 import useStore from '../../store/index.ts';
-import {
-  resetPathwayState,
-  updatePathwayState,
-} from '../../store/themeEditor/actions.ts';
+import { resetPathwayState } from '../../store/themeEditor/actions.ts';
 
 export default function WelcomePage() {
   const [isPlexConnected, setIsPlexConnected] = React.useState<boolean>(false);
@@ -32,7 +28,7 @@ export default function WelcomePage() {
     from: startDate,
     to: endDate,
   });
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   const pathway = useStore((state) => state.theme.pathway);
 
   useEffect(() => {
@@ -53,13 +49,13 @@ export default function WelcomePage() {
     }
   }, [plexServers, channels, programming]);
 
-  const handlePathway = (pathway: string) => {
-    updatePathwayState(pathway);
+  // const handlePathway = (pathway: string) => {
+  //   updatePathwayState(pathway);
 
-    if (pathway === 'advanced') {
-      navigate('/guide');
-    }
-  };
+  //   if (pathway === 'advanced') {
+  //     navigate('/guide');
+  //   }
+  // };
 
   const header = (
     <>

--- a/web/src/pages/welcome/WelcomePage.tsx
+++ b/web/src/pages/welcome/WelcomePage.tsx
@@ -1,19 +1,5 @@
-import {
-  ArrowBack,
-  CheckBox,
-  CheckBoxOutlineBlank,
-  Elderly,
-  FiberNew,
-  MilitaryTech,
-} from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Stack,
-  Typography,
-} from '@mui/material';
+import { ArrowBack, CheckBox, CheckBoxOutlineBlank } from '@mui/icons-material';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import dayjs from 'dayjs';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -90,78 +76,78 @@ export default function WelcomePage() {
     </>
   );
 
-  const chooseYourPathway = (
-    <>
-      <Typography variant="body1" sx={{ mb: 4 }}>
-        Get started in a way that works for you...
-      </Typography>
-      <Box
-        display={'flex'}
-        flexDirection={{ xs: 'column', md: 'row' }}
-        justifyContent={'center'}
-        columnGap={4}
-        rowGap={4}
-      >
-        <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
-          <CardContent>
-            <FiberNew fontSize="large" />
-            <Typography variant="h5" component="div">
-              I'm new here.
-            </Typography>
-            <Typography variant="body2">
-              I've never used dizquetv and this is my first time setting up
-              Tunarr.
-            </Typography>
-            <Button
-              variant="contained"
-              sx={{ my: 2 }}
-              onClick={() => handlePathway('get-started')}
-            >
-              Get Started
-            </Button>
-          </CardContent>
-        </Card>
-        <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
-          <CardContent>
-            <Elderly fontSize="large" />
-            <Typography variant="h5" component="div">
-              I've used dizqueTV
-            </Typography>
-            <Typography variant="body2">
-              This isn't my first rodeo. I have an existing dizqueTV database
-              that I want to migrate into Tunarr.
-            </Typography>
-            <Button
-              variant="contained"
-              sx={{ my: 2 }}
-              onClick={() => handlePathway('migration')}
-            >
-              Get Instructions
-            </Button>
-          </CardContent>
-        </Card>
-        <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
-          <CardContent>
-            <MilitaryTech fontSize="large" />
-            <Typography variant="h5" component="div">
-              Advanced
-            </Typography>
-            <Typography variant="body2">
-              I know what I am doing and don't need any instructions. Please
-              leave me alone.
-            </Typography>
-            <Button
-              variant="contained"
-              sx={{ my: 2 }}
-              onClick={() => handlePathway('advanced')}
-            >
-              Hide this page
-            </Button>
-          </CardContent>
-        </Card>
-      </Box>
-    </>
-  );
+  // const chooseYourPathway = (
+  //   <>
+  //     <Typography variant="body1" sx={{ mb: 4 }}>
+  //       Get started in a way that works for you...
+  //     </Typography>
+  //     <Box
+  //       display={'flex'}
+  //       flexDirection={{ xs: 'column', md: 'row' }}
+  //       justifyContent={'center'}
+  //       columnGap={4}
+  //       rowGap={4}
+  //     >
+  //       <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
+  //         <CardContent>
+  //           <FiberNew fontSize="large" />
+  //           <Typography variant="h5" component="div">
+  //             I'm new here.
+  //           </Typography>
+  //           <Typography variant="body2">
+  //             I've never used dizquetv and this is my first time setting up
+  //             Tunarr.
+  //           </Typography>
+  //           <Button
+  //             variant="contained"
+  //             sx={{ my: 2 }}
+  //             onClick={() => handlePathway('get-started')}
+  //           >
+  //             Get Started
+  //           </Button>
+  //         </CardContent>
+  //       </Card>
+  //       <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
+  //         <CardContent>
+  //           <Elderly fontSize="large" />
+  //           <Typography variant="h5" component="div">
+  //             I've used dizqueTV
+  //           </Typography>
+  //           <Typography variant="body2">
+  //             This isn't my first rodeo. I have an existing dizqueTV database
+  //             that I want to migrate into Tunarr.
+  //           </Typography>
+  //           <Button
+  //             variant="contained"
+  //             sx={{ my: 2 }}
+  //             onClick={() => handlePathway('migration')}
+  //           >
+  //             Get Instructions
+  //           </Button>
+  //         </CardContent>
+  //       </Card>
+  //       <Card sx={{ minWidth: 275, pb: 1, pr: 1, maxWidth: 400 }}>
+  //         <CardContent>
+  //           <MilitaryTech fontSize="large" />
+  //           <Typography variant="h5" component="div">
+  //             Advanced
+  //           </Typography>
+  //           <Typography variant="body2">
+  //             I know what I am doing and don't need any instructions. Please
+  //             leave me alone.
+  //           </Typography>
+  //           <Button
+  //             variant="contained"
+  //             sx={{ my: 2 }}
+  //             onClick={() => handlePathway('advanced')}
+  //           >
+  //             Hide this page
+  //           </Button>
+  //         </CardContent>
+  //       </Card>
+  //     </Box>
+  //   </>
+  // );
 
   const getStarted = (
     <>
@@ -199,23 +185,23 @@ export default function WelcomePage() {
   );
 
   // to do: write proper migration instructions or just write new ones in wiki and link to it
-  const migration = (
-    <Box textAlign={'left'} margin={'0 auto'}>
-      <Typography variant="body1">
-        We've made migrating from dizqueTV easy...
-      </Typography>
-      <Typography>1.) Stop your existing dizqueTV</Typography>
-      <Typography>2.) Take a backup of your .dizquetv folder.</Typography>
-      <Typography>
-        3.) Within your new Tunarr install, replace your .dizquetv folder with
-        the one you just backed up.
-      </Typography>
-      <Typography>
-        3.) Startup Tunarr, it might need a couple of minutes to migrate the
-        databases. It's a good idea to pay attention to the logs during this.
-      </Typography>
-    </Box>
-  );
+  // const migration = (
+  //   <Box textAlign={'left'} margin={'0 auto'}>
+  //     <Typography variant="body1">
+  //       We've made migrating from dizqueTV easy...
+  //     </Typography>
+  //     <Typography>1.) Stop your existing dizqueTV</Typography>
+  //     <Typography>2.) Take a backup of your .dizquetv folder.</Typography>
+  //     <Typography>
+  //       3.) Within your new Tunarr install, replace your .dizquetv folder with
+  //       the one you just backed up.
+  //     </Typography>
+  //     <Typography>
+  //       3.) Startup Tunarr, it might need a couple of minutes to migrate the
+  //       databases. It's a good idea to pay attention to the logs during this.
+  //     </Typography>
+  //   </Box>
+  // );
 
   return (
     <>


### PR DESCRIPTION
- Replace native browser datetime picker with material x date picker.  Unfortunately native picker offers no styling so it does not support dark mode or custom theming.  New component supports this out of the box.
Fixes: https://github.com/chrisbenincasa/tunarr/issues/152

<img width="668" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/7dbe6534-fb61-41bd-9110-b7f0068bef6a">
