### PR TITLE
Support for custom shows in channels - Part 2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      ts-essentials:
+        specifier: ^9.4.1
+        version: 9.4.1(typescript@5.2.2)
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(typescript@5.2.2)
@@ -8650,6 +8653,17 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
+    dev: true
+
+  /ts-essentials@9.4.1(typescript@5.2.2):
+    resolution: {integrity: sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==}
+    peerDependencies:
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.2.2
     dev: true
 
   /ts-essentials@9.4.1(typescript@5.3.3):

--- a/server/src/api/v2/customShowsApiV2.ts
+++ b/server/src/api/v2/customShowsApiV2.ts
@@ -2,10 +2,7 @@ import {
   CreateCustomShowRequestSchema,
   IdPathParamSchema,
 } from '@tunarr/types/api';
-import {
-  CustomShowProgrammingSchema,
-  CustomShowSchema,
-} from '@tunarr/types/schemas';
+import { CustomProgramSchema, CustomShowSchema } from '@tunarr/types/schemas';
 import { isNull, map } from 'lodash-es';
 import { z } from 'zod';
 import { CustomShow } from '../../dao/entities/CustomShow.js';
@@ -78,7 +75,7 @@ export const customShowsApiV2: RouterPluginAsyncCallback = async (fastify) => {
       schema: {
         params: IdPathParamSchema,
         response: {
-          200: CustomShowProgrammingSchema,
+          200: z.array(CustomProgramSchema),
           404: z.void(),
         },
       },

--- a/server/src/dao/converters/programConverters.ts
+++ b/server/src/dao/converters/programConverters.ts
@@ -13,7 +13,7 @@ export function dbProgramToContentProgram(
     rating: program.rating,
     icon: program.showIcon ?? program.episodeIcon ?? program.icon,
     title: program.showTitle ?? program.title,
-    duration: program?.duration,
+    duration: program.duration,
     type: 'content',
     id: program.uuid,
     subtype: program.type,

--- a/server/src/dao/customShowDb.ts
+++ b/server/src/dao/customShowDb.ts
@@ -1,3 +1,4 @@
+import { CustomProgram } from '@tunarr/types';
 import { CreateCustomShowRequest } from '@tunarr/types/api';
 import { filter, isUndefined, map } from 'lodash-es';
 import { MarkOptional } from 'ts-essentials';
@@ -25,7 +26,7 @@ export class CustomShowDB {
       .findOne({ uuid: id }, { populate: ['content.uuid'] });
   }
 
-  async getShowPrograms(id: string) {
+  async getShowPrograms(id: string): Promise<CustomProgram[]> {
     const customShowContent = await getEm()
       .repo(CustomShowContent)
       .find(
@@ -33,9 +34,15 @@ export class CustomShowDB {
         { populate: ['content.*'], orderBy: { index: 'desc' } },
       );
 
-    return customShowContent.map((csc) => {
-      return dbProgramToContentProgram(csc.content, true);
-    });
+    return customShowContent.map((csc) => ({
+      type: 'custom',
+      persisted: true,
+      duration: csc.content.duration,
+      program: dbProgramToContentProgram(csc.content, true),
+      customShowId: id,
+      index: csc.index,
+      id: csc.content.uuid,
+    }));
   }
 
   async saveShow(id: Maybe<string>, customShow: CustomShowUpdate) {

--- a/server/src/dao/derived_types/Lineup.ts
+++ b/server/src/dao/derived_types/Lineup.ts
@@ -1,6 +1,6 @@
 import { Program as ProgramDTO } from '@tunarr/types';
-import { Program } from '../entities/Program.js';
 import { LineupSchedule } from '@tunarr/types/api';
+import { Program } from '../entities/Program.js';
 
 export type Lineup = {
   items: LineupItem[];
@@ -24,6 +24,11 @@ type BaseLineupItem = {
 export type ContentItem = BaseLineupItem & {
   type: 'content';
   id: string;
+  // If this lineup item was a part of a custom show
+  // this is a pointer to that show.
+  // TODO: If a custom show is deleted, we have to remove
+  // references to these content items in the lineup
+  customShowId?: string;
 };
 
 export type OfflineItem = BaseLineupItem & {

--- a/server/src/types/path.ts
+++ b/server/src/types/path.ts
@@ -1,0 +1,73 @@
+import { property } from 'lodash-es';
+
+// These are ripped from react-hook-form and slightly altered to work in a Node env - thanks!!!
+export type IsEqual<T1, T2> = T1 extends T2
+  ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2
+    ? true
+    : false
+  : false;
+
+type ArrayKey = number;
+
+type IsTuple<T extends ReadonlyArray<unknown>> = number extends T['length']
+  ? false
+  : true;
+
+type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TupleKeys<T extends ReadonlyArray<any>> = Exclude<keyof T, keyof any[]>;
+
+type AnyIsEqual<T1, T2> = T1 extends T2
+  ? IsEqual<T1, T2> extends true
+    ? true
+    : never
+  : never;
+
+type PathImpl<
+  K extends string | number,
+  V,
+  TraversedTypes,
+> = V extends Primitive
+  ? `${K}`
+  : true extends AnyIsEqual<TraversedTypes, V>
+  ? `${K}`
+  : `${K}` | `${K}.${PathInternal<V, TraversedTypes | V>}`;
+
+type PathInternal<T, TraversedTypes = T> = T extends ReadonlyArray<infer V>
+  ? IsTuple<T> extends true
+    ? {
+        [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
+      }[TupleKeys<T>]
+    : PathImpl<ArrayKey, V, TraversedTypes>
+  : {
+      [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
+    }[keyof T];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Path<T> = T extends any ? PathInternal<T> : never;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PathValue<T, P extends Path<T>> = T extends any
+  ? P extends `${infer K}.${infer R}`
+    ? K extends keyof T
+      ? R extends Path<T[K]>
+        ? PathValue<T[K], R>
+        : never
+      : K extends `${ArrayKey}`
+      ? T extends ReadonlyArray<infer V>
+        ? PathValue<V, R & Path<V>>
+        : never
+      : never
+    : P extends keyof T
+    ? T[P]
+    : P extends `${ArrayKey}`
+    ? T extends ReadonlyArray<infer V>
+      ? V
+      : never
+    : never
+  : never;
+
+export function typedProperty<T, TPath extends Path<T> = Path<T>>(path: TPath) {
+  return property<T, PathValue<T, TPath>>(path);
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,6 +14,13 @@
     "./constants": {
       "types": "./build/util/constants.d.ts",
       "default": "./build/util/constants.js"
+    },
+    "./util": {
+      "types": "./build/util/index.d.ts",
+      "default": "./build/util/index.js"
+    },
+    "./types": {
+      "types": "./build/types/index.d.ts"
     }
   },
   "main": "index.ts",
@@ -34,6 +41,7 @@
     "@types/node": "18.18.0",
     "rimraf": "^5.0.5",
     "tsup": "^8.0.2",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "ts-essentials": "^9.4.1"
   }
 }

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -1,0 +1,15 @@
+export type GenSubtypeMapping<T extends { type: string }> = {
+  [X in T['type']]: Extract<T, { type: X }>;
+};
+
+export type GenGroupedSubtypeMapping<T extends { type: string }> = {
+  [X in T['type']]: Extract<T, { type: X }>[];
+};
+
+export type PerTypeCallback<Union extends { type: string }, CallbackRet> = {
+  [X in Union['type']]?:
+    | ((m: GenSubtypeMapping<Union>[X]) => CallbackRet)
+    | CallbackRet;
+} & {
+  default?: ((m: Union) => CallbackRet) | CallbackRet;
+};

--- a/shared/src/util/dayjsExtensions.ts
+++ b/shared/src/util/dayjsExtensions.ts
@@ -1,5 +1,5 @@
 import inst, { Dayjs, ManipulateType, PluginFunc } from 'dayjs';
-import duration, { Duration } from 'dayjs/plugin/duration.js';
+import duration, { type Duration } from 'dayjs/plugin/duration.js';
 
 declare module 'dayjs' {
   interface Dayjs {

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -1,0 +1,53 @@
+import { ChannelProgram } from '@tunarr/types';
+import isFunction from 'lodash-es/isFunction.js';
+import { MarkRequired } from 'ts-essentials';
+import type { PerTypeCallback } from '../types/index.js';
+
+export const applyOrValue = <Super, X extends Super, T>(
+  f: ((m: X) => T) | T,
+  arg: X,
+) => (isFunction(f) ? f(arg) : f);
+
+export function forProgramType<T>(
+  choices:
+    | Omit<Required<PerTypeCallback<ChannelProgram, T>>, 'default'>
+    | MarkRequired<PerTypeCallback<ChannelProgram, T>, 'default'>,
+): (m: ChannelProgram) => NonNullable<T>;
+export function forProgramType<T>(
+  choices: PerTypeCallback<ChannelProgram, T>,
+): (m: ChannelProgram) => T | null;
+export function forProgramType<T>(
+  choices: PerTypeCallback<ChannelProgram, T>,
+): (m: ChannelProgram) => T | null {
+  return (m: ChannelProgram) => {
+    switch (m.type) {
+      case 'content':
+        if (choices.content) {
+          return applyOrValue(choices.content, m);
+        }
+        break;
+      case 'custom':
+        if (choices.custom) {
+          return applyOrValue(choices.custom, m);
+        }
+        break;
+      case 'redirect':
+        if (choices.redirect) {
+          return applyOrValue(choices.redirect, m);
+        }
+        break;
+      case 'flex':
+        if (choices.flex) {
+          return applyOrValue(choices.flex, m);
+        }
+        break;
+    }
+
+    // If we made it this far try to do the default
+    if (choices.default) {
+      return applyOrValue(choices.default, m);
+    }
+
+    return null;
+  };
+}

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     'constants/index': 'src/util/constants.ts',
+    'util/index': 'src/util/index.ts',
+    'types/index': 'src/types/index.ts',
   },
   dts: true,
   splitting: false,

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "clean": {},
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["clean", "^build"],
       "outputs": ["build/**", "dist/**"]
     },
     "bundle": {
@@ -11,7 +11,7 @@
       "outputs": ["build/**", "dist/**"]
     },
     "dev": {
-      "dependsOn": ["clean", "@tunarr/shared#build", "@tunarr/types#build"],
+      "dependsOn": ["@tunarr/shared#build", "@tunarr/types#build"],
       "cache": false,
       "persistent": true
     }

--- a/types/src/schemas/customShowsSchema.ts
+++ b/types/src/schemas/customShowsSchema.ts
@@ -12,5 +12,5 @@ export const CustomShowSchema = z.object({
   id: z.string(),
   name: z.string(),
   contentCount: z.number(),
-  programs: CustomShowProgrammingSchema.optional(),
+  programs: z.array(CustomProgramSchema).optional(),
 });

--- a/types/src/schemas/programmingSchema.ts
+++ b/types/src/schemas/programmingSchema.ts
@@ -105,11 +105,6 @@ export const ContentProgramSchema = BaseProgramSchema.extend({
 
 export const CondensedContentProgramSchema = BaseProgramSchema.extend({
   type: z.literal('content'),
-  // subtype: z.union([
-  //   z.literal('movie'),
-  //   z.literal('episode'),
-  //   z.literal('track'),
-  // ]),
   id: z.string().optional(), // Populated if persisted
   // Only populated on client requests to the server
   originalProgram: z
@@ -119,13 +114,19 @@ export const CondensedContentProgramSchema = BaseProgramSchema.extend({
 
 export const CondensedCustomProgramSchema = BaseProgramSchema.extend({
   type: z.literal('custom'),
+  // The ID of the underlying program
   id: z.string(),
+  customShowId: z.string(),
+  index: z.number(),
   program: CondensedContentProgramSchema.optional(),
 });
 
 export const CustomProgramSchema = BaseProgramSchema.extend({
   type: z.literal('custom'),
+  // The ID of the underlying program
   id: z.string(),
+  customShowId: z.string(),
+  index: z.number(),
   program: ContentProgramSchema.optional(),
 });
 
@@ -149,7 +150,7 @@ export const ChannelProgrammingSchema = z.object({
 
 export const CondensedChannelProgramSchema = z.discriminatedUnion('type', [
   CondensedContentProgramSchema,
-  CustomProgramSchema,
+  CondensedCustomProgramSchema,
   RedirectProgramSchema,
   FlexProgramSchema,
 ]);

--- a/web/package.json
+++ b/web/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit",
+    "build-dev": "tsc --noEmit --watch",
     "bundle": "vite build",
-    "buildw": "nodemon -e ts,json,tsx,js,yaml --watch src --ignore dist/ -x tsc --noEmit --project tsconfig.build.json",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -108,7 +108,7 @@ const ProgramListItem = ({
 
   switch (program.type) {
     case 'custom':
-      title = 'custom...';
+      title = 'Custom Show';
       break;
     case 'redirect':
       title = 'redirect...';

--- a/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
+++ b/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
@@ -7,13 +7,14 @@ import {
   ListItem,
   ListItemText,
 } from '@mui/material';
-import { ContentProgram, isContentProgram } from '@tunarr/types';
+import { forProgramType } from '@tunarr/shared/util';
+import { CustomProgram, isCustomProgram } from '@tunarr/types';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import { chain, isEmpty, isNil, property } from 'lodash-es';
+import { chain, flow, isEmpty, isNil, negate } from 'lodash-es';
 import { MouseEvent, useCallback, useState } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
-import { forProgramType } from '../../helpers/util';
+import { typedProperty } from '../../helpers/util';
 import { useCustomShow } from '../../hooks/useCustomShows';
 import useStore from '../../store';
 import { addSelectedMedia } from '../../store/programmingSelector/actions';
@@ -38,6 +39,7 @@ export function CustomShowProgrammingSelector() {
   const formattedTitle = useCallback(
     forProgramType({
       content: (p) => p.title,
+      custom: (p) => p.program!.title,
     }),
     [],
   );
@@ -62,7 +64,7 @@ export function CustomShowProgrammingSelector() {
   });
 
   const handleItem = useCallback(
-    (e: MouseEvent<HTMLButtonElement>, item: ContentProgram) => {
+    (e: MouseEvent<HTMLButtonElement>, item: CustomProgram) => {
       e.stopPropagation();
       if (selectedCustomShow) {
         addSelectedMedia({
@@ -82,8 +84,9 @@ export function CustomShowProgrammingSelector() {
       programsResult.data.length > 0
     ) {
       return chain(programsResult.data)
-        .filter(isContentProgram)
-        .filter(property('persisted'))
+        .filter(isCustomProgram)
+        .filter(typedProperty('persisted'))
+        .filter(flow(typedProperty('program'), negate(isNil)))
         .map((program) => {
           let title = formattedTitle(program);
           let epTitle = formattedEpisodeTitle(program);

--- a/web/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web/src/components/channel_config/ProgrammingSelector.tsx
@@ -9,7 +9,7 @@ import {
 import { PlexMedia, isPlexDirectory } from '@tunarr/types/plex';
 import { find, isEmpty, isNil, isUndefined } from 'lodash-es';
 import React, { useCallback, useEffect, useState } from 'react';
-import { EnrichedPlexMedia, usePlex } from '../../hooks/plexHooks.ts';
+import { usePlex } from '../../hooks/plexHooks.ts';
 import { usePlexServerSettings } from '../../hooks/settingsHooks.ts';
 import { useCustomShows } from '../../hooks/useCustomShows.ts';
 import useStore from '../../store/index.ts';
@@ -18,6 +18,7 @@ import {
   setProgrammingListLibrary,
   setProgrammingListingServer,
 } from '../../store/programmingSelector/actions.ts';
+import { AddedMedia } from '../../types/index.ts';
 import { CustomShowProgrammingSelector } from './CustomShowProgrammingSelector.tsx';
 import PlexProgrammingSelector from './PlexProgrammingSelector.tsx';
 import SelectedProgrammingList from './SelectedProgrammingList.tsx';
@@ -31,7 +32,7 @@ export interface PlexListItemProps<T extends PlexMedia> {
 }
 
 type Props = {
-  onAddSelectedMedia: (items: EnrichedPlexMedia[]) => void;
+  onAddSelectedMedia: (items: AddedMedia[]) => void;
 };
 
 export default function ProgrammingSelector({ onAddSelectedMedia }: Props) {
@@ -119,7 +120,6 @@ export default function ProgrammingSelector({ onAddSelectedMedia }: Props) {
   const onLibraryChange = useCallback(
     (libraryUuid: string) => {
       if (mediaSource === 'custom-shows') {
-        console.log('hello', customShows);
         const library = find(customShows, { id: libraryUuid });
         if (library) {
           setProgrammingListLibrary({ type: 'custom-show', library });

--- a/web/src/components/channel_config/SelectedProgrammingList.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingList.tsx
@@ -11,26 +11,23 @@ import {
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
+import { forProgramType } from '@tunarr/shared/util';
 import { isPlexDirectory, isPlexSeason, isPlexShow } from '@tunarr/types/plex';
 import { chain, first, groupBy, mapValues } from 'lodash-es';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  forProgramType,
-  forSelectedMediaType,
-  unwrapNil,
-} from '../../helpers/util.ts';
-import { EnrichedPlexMedia } from '../../hooks/plexHooks.ts';
+import { forSelectedMediaType, unwrapNil } from '../../helpers/util.ts';
 import { useCustomShows } from '../../hooks/useCustomShows.ts';
 import useStore from '../../store/index.ts';
 import {
   clearSelectedMedia,
   removeSelectedMedia,
 } from '../../store/programmingSelector/actions.ts';
+import { AddedMedia } from '../../types/index.ts';
 import AddSelectedMediaButton from './AddSelectedMediaButton.tsx';
 
 type Props = {
-  onAddSelectedMedia: (media: EnrichedPlexMedia[]) => void;
+  onAddSelectedMedia: (media: AddedMedia[]) => void;
 };
 
 export default function SelectedProgrammingList({ onAddSelectedMedia }: Props) {

--- a/web/src/external/api.ts
+++ b/web/src/external/api.ts
@@ -10,7 +10,7 @@ import {
   ChannelLineupSchema,
   ChannelSchema,
   CondensedChannelProgrammingSchema,
-  CustomShowProgrammingSchema,
+  CustomProgramSchema,
   CustomShowSchema,
   FillerListProgrammingSchema,
   FillerListSchema,
@@ -163,7 +163,7 @@ export const api = makeApi([
     method: 'get',
     path: '/api/v2/custom-shows/:id/programs',
     alias: 'getCustomShowPrograms',
-    response: CustomShowProgrammingSchema,
+    response: z.array(CustomProgramSchema),
     parameters: parametersBuilder()
       .addPaths({
         id: z.string(),

--- a/web/src/pages/channels/ProgrammingSelectorPage.tsx
+++ b/web/src/pages/channels/ProgrammingSelectorPage.tsx
@@ -1,7 +1,7 @@
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
 import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import ProgrammingSelector from '../../components/channel_config/ProgrammingSelector.tsx';
-import { addPlexMediaToCurrentChannel } from '../../store/channelEditor/actions.ts';
+import { addMediaToCurrentChannel } from '../../store/channelEditor/actions.ts';
 
 export default function ProgrammingSelectorPage() {
   return (
@@ -9,9 +9,7 @@ export default function ProgrammingSelectorPage() {
       <Breadcrumbs />
       <PaddedPaper>
         {/* TODO: This shouldn't assume we are editing a channel. You can also add media to a custom show or filler show */}
-        <ProgrammingSelector
-          onAddSelectedMedia={addPlexMediaToCurrentChannel}
-        />
+        <ProgrammingSelector onAddSelectedMedia={addMediaToCurrentChannel} />
       </PaddedPaper>
     </>
   );

--- a/web/src/pages/library/EditCustomShowPage.tsx
+++ b/web/src/pages/library/EditCustomShowPage.tsx
@@ -30,7 +30,7 @@ import {
   newCustomShowLoader,
 } from '../../preloaders/customShowLoaders.ts';
 import {
-  addPlexMediaToCurrentCustomShow,
+  addMediaToCurrentCustomShow,
   removeCustomShowProgram,
 } from '../../store/channelEditor/actions.ts';
 import useStore from '../../store/index.ts';
@@ -200,7 +200,7 @@ export default function EditCustomShowPage({ isNew }: Props) {
         </AccordionSummary>
         <AccordionDetails>
           <ProgrammingSelector
-            onAddSelectedMedia={addPlexMediaToCurrentCustomShow}
+            onAddSelectedMedia={addMediaToCurrentCustomShow}
           />
           <Divider />
           <Box
@@ -212,7 +212,7 @@ export default function EditCustomShowPage({ isNew }: Props) {
             }}
           >
             <AddSelectedMediaButton
-              onAdd={addPlexMediaToCurrentCustomShow}
+              onAdd={addMediaToCurrentCustomShow}
               onSuccess={() => {}}
               variant="contained"
             />

--- a/web/src/pages/library/EditFillerPage.tsx
+++ b/web/src/pages/library/EditFillerPage.tsx
@@ -24,10 +24,9 @@ import PaddedPaper from '../../components/base/PaddedPaper.tsx';
 import AddSelectedMediaButton from '../../components/channel_config/AddSelectedMediaButton.tsx';
 import ProgrammingSelector from '../../components/channel_config/ProgrammingSelector.tsx';
 import { apiClient } from '../../external/api.ts';
-import { EnrichedPlexMedia } from '../../hooks/plexHooks.ts';
 import { useCurrentFillerList } from '../../hooks/useFillerLists.ts';
 import {
-  addPlexMediaToCurrentFillerList,
+  addMediaToCurrentFillerList,
   removeFillerListProgram,
 } from '../../store/channelEditor/actions.ts';
 import useStore from '../../store/index.ts';
@@ -106,10 +105,6 @@ export default function EditFillerPage({ isNew }: Props) {
   const deleteProgramAtIndex = useCallback((idx: number) => {
     removeFillerListProgram(idx);
   }, []);
-
-  const onAddPrograms = (programs: EnrichedPlexMedia[]) => {
-    addPlexMediaToCurrentFillerList(programs);
-  };
 
   useEffect(() => {
     setValue('programs', fillerListPrograms);
@@ -214,7 +209,7 @@ export default function EditFillerPage({ isNew }: Props) {
           </AccordionSummary>
           <AccordionDetails>
             <ProgrammingSelector
-              onAddSelectedMedia={addPlexMediaToCurrentFillerList}
+              onAddSelectedMedia={addMediaToCurrentFillerList}
             />
             <Divider />
             <Box
@@ -226,7 +221,7 @@ export default function EditFillerPage({ isNew }: Props) {
               }}
             >
               <AddSelectedMediaButton
-                onAdd={onAddPrograms}
+                onAdd={addMediaToCurrentFillerList}
                 onSuccess={() => {}}
                 variant="contained"
               />

--- a/web/src/preloaders/channelLoaders.ts
+++ b/web/src/preloaders/channelLoaders.ts
@@ -54,7 +54,6 @@ function updateChannelState(
     isNil(currentState.originalEntity) ||
     channel.id !== currentState.originalEntity.id
   ) {
-    console.log('setting state...');
     setCurrentChannel(channel, programming);
     return true;
   }
@@ -110,7 +109,6 @@ export const editProgrammingLoader: Preloader<{
           !updateChannelState(channel, programming) &&
           !currentState.programsLoaded
         ) {
-          console.log('setting programming...');
           setCurrentChannelProgramming(programming);
         }
 

--- a/web/src/store/programmingSelector/store.ts
+++ b/web/src/store/programmingSelector/store.ts
@@ -1,4 +1,4 @@
-import { ContentProgram, CustomShow, PlexServerSettings } from '@tunarr/types';
+import { CustomProgram, CustomShow, PlexServerSettings } from '@tunarr/types';
 import { PlexLibrarySection, PlexMedia } from '@tunarr/types/plex';
 import { StateCreator } from 'zustand';
 
@@ -14,7 +14,7 @@ export type PlexSelectedMedia = {
 export type CustomShowSelectedMedia = {
   type: 'custom-show';
   customShowId: string;
-  program: ContentProgram;
+  program: CustomProgram;
 };
 
 export type SelectedMedia = PlexSelectedMedia | CustomShowSelectedMedia;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -15,6 +15,7 @@ import {
 } from '@zodios/core/lib/zodios.types';
 import { LoaderFunctionArgs } from 'react-router-dom';
 import { apiClient } from '../external/api.ts';
+import { EnrichedPlexMedia } from '../hooks/plexHooks.ts';
 
 // A program that may or may not exist in the DB yet
 export type EphemeralProgram = Omit<Program, 'id'>;
@@ -108,3 +109,16 @@ export type UICustomShowProgram = (ContentProgram | CustomProgram) & UIIndex;
 export type NonUndefinedGuard<T> = T extends undefined ? never : T;
 
 export type ProgramSelectorViewType = 'list' | 'grid';
+
+export type AddedCustomShowProgram = {
+  type: 'custom-show';
+  customShowId: string;
+  program: CustomProgram;
+};
+
+export type AddedPlexMedia = {
+  type: 'plex';
+  media: EnrichedPlexMedia;
+};
+
+export type AddedMedia = AddedPlexMedia | AddedCustomShowProgram;

--- a/web/turbo.json
+++ b/web/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build-dev": {
+      "dependsOn": ["^build"]
+    }
+  }
+}


### PR DESCRIPTION
A huge set of changes... but we now have mostly generalized support for different content types in Channels. This brings us much closer to parity to the original dizquetv and paves the way for future added media-sources and perhaps even different content types.

Main changes include: 
* Support for adding custom show programs to a channel. Right now, unlike dizquetv, individual movies / episode within a custom show can be added. I will likely change this to be closer to dizquetv, where the entire custom show must be added wholesale
* Some common code additions for utility functions I've found helpful
* Loading "condensed" versions of custom programs, just like regular content programs, to keep the API response sizes lean for *huge* channels
* Random other stuff here and there...
