### PR TITLE
Support for music tracks in Plex - fixes #22

### DIFF
--- a/nvidia.Dockerfile
+++ b/nvidia.Dockerfile
@@ -3,6 +3,7 @@ FROM jrottenberg/ffmpeg:4.4.4-nvidia2204 AS ffmpeg-base
 ENV NODE_MAJOR=20
 
 # Install musl for native node bindings (sqlite)
+RUN apt-get update --fix-missing
 RUN apt-get install -y musl-dev
 RUN ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
 

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -18,6 +18,7 @@ import { debugApi } from './debugApi.js';
 import { fillerListsApi } from './fillerListsApi.js';
 import { programmingApi } from './programmingApi.js';
 import { tasksApiRouter } from './tasksApi.js';
+import { metadataApiRouter } from './metadataApi.js';
 
 const logger = createLogger(import.meta);
 
@@ -49,7 +50,8 @@ export const apiRouter: RouterPluginAsyncCallback = async (fastify) => {
     .register(customShowsApiV2)
     .register(fillerListsApi)
     .register(programmingApi)
-    .register(debugApi);
+    .register(debugApi)
+    .register(metadataApiRouter);
 
   fastify.get(
     '/version',

--- a/server/src/api/metadataApi.ts
+++ b/server/src/api/metadataApi.ts
@@ -1,0 +1,134 @@
+import axios, { AxiosHeaders } from 'axios';
+import { HttpHeader } from 'fastify/types/utils';
+import { isNil, isNull, isString, isUndefined, omitBy } from 'lodash-es';
+import stream from 'stream';
+import { z } from 'zod';
+import { withDb } from '../dao/dataSource';
+import { PlexServerSettings } from '../dao/entities/PlexServerSettings';
+import {
+  ProgramSourceType,
+  programSourceTypeFromString,
+} from '../dao/entities/Program';
+import { Plex } from '../plex';
+import { RouterPluginAsyncCallback } from '../types/serverType';
+
+type ExternalId = {
+  externalSourceType: ProgramSourceType;
+  externalSourceId: string;
+  externalItemId: string;
+};
+
+const externalIdSchema = z
+  .string()
+  .refine((val) => {
+    if (isString(val)) {
+      const parts = val.split('|', 3);
+      if (parts.length !== 3) {
+        return 'Invalid number of parts after splitting on delimiter';
+      }
+
+      if (isUndefined(programSourceTypeFromString(parts[0]))) {
+        return `Invalid program source type: ${parts[0]}`;
+      }
+
+      return true;
+    }
+
+    return 'Input was not a string';
+  })
+  .transform((val) => {
+    const [sourceType, sourceId, itemId] = val.split('|', 3);
+    return {
+      externalSourceType: programSourceTypeFromString(sourceType)!,
+      externalSourceId: sourceId,
+      externalItemId: itemId,
+    };
+  });
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const metadataApiRouter: RouterPluginAsyncCallback = async (fastify) => {
+  fastify.get(
+    '/metadata/external',
+    {
+      schema: {
+        querystring: z.object({
+          id: externalIdSchema,
+          asset: z.union([z.literal('thumb'), z.literal('external-link')]),
+          mode: z.union([
+            z.literal('json'),
+            z.literal('redirect'),
+            z.literal('proxy'),
+          ]),
+        }),
+      },
+    },
+    async (req, res) => {
+      let result: string | null = null;
+      switch (req.query.id.externalSourceType) {
+        case ProgramSourceType.PLEX: {
+          result = await handlePlexItem(req.query.id, req.query.asset);
+        }
+      }
+
+      if (isNull(result)) {
+        return res.status(405).send();
+      }
+
+      switch (req.query.mode) {
+        case 'json':
+          return res.send({ data: result });
+        case 'redirect':
+          if (!result) {
+            return res.status(404).send();
+          }
+          return res.redirect(302, result).send();
+        case 'proxy': {
+          if (!result) {
+            return res.status(404).send();
+          }
+          const proxyRes = await axios.request<stream.Readable>({
+            url: result,
+            responseType: 'stream',
+          });
+
+          let headers: Partial<Record<HttpHeader, string | string[]>>;
+          if (proxyRes.headers instanceof AxiosHeaders) {
+            headers = {
+              ...proxyRes.headers,
+            };
+          } else {
+            headers = { ...omitBy(proxyRes.headers, isNull) };
+          }
+
+          return res
+            .status(proxyRes.status)
+            .headers(headers)
+            .send(proxyRes.data);
+        }
+      }
+    },
+  );
+
+  async function handlePlexItem(
+    id: ExternalId,
+    asset: 'thumb' | 'external-link',
+  ) {
+    const plexServer = await withDb((em) => {
+      return em.findOne(PlexServerSettings, { name: id.externalSourceId });
+    });
+
+    if (isNil(plexServer)) {
+      return null;
+    }
+
+    if (asset === 'thumb') {
+      return Plex.getThumbUrl({
+        uri: plexServer.uri,
+        accessToken: plexServer.accessToken,
+        itemKey: id.externalItemId,
+      });
+    }
+
+    return null;
+  }
+};

--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -431,7 +431,7 @@ export class ChannelDB {
     if (lineup.items.length === 0) {
       lineup.items.push({
         type: 'offline',
-        durationMs: Number.MAX_SAFE_INTEGER,
+        durationMs: 1000 * 60 * 60 * 24 * 30,
       });
     }
     lineup.startTimeOffsets = reduce(

--- a/server/src/dao/converters/programConverters.ts
+++ b/server/src/dao/converters/programConverters.ts
@@ -12,7 +12,10 @@ export function dbProgramToContentProgram(
     date: program.originalAirDate,
     rating: program.rating,
     icon: program.showIcon ?? program.episodeIcon ?? program.icon,
-    title: program.showTitle ?? program.title,
+    title:
+      program.type === ProgramType.Episode
+        ? program.showTitle ?? program.title
+        : program.title,
     duration: program.duration,
     type: 'content',
     id: program.uuid,
@@ -23,5 +26,7 @@ export function dbProgramToContentProgram(
       program.type === ProgramType.Episode ? program.episode : undefined,
     episodeTitle:
       program.type === ProgramType.Episode ? program.title : undefined,
+    albumName: program.albumName,
+    artistName: program.artistName,
   };
 }

--- a/server/src/dao/entities/Program.ts
+++ b/server/src/dao/entities/Program.ts
@@ -9,8 +9,8 @@ import {
   Unique,
   serialize,
 } from '@mikro-orm/core';
-import type { Duration } from 'dayjs/plugin/duration.js';
 import { Program as ProgramDTO } from '@tunarr/types';
+import type { Duration } from 'dayjs/plugin/duration.js';
 import { BaseEntity } from './BaseEntity.js';
 import { Channel } from './Channel.js';
 import { CustomShow } from './CustomShow.js';
@@ -110,7 +110,10 @@ export class Program extends BaseEntity {
   year?: number;
 
   @Property({ nullable: true })
-  customOrder?: number;
+  artistName?: string;
+
+  @Property({ nullable: true })
+  albumName?: string;
 
   @ManyToMany(() => Channel, (channel) => channel.programs, { eager: false })
   channels = new Collection<Channel>(this);

--- a/server/src/dao/programHelpers.ts
+++ b/server/src/dao/programHelpers.ts
@@ -27,6 +27,7 @@ export async function upsertContentPrograms(
     .filter(isContentProgram)
     .uniqBy((p) => p.uniqueId)
     .map((p) => minter.mint(p.externalSourceName!, p.originalProgram!))
+    .compact()
     .value();
 
   logger.debug('Upserting %d programs', programsToPersist.length);

--- a/server/src/migrations/.snapshot-db.db.json
+++ b/server/src/migrations/.snapshot-db.db.json
@@ -888,14 +888,23 @@
           "nullable": true,
           "mappedType": "integer"
         },
-        "custom_order": {
-          "name": "custom_order",
-          "type": "integer",
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "mappedType": "integer"
+          "mappedType": "text"
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
         }
       },
       "name": "program",

--- a/server/src/plex.ts
+++ b/server/src/plex.ts
@@ -284,6 +284,32 @@ export class Plex {
     }).parse(response) as PlexTvDevicesResponse;
     return parsed;
   }
+
+  static getThumbUrl(opts: {
+    uri: string;
+    accessToken: string;
+    itemKey: string;
+    width?: number;
+    height?: number;
+    upscale?: string;
+  }): string {
+    const { uri, accessToken, itemKey, width, height, upscale } = opts;
+    const cleanKey = itemKey.replaceAll(/\/library\/metadata\//g, '');
+
+    let thumbUrl: URL;
+    const key = `/library/metadata/${cleanKey}/thumb?X-Plex-Token=${accessToken}`;
+    if (isUndefined(height) || isUndefined(width)) {
+      thumbUrl = new URL(`${uri}${key}`);
+    } else {
+      thumbUrl = new URL(`${uri}/photo/:/transcode`);
+      thumbUrl.searchParams.append('url', key);
+      thumbUrl.searchParams.append('X-Plex-Token', accessToken);
+      thumbUrl.searchParams.append('width', width.toString());
+      thumbUrl.searchParams.append('height', height.toString());
+      thumbUrl.searchParams.append('upscale', (upscale ?? '1').toString());
+    }
+    return thumbUrl.toString();
+  }
 }
 
 type PlexTvDevicesResponse = {

--- a/server/src/services/scheduler.ts
+++ b/server/src/services/scheduler.ts
@@ -1,11 +1,11 @@
+import { once } from 'lodash-es';
 import schedule from 'node-schedule';
+import { withDb } from '../dao/dataSource.js';
+import createLogger from '../logger.js';
 import { ServerContext } from '../serverContext.js';
+import { CleanupSessionsTask } from '../tasks/cleanupSessionsTask.js';
 import { Task, TaskId } from '../tasks/task.js';
 import { UpdateXmlTvTask } from '../tasks/updateXmlTvTask.js';
-import createLogger from '../logger.js';
-import { withDb } from '../dao/dataSource.js';
-import { CleanupSessionsTask } from '../tasks/cleanupSessionsTask.js';
-import { once } from 'lodash-es';
 
 const logger = createLogger(import.meta);
 
@@ -93,7 +93,7 @@ export const scheduleJobs = once((serverContext: ServerContext) => {
 
   scheduledJobsById[CleanupSessionsTask.ID] = new ScheduledTask(
     CleanupSessionsTask.name,
-    minutesCrontab(1),
+    minutesCrontab(30),
     () => new CleanupSessionsTask(),
   );
 });

--- a/server/src/services/tvGuideService.ts
+++ b/server/src/services/tvGuideService.ts
@@ -225,7 +225,7 @@ export class TVGuideService {
         startTimeMs: currentUpdateTimeMs - d,
         program: {
           type: 'flex',
-          duration: Number.MAX_SAFE_INTEGER,
+          duration: 1000 * 60 * 60 * 24 * 30, // One month
           isOffline: true,
         },
       };

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,3 +1,12 @@
 export { scheduleRandomSlots } from './services/randomSlotsService.js';
 export { scheduleTimeSlots } from './services/timeSlotService.js';
 export { mod as dayjsMod } from './util/dayjsExtensions.js';
+
+// TODO replace first arg with shared type
+export function createExternalId(
+  sourceType: 'plex',
+  sourceId: string,
+  itemId: string,
+): `${string}|${string}|${string}` {
+  return `${sourceType}|${sourceId}|${itemId}`;
+}

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -19,23 +19,23 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from '@mui/material';
 import { DataTag, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
   PlexLibraryCollections,
   PlexLibraryMovies,
+  PlexLibraryMusic,
   PlexLibraryShows,
   PlexMovie,
+  PlexMusicArtist,
   PlexTvShow,
 } from '@tunarr/types/plex';
 import { chain, first, isEmpty, isNil, isUndefined, map } from 'lodash-es';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { toggle } from '../../helpers/util';
-import {
-  fetchPlexPath,
-  usePlex
-} from '../../hooks/plexHooks';
+import { fetchPlexPath, usePlex } from '../../hooks/plexHooks';
 import { usePlexServerSettings } from '../../hooks/settingsHooks';
 import useDebouncedState from '../../hooks/useDebouncedState';
 import useStore from '../../store';
@@ -105,7 +105,7 @@ export default function PlexProgrammingSelector() {
       debounceSearch,
     ] as DataTag<
       ['plex-search', string, string, string],
-      PlexLibraryMovies | PlexLibraryShows
+      PlexLibraryMovies | PlexLibraryShows | PlexLibraryMusic
     >,
     enabled: !isNil(selectedServer) && !isNil(selectedLibrary),
     initialPageParam: 0,
@@ -119,7 +119,9 @@ export default function PlexProgrammingSelector() {
         plexQuery.set('title<', debounceSearch);
       }
 
-      return fetchPlexPath<PlexLibraryMovies | PlexLibraryShows>(
+      return fetchPlexPath<
+        PlexLibraryMovies | PlexLibraryShows | PlexLibraryMusic
+      >(
         selectedServer!.name,
         `/library/sections/${
           selectedLibrary!.library.key
@@ -218,7 +220,7 @@ export default function PlexProgrammingSelector() {
         .take(scrollParams.limit)
         .value();
       elements.push(
-        ...map(items, (item: PlexMovie | PlexTvShow) => {
+        ...map(items, (item: PlexMovie | PlexTvShow | PlexMusicArtist) => {
           return viewType === 'list' ? (
             <PlexListItem key={item.guid} item={item} />
           ) : (
@@ -315,6 +317,11 @@ export default function PlexProgrammingSelector() {
               marginTop: 1,
             }}
           />
+          {!searchLoading && (
+            <Typography variant="caption" color={(t) => t.palette.grey[700]}>
+              {first(searchData?.pages)?.size} Items
+            </Typography>
+          )}
           <List
             component="nav"
             sx={{

--- a/web/src/helpers/util.ts
+++ b/web/src/helpers/util.ts
@@ -316,6 +316,15 @@ export const forPlexMedia = <T>(choices: PerTypeCallback<PlexMedia, T>) => {
       case 'episode':
         if (choices.episode) return applyOrValue(choices.episode, m);
         break;
+      case 'artist':
+        if (choices.artist) return applyOrValue(choices.artist, m);
+        break;
+      case 'album':
+        if (choices.album) return applyOrValue(choices.album, m);
+        break;
+      case 'track':
+        if (choices.track) return applyOrValue(choices.track, m);
+        break;
       case 'collection':
         if (choices.collection) return applyOrValue(choices.collection, m);
         break;


### PR DESCRIPTION
This should _mostly_ fix #22  and also includes the beginnings of supporting #183

Includes:
* Frontend and backend support for adding music tracks to a Channel
* New endpoint for proxying metadata calls out to Plex
  * e.g. /api/metadata/external?id=plex|server|item_id&mode=proxy&asset=thumb will proxy requests to the Plex server backend for thumbnails and return the image bytes directly
* Various bug fixes around the codebase that I stumbled on
