### PR TITLE
Add basic padding times

### DIFF
--- a/web/src/hooks/programming_controls/usePadStartTimes.ts
+++ b/web/src/hooks/programming_controls/usePadStartTimes.ts
@@ -19,8 +19,12 @@ const OneMinuteMillis = 1000 * 60;
 
 export const StartTimePaddingOptions: readonly StartTimePadding[] = [
   { mod: -1, description: 'None' },
+  { mod: 5, description: ':05, :10, ..., :55' },
+  { mod: 10, description: ':10, :20, ..., :50' },
   { mod: 15, description: ':00, :15, :30, :45' },
   { mod: 30, description: ':00, :30' },
+  { mod: 60, description: ':00' },
+  { mod: 20, description: ':20, :40, :00' },
 ] as const;
 
 export function usePadStartTimes() {


### PR DESCRIPTION
Does not yet add support for "*0 or *5" and other similar paddings that
dizque has, since that will require a bit more work.
