### PR TITLE
Hook up plex local/server status indicators on the settings page

### DIFF
--- a/server/src/api/plexServersApi.ts
+++ b/server/src/api/plexServersApi.ts
@@ -7,13 +7,13 @@ import {
 import { PlexServerSettingsSchema } from '@tunarr/types/schemas';
 import { isError, isNil, isObject } from 'lodash-es';
 import z from 'zod';
+import { PlexServerSettings } from '../dao/entities/PlexServerSettings.js';
 import createLogger from '../logger.js';
 import { Plex, PlexApiFactory } from '../plex.js';
 import { scheduledJobsById } from '../services/scheduler.js';
 import { UpdateXmlTvTask } from '../tasks/updateXmlTvTask.js';
 import { RouterPluginAsyncCallback } from '../types/serverType.js';
 import { firstDefined, wait } from '../util.js';
-import { PlexServerSettings } from '../dao/entities/PlexServerSettings.js';
 
 const logger = createLogger(import.meta);
 
@@ -50,8 +50,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
         params: BasicIdParamSchema,
         response: {
           200: z.object({
-            // TODO Change this, this is very stupid
-            status: z.union([z.literal(1), z.literal(-1)]),
+            healthy: z.boolean(),
           }),
           404: z.void(),
           500: z.void(),
@@ -80,7 +79,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
         ]);
 
         return res.send({
-          status: s,
+          healthy: s === 1,
         });
       } catch (err) {
         logger.error(err);

--- a/server/src/plex.ts
+++ b/server/src/plex.ts
@@ -1,4 +1,5 @@
 import { EntityDTO } from '@mikro-orm/core';
+import { DefaultPlexHeaders } from '@tunarr/shared/constants';
 import { PlexDvr, PlexDvrsResponse, PlexResource } from '@tunarr/types/plex';
 import axios, {
   AxiosInstance,
@@ -19,8 +20,6 @@ import {
   PlexMediaContainerResponse,
 } from './types/plexApiTypes.js';
 
-const ClientIdentifier = 'p86cy1w47clco3ro8t92nfy1';
-
 type AxiosConfigWithMetadata = InternalAxiosRequestConfig & {
   metadata: {
     startTime: number;
@@ -28,17 +27,6 @@ type AxiosConfigWithMetadata = InternalAxiosRequestConfig & {
 };
 
 const logger = createLogger(import.meta);
-
-const DEFAULT_HEADERS = {
-  Accept: 'application/json',
-  'X-Plex-Device': 'Tunarr',
-  'X-Plex-Device-Name': 'Tunarr',
-  'X-Plex-Product': 'Tunarr',
-  'X-Plex-Version': '0.1',
-  'X-Plex-Client-Identifier': ClientIdentifier,
-  'X-Plex-Platform': 'Chrome',
-  'X-Plex-Platform-Version': '80.0',
-};
 
 type PlexApiOptions = Pick<
   EntityDTO<PlexServerSettings>,
@@ -75,7 +63,7 @@ export class Plex {
     this.axiosInstance = axios.create({
       baseURL: uri,
       headers: {
-        ...DEFAULT_HEADERS,
+        ...DefaultPlexHeaders,
         'X-Plex-Token': this._accessToken,
       },
     });

--- a/shared/src/util/constants.ts
+++ b/shared/src/util/constants.ts
@@ -10,4 +10,17 @@ const constants = {
   DEFAULT_DATA_DIR: '.dizquetv',
 };
 
+const PlexClientIdentifier = 'p86cy1w47clco3ro8t92nfy1';
+
+export const DefaultPlexHeaders = {
+  Accept: 'application/json',
+  'X-Plex-Device': 'Tunarr',
+  'X-Plex-Device-Name': 'Tunarr',
+  'X-Plex-Product': 'Tunarr',
+  'X-Plex-Version': '0.1',
+  'X-Plex-Client-Identifier': PlexClientIdentifier,
+  'X-Plex-Platform': 'Chrome',
+  'X-Plex-Platform-Version': '80.0',
+};
+
 export default constants;

--- a/web/src/components/base/LoadingIcon.tsx
+++ b/web/src/components/base/LoadingIcon.tsx
@@ -1,0 +1,6 @@
+import Loop from '@mui/icons-material/Loop';
+import { styled } from '@mui/material/styles';
+
+export const RotatingLoopIcon = styled(Loop)({
+  animation: 'spin 2s linear infinite',
+});

--- a/web/src/external/api.ts
+++ b/web/src/external/api.ts
@@ -1,4 +1,5 @@
 import {
+  BaseErrorSchema,
   BatchLookupExternalProgrammingSchema,
   CreateCustomShowRequestSchema,
   CreateFillerListRequestSchema,
@@ -195,6 +196,29 @@ export const api = makeApi([
       })
       .build(),
     response: z.any(),
+  },
+  {
+    method: 'get',
+    path: '/api/plex-servers/:id/status',
+    alias: 'getPlexServerStatus',
+    parameters: parametersBuilder()
+      .addPaths({
+        id: z.string(),
+      })
+      .build(),
+    response: z.object({
+      healthy: z.boolean(),
+    }),
+    errors: makeErrors([
+      {
+        status: 404,
+        schema: BaseErrorSchema,
+      },
+      {
+        status: 500,
+        schema: BaseErrorSchema,
+      },
+    ]),
   },
   {
     method: 'get',

--- a/web/src/pages/ErrorPage.tsx
+++ b/web/src/pages/ErrorPage.tsx
@@ -1,26 +1,15 @@
 import GitHub from '@mui/icons-material/GitHub';
-import Loop from '@mui/icons-material/Loop';
 import Refresh from '@mui/icons-material/Refresh';
-import {
-  Box,
-  Button,
-  Collapse,
-  Stack,
-  Typography,
-  styled,
-} from '@mui/material';
+import { Box, Button, Collapse, Stack, Typography } from '@mui/material';
 import Bowser from 'bowser';
 import { isError } from 'lodash-es';
 import { useMemo } from 'react';
 import { useRouteError } from 'react-router-dom';
 import errorImage from '../assets/error_this_is_fine.png';
+import { RotatingLoopIcon } from '../components/base/LoadingIcon';
 import { useVersion } from '../hooks/useVersion';
 
 const browser = Bowser.getParser(window.navigator.userAgent);
-
-const RotatingLoopIcon = styled(Loop)({
-  animation: 'spin 2s linear infinite',
-});
 
 export function ErrorPage() {
   const { data: version, isLoading: versionLoading } = useVersion();

--- a/web/src/queryClient.ts
+++ b/web/src/queryClient.ts
@@ -2,4 +2,10 @@ import { QueryCache } from '@tanstack/react-query';
 
 // Shared query cache so non-hook / in-component usages share the same
 // underlying cache
-export const queryCache = new QueryCache();
+export const queryCache = new QueryCache({
+  onError: (err) => {
+    if (import.meta.env.DEV) {
+      console.error('Query error', err);
+    }
+  },
+});


### PR DESCRIPTION
It's unclear whether we need the UI status, since the UI makes limited,
direct calls to Plex (most things are proxied through the server). It
was easy enough to hookup and will be easy remove later if we decide to
do so.
