### PR TITLE
Implement more restricted pad times - Fixes #193

### DIFF
--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -1,8 +1,8 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
-import MovieIcon from '@mui/icons-material/Movie';
 import MusicNote from '@mui/icons-material/MusicNote';
+import TheatersIcon from '@mui/icons-material/Theaters';
 import TvIcon from '@mui/icons-material/Tv';
 import { ListItemIcon, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -162,7 +162,7 @@ const ProgramListItem = ({
   if (program.type === 'content') {
     switch (program.subtype) {
       case 'movie':
-        icon = <MovieIcon />;
+        icon = <TheatersIcon />;
         break;
       case 'episode':
         icon = <TvIcon />;
@@ -171,6 +171,9 @@ const ProgramListItem = ({
         icon = <MusicNote />;
         break;
     }
+  }
+  if (icon !== null) {
+    icon = <ListItemIcon sx={{ minWidth: 0, pr: 1 }}>{icon}</ListItemIcon>;
   }
 
   return (
@@ -217,21 +220,19 @@ const ProgramListItem = ({
           >
             <DragIndicatorIcon />
           </ListItemIcon>
-          {program.type === 'content' && (
+          {program.type === 'content' ? (
             <ListItemIcon
               onClick={handleInfoButtonClick}
-              sx={{ cursor: 'pointer' }}
+              sx={{ cursor: 'pointer', minWidth: 0, pr: 1 }}
             >
               <InfoOutlined />
             </ListItemIcon>
+          ) : (
+            <Box sx={{ pr: 1, width: 24 }} />
           )}
+          {icon ?? <Box sx={{ pr: 1, width: 20 }} />}
           <ListItemText
-            primary={
-              <>
-                {icon}
-                {title}
-              </>
-            }
+            primary={title}
             sx={{
               fontStyle: program.persisted ? 'normal' : 'italic',
             }}

--- a/web/src/components/programming_controls/AddPaddingModal.tsx
+++ b/web/src/components/programming_controls/AddPaddingModal.tsx
@@ -1,18 +1,20 @@
-import { useState } from 'react';
+import { Expand as PaddingIcon } from '@mui/icons-material';
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
-  FormControl,
+  DialogContentText,
   DialogTitle,
+  FormControl,
   FormGroup,
   InputLabel,
   MenuItem,
   Select,
-  DialogContentText,
 } from '@mui/material';
-import { Expand as PaddingIcon } from '@mui/icons-material';
+import { find } from 'lodash-es';
+import { useCallback, useState } from 'react';
+import { handleNumericFormValue } from '../../helpers/util.ts';
 import {
   StartTimePadding,
   StartTimePaddingOptions,
@@ -30,6 +32,17 @@ const AddPaddingModal = ({ open, onClose }: AddPaddingModalProps) => {
   );
   const padStartTimes = usePadStartTimes();
 
+  const handlePaddingChange = useCallback(
+    (value: number) => {
+      setCurrentPadding(
+        value === -1 || isNaN(value)
+          ? null
+          : find(StartTimePaddingOptions, { key: value })!,
+      );
+    },
+    [setCurrentPadding],
+  );
+
   return (
     <Dialog open={open}>
       <DialogTitle>Pad Start Times</DialogTitle>
@@ -41,21 +54,17 @@ const AddPaddingModal = ({ open, onClose }: AddPaddingModalProps) => {
         <FormGroup sx={{ flexGrow: 1, flexWrap: 'nowrap' }}>
           <FormControl fullWidth sx={{ my: 1 }}>
             <InputLabel>Pad Start Times</InputLabel>
-            <Select
-              value={currentPadding?.mod ?? -1}
+            <Select<StartTimePadding['key']>
+              value={currentPadding?.key ?? -1}
               label={'Pad Start Times'}
               onChange={(e) =>
-                setCurrentPadding(
-                  e.target.value === -1
-                    ? null
-                    : StartTimePaddingOptions.find(
-                        (opt) => opt.mod === e.target.value,
-                      )!,
+                handlePaddingChange(
+                  handleNumericFormValue(e.target.value, true),
                 )
               }
             >
               {StartTimePaddingOptions.map((opt, idx) => (
-                <MenuItem key={idx} value={opt.mod}>
+                <MenuItem key={idx} value={opt.key}>
                   {opt.description}
                 </MenuItem>
               ))}

--- a/web/src/helpers/util.ts
+++ b/web/src/helpers/util.ts
@@ -14,7 +14,15 @@ import {
 import { PlexMedia } from '@tunarr/types/plex';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import { isNumber, property, range, reduce, zipWith } from 'lodash-es';
+import {
+  flatMap,
+  isNumber,
+  map,
+  property,
+  range,
+  reduce,
+  zipWith,
+} from 'lodash-es';
 import { Path, PathValue } from 'react-hook-form';
 import { SelectedMedia } from '../store/programmingSelector/store';
 import { AddedMedia, UIChannelProgram } from '../types';
@@ -376,3 +384,18 @@ export function typedProperty<T, TPath extends Path<T> = Path<T>>(path: TPath) {
 }
 export const uuidRegexPattern =
   '[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}';
+
+export function product<T, U, V>(
+  l: readonly T[] | null | undefined,
+  r: readonly U[] | null | undefined,
+  f: (l0: T, r0: U) => V,
+): V[] {
+  return flatMap(l, (l0) => map(r, (r0) => f(l0, r0)));
+}
+
+export function scale(
+  coll: readonly number[] | null | undefined,
+  factor: number,
+): number[] {
+  return map(coll, (c) => c * factor);
+}

--- a/web/src/hooks/programming_controls/usePadStartTimes.ts
+++ b/web/src/hooks/programming_controls/usePadStartTimes.ts
@@ -1,8 +1,9 @@
 import { Channel, CondensedChannelProgram, isFlexProgram } from '@tunarr/types';
 import dayjs from 'dayjs';
-import { forEach } from 'lodash-es';
+import { find, flatMap, forEach, isEmpty, sortBy } from 'lodash-es';
 import filter from 'lodash-es/filter';
 import negate from 'lodash-es/negate';
+import { scale } from '../../helpers/util.ts';
 import {
   setCurrentLineup,
   updateCurrentChannel,
@@ -11,20 +12,39 @@ import useStore from '../../store/index.ts';
 import { materializedProgramListSelector } from '../../store/selectors.ts';
 
 export type StartTimePadding = {
+  key: number;
   mod: number;
   description: string;
+  allowedOffsets?: number[];
 };
 
-const OneMinuteMillis = 1000 * 60;
-
+/**
+ * The 'key' value here should be unique and used for React keys, Select menu values
+ * etc.
+ *
+ * There are two ways to configure padding:
+ *  1. Simple way - just define a modulo. This will just incrementally round off
+ *     programs to the nearest mod mins
+ *  2. Less simple - define a modulo and an 'allowed offsets'. Allowed offsets are
+ *     minute offsets within an hour that we can start shows. These are combined
+ *     with the modulo to create sets of restricted start times. For instance,
+ *     allowedOffsets = [0, 30] will allow programs to only start on minutes
+ *     [0, 5, 30, 35].
+ */
 export const StartTimePaddingOptions: readonly StartTimePadding[] = [
-  { mod: -1, description: 'None' },
-  { mod: 5, description: ':05, :10, ..., :55' },
-  { mod: 10, description: ':10, :20, ..., :50' },
-  { mod: 15, description: ':00, :15, :30, :45' },
-  { mod: 30, description: ':00, :30' },
-  { mod: 60, description: ':00' },
-  { mod: 20, description: ':20, :40, :00' },
+  { key: -1, mod: -1, description: 'None' },
+  { key: 5, mod: 5, description: ':05, :10, ..., :55' },
+  { key: 10, mod: 10, description: ':10, :20, ..., :50' },
+  { key: 15, mod: 15, description: ':00, :15, :30, :45' },
+  { key: 30, mod: 30, description: ':00, :30' },
+  { key: 60, mod: 60, description: ':00' },
+  { key: 20, mod: 20, description: ':20, :40, :00' },
+  {
+    key: 5.1,
+    mod: 5,
+    description: ':00, :05, :30, :35',
+    allowedOffsets: [0, 30],
+  },
 ] as const;
 
 export function usePadStartTimes() {
@@ -47,23 +67,53 @@ export function padStartTimes(
   programs: CondensedChannelProgram[],
   padding: StartTimePadding | null,
 ) {
-  const mod =
-    !padding || padding.mod <= 0 ? OneMinuteMillis : padding.mod * 60 * 1000;
+  const modMins = !padding || padding.mod <= 0 ? 1 : padding.mod;
+  const mod = modMins * 60 * 1000;
   const startTime = dayjs(channel?.startTime).unix() * 1000;
   const newStartTime = startTime - (startTime % mod);
   const filteredPrograms = filter(programs, negate(isFlexProgram));
+
+  const manualOffsets = sortBy(
+    scale(
+      flatMap(padding?.allowedOffsets, (off) => [off, off + modMins]),
+      60 * 1000,
+    ),
+  );
+  console.log(manualOffsets);
 
   let lastStartTime = newStartTime;
   const newProgramList: CondensedChannelProgram[] = [];
   forEach(filteredPrograms, (program) => {
     newProgramList.push(program);
     const last = dayjs(lastStartTime);
-    // How many "slots" of time does this program take up?
-    // We find the next available start time for a program
-    const nextProgramTime = last.add(
-      Math.ceil(program.duration / mod) * mod,
-      'milliseconds',
-    );
+
+    let nextProgramTime: dayjs.Dayjs;
+    if (!isEmpty(manualOffsets)) {
+      const thisProgramEnd = last.add(program.duration);
+      const endMillis = dayjs
+        .duration(thisProgramEnd.diff(thisProgramEnd.startOf('h')))
+        .asMilliseconds();
+      const foundOffset = find(manualOffsets, (off) => off >= endMillis);
+      if (!foundOffset) {
+        // Increment to the next hour and pick the first offset,
+        // which will _always_ be the correct one, since we sorted
+        // the offsets above are sure they are non-empty
+        nextProgramTime = thisProgramEnd
+          .add(1, 'h')
+          .startOf('h')
+          .add(manualOffsets[0], 'm');
+      } else {
+        // Reset m,s,ms on the end timestamp the rounded offset
+        nextProgramTime = thisProgramEnd.startOf('h').add(foundOffset);
+      }
+    } else {
+      // How many "slots" of time does this program take up?
+      // We find the next available start time for a program
+      nextProgramTime = last.add(
+        Math.ceil(program.duration / mod) * mod,
+        'milliseconds',
+      );
+    }
     // Advance by the duration of the program
     lastStartTime += program.duration;
     // How much padding do we need?


### PR DESCRIPTION
This code implements pad times where only certain offsets can be used.
For instance, [0, 5, 30, 35] min start times for shows.
