### PR TITLE
Fixes fade in grid items and some other modal issues

### DIFF
--- a/web/src/components/InlineModal.tsx
+++ b/web/src/components/InlineModal.tsx
@@ -28,16 +28,21 @@ function InlineModal(props: InlineModalProps) {
   const gridItemRef = useRef<HTMLDivElement>(null);
   const inlineModalRef = useRef<HTMLDivElement>(null);
   const darkMode = useStore((state) => state.theme.darkMode);
-  const modalHeight = getEstimatedModalHeight(
-    rowSize,
-    containerWidth,
-    itemWidth,
-    modalChildren?.length || 0,
-    type,
-  );
+  const modalHeight = open
+    ? getEstimatedModalHeight(
+        rowSize,
+        containerWidth,
+        modalChildren?.length || 0,
+        type,
+      )
+    : 0;
 
-  const toggleModal = () => {
-    setIsOpen(!isOpen);
+  const toggleModal = (value?: boolean) => {
+    if (value) {
+      setIsOpen(value);
+    } else {
+      setIsOpen(!isOpen);
+    }
   };
 
   useEffect(() => {
@@ -115,9 +120,14 @@ function InlineModal(props: InlineModalProps) {
         }}
         mountOnEnter
         unmountOnExit
-        sx={{ width: '100%', display: 'grid', gridColumn: '1 / -1' }}
-        onEnter={toggleModal}
-        onExited={toggleModal}
+        sx={{
+          width: '100%',
+          display: 'grid',
+          gridColumn: '1 / -1',
+          minHeight: modalHeight,
+        }}
+        onEnter={() => toggleModal()}
+        onExited={() => toggleModal()}
       >
         <List
           component={'ul'}
@@ -130,7 +140,7 @@ function InlineModal(props: InlineModalProps) {
             justifyContent: 'flex-start',
             backgroundColor: (theme) =>
               darkMode ? theme.palette.grey[800] : theme.palette.grey[400],
-            padding: '0',
+            padding: 0,
             paddingTop: 2,
             minHeight: modalHeight,
           }}

--- a/web/src/components/channel_config/PlexGridItem.tsx
+++ b/web/src/components/channel_config/PlexGridItem.tsx
@@ -53,6 +53,7 @@ const PlexGridItem = forwardRef(
     const server = useStore((s) => s.currentServer!); // We have to have a server at this point
     const darkMode = useStore((state) => state.theme.darkMode);
     const [open, setOpen] = useState(false);
+    const [imageLoaded, setImageLoaded] = useState(false);
     const { item, style, moveModal, modalChildren } = props;
     const hasChildren = !isTerminalItem(item);
     const childPath = isPlexCollection(item) ? 'collections' : 'metadata';
@@ -68,18 +69,6 @@ const PlexGridItem = forwardRef(
       filter(s.selectedMedia, (p): p is PlexSelectedMedia => p.type === 'plex'),
     );
     const selectedMediaIds = selectedMedia.map((item) => item.guid);
-
-    const handleClick = () => {
-      setOpen(!open);
-
-      if (moveModal) {
-        moveModal();
-
-        if (children && modalChildren) {
-          modalChildren(children.Metadata);
-        }
-      }
-    };
 
     useEffect(() => {
       if (props.modalIsPending) {
@@ -97,6 +86,20 @@ const PlexGridItem = forwardRef(
       }
     }, [item.guid, server.name, children]);
 
+    // Manages opening children in inline modal
+    const handleClick = () => {
+      setOpen(!open);
+
+      if (moveModal) {
+        moveModal();
+
+        if (children && modalChildren) {
+          modalChildren(children.Metadata);
+        }
+      }
+    };
+
+    // Manages click event on items with no children
     const handleItem = useCallback(
       (e: MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
         e.stopPropagation();
@@ -125,79 +128,82 @@ const PlexGridItem = forwardRef(
 
     return (
       <Fade
-        in={isInViewport && !_.isUndefined(item)} // TODO: eventually we will want to add in:  && imageLoaded so it only fades in after image has loaded
+        in={isInViewport && !_.isUndefined(item) && imageLoaded} // TODO: eventually we will want to add in:  && imageLoaded so it only fades in after image has loaded
         timeout={500}
         ref={imageContainerRef}
       >
-        <ImageListItem
-          component={Grid}
-          key={item.guid}
-          sx={{
-            cursor: 'pointer',
-            display: 'flex',
-            flexDirection: 'column',
-            flexGrow: 1,
-            paddingLeft: '8px !important',
-            paddingRight: '8px',
-            paddingTop: '8px',
-            borderRadiusTopLeft: '10px',
-            borderRadiusTopRight: '10px',
-            height: 'auto',
-            backgroundColor: (theme) =>
-              props.modalIndex === props.index
-                ? darkMode
-                  ? theme.palette.grey[800]
-                  : theme.palette.grey[400]
-                : 'transparent',
-            transition: 'background-color 350ms linear !important',
-            ...style,
-          }}
-          onClick={
-            hasChildren
-              ? handleClick
-              : (event: MouseEvent<HTMLDivElement>) => handleItem(event)
-          }
-          ref={ref}
-        >
-          {isInViewport && ( // To do: Eventually turn this itno isNearViewport so images load before they hit the viewport
-            <img
-              src={`${server.uri}${item.thumb}?X-Plex-Token=${server.accessToken}`}
-              width={100}
-              style={{ borderRadius: '5%', height: 'auto' }}
-            />
-          )}
-          <ImageListItemBar
-            title={item.title}
-            subtitle={
-              item.type !== 'movie' ? (
-                <span>{`${
-                  !isNaN(extractChildCount(item)) && extractChildCount(item)
-                } items`}</span>
-              ) : (
-                <span>{prettyItemDuration(item.duration)}</span>
-              )
+        <div>
+          <ImageListItem
+            component={Grid}
+            key={item.guid}
+            sx={{
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              flexGrow: 1,
+              paddingLeft: '8px !important',
+              paddingRight: '8px',
+              paddingTop: '8px',
+              borderRadiusTopLeft: '10px',
+              borderRadiusTopRight: '10px',
+              height: 'auto',
+              backgroundColor: (theme) =>
+                props.modalIndex === props.index
+                  ? darkMode
+                    ? theme.palette.grey[800]
+                    : theme.palette.grey[400]
+                  : 'transparent',
+              transition: 'background-color 350ms linear !important',
+              ...style,
+            }}
+            onClick={
+              hasChildren
+                ? handleClick
+                : (event: MouseEvent<HTMLDivElement>) => handleItem(event)
             }
-            position="below"
-            actionIcon={
-              <IconButton
-                sx={{ color: 'black' }}
-                aria-label={`star ${item.title}`}
-                onClick={(event: MouseEvent<HTMLButtonElement>) =>
-                  handleItem(event)
-                }
-              >
-                {selectedMediaIds.includes(item.guid) ? (
-                  <CheckCircle sx={{ color: darkMode ? '#fff' : '#000' }} />
+            ref={ref}
+          >
+            {isInViewport && ( // To do: Eventually turn this itno isNearViewport so images load before they hit the viewport
+              <img
+                src={`${server.uri}${item.thumb}?X-Plex-Token=${server.accessToken}`}
+                width={100}
+                style={{ borderRadius: '5%', height: 'auto' }}
+                onLoad={() => setImageLoaded(true)}
+              />
+            )}
+            <ImageListItemBar
+              title={item.title}
+              subtitle={
+                item.type !== 'movie' ? (
+                  <span>{`${
+                    !isNaN(extractChildCount(item)) && extractChildCount(item)
+                  } items`}</span>
                 ) : (
-                  <RadioButtonUnchecked
-                    sx={{ color: darkMode ? '#fff' : '#000' }}
-                  />
-                )}
-              </IconButton>
-            }
-            actionPosition="right"
-          />
-        </ImageListItem>
+                  <span>{prettyItemDuration(item.duration)}</span>
+                )
+              }
+              position="below"
+              actionIcon={
+                <IconButton
+                  sx={{ color: 'black' }}
+                  aria-label={`star ${item.title}`}
+                  onClick={(event: MouseEvent<HTMLButtonElement>) =>
+                    handleItem(event)
+                  }
+                >
+                  {selectedMediaIds.includes(item.guid) ? (
+                    <CheckCircle sx={{ color: darkMode ? '#fff' : '#000' }} />
+                  ) : (
+                    <RadioButtonUnchecked
+                      sx={{ color: darkMode ? '#fff' : '#000' }}
+                    />
+                  )}
+                </IconButton>
+              }
+              actionPosition="right"
+            />
+          </ImageListItem>
+        </div>
       </Fade>
     );
   },

--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -4,17 +4,19 @@ export function getImagesPerRow(
   containerWidth: number,
   imageWidth: number,
 ): number {
+  const roundedImageWidth = Math.round(imageWidth * 100) / 100;
+
   if (!imageWidth || !containerWidth) {
     return 9; // some default value
   }
-  return Math.floor(containerWidth / imageWidth);
+
+  return Math.round(((containerWidth / roundedImageWidth) * 100) / 100);
 }
 
 // Estimate the modal height to prevent div collapse while new modal images load
 export function getEstimatedModalHeight(
-  rowSize: number,
+  itemsPerRow: number,
   containerWidth: number,
-  imageContainerWidth: number,
   listSize: number,
   type: PlexMedia['type'] | 'all',
 ): number {
@@ -22,26 +24,24 @@ export function getEstimatedModalHeight(
   if (type === 'season') {
     return 143;
   }
-  // Exit with defaults if container & image width are not provided
-  if (containerWidth === 0 || imageContainerWidth === 0) {
-    return 294; //default modal height for 1 row
-  }
 
-  // const columns = getImagesPerRow(containerWidth, imageContainerWidth);
-  const columns = rowSize;
+  const imageContainerWidth = containerWidth / itemsPerRow;
+
+  // If the container width isn't available yet, just exit and use the approx
+  if (containerWidth === 0) {
+    return (listSize / itemsPerRow) * 294; //299 is approx height of items
+  }
 
   // Magic Numbers
   // to do: eventually grab this data via refs just in case it changes in the future
   const inlineModalTopPadding = 16;
   const imageContainerXPadding = 8;
   const listItemBarContainerHeight = 54;
-
-  const imagewidth = imageContainerWidth - imageContainerXPadding * 2; // 16px padding on each item
-  const heightPerImage = (3 * imagewidth) / 2; // Movie Posters are 2:3
+  const heightPerImage = (3 * imageContainerWidth) / 2; // Movie Posters are 2:3
   const heightPerItem =
     heightPerImage + listItemBarContainerHeight + imageContainerXPadding; // 54px
 
-  const rows = listSize < columns ? 1 : Math.ceil(listSize / columns);
+  const rows = listSize < itemsPerRow ? 1 : Math.ceil(listSize / itemsPerRow);
   //This is min-height so we only need to adjust it for visible rows since we
   //use interesectionObserver to load them in
   const maxRows = rows >= 3 ? 3 : rows;


### PR DESCRIPTION
- Fade now correctly works for PlexGridtem component
- Updated PlexGridItem to initiate Fade after the image has fully loaded (so Fade is visible to user)
- Fixes issue where rowSize calculation would be wrong, now rounding the number to make it match Grid calc.
- Update calculation for estimating inline modal height so it doesn't display as the wrong size initially while images load in
- Cleaned up some variable naming in the modal utilities to make it easier to understand