### PR TITLE
Fixes fade in PlexGridItems and some other modal issues

### DIFF
--- a/web/src/components/InlineModal.tsx
+++ b/web/src/components/InlineModal.tsx
@@ -130,7 +130,7 @@ function InlineModal(props: InlineModalProps) {
             justifyContent: 'flex-start',
             backgroundColor: (theme) =>
               darkMode ? theme.palette.grey[800] : theme.palette.grey[400],
-            padding: '0',
+            padding: 0,
             paddingTop: 2,
             minHeight: modalHeight,
           }}

--- a/web/src/components/channel_config/PlexGridItem.tsx
+++ b/web/src/components/channel_config/PlexGridItem.tsx
@@ -53,6 +53,7 @@ const PlexGridItem = forwardRef(
     const server = useStore((s) => s.currentServer!); // We have to have a server at this point
     const darkMode = useStore((state) => state.theme.darkMode);
     const [open, setOpen] = useState(false);
+    const [imageLoaded, setImageLoaded] = useState(false);
     const { item, style, moveModal, modalChildren } = props;
     const hasChildren = !isTerminalItem(item);
     const childPath = isPlexCollection(item) ? 'collections' : 'metadata';
@@ -125,79 +126,82 @@ const PlexGridItem = forwardRef(
 
     return (
       <Fade
-        in={isInViewport && !_.isUndefined(item)} // TODO: eventually we will want to add in:  && imageLoaded so it only fades in after image has loaded
+        in={isInViewport && !_.isUndefined(item) && imageLoaded}
         timeout={500}
         ref={imageContainerRef}
       >
-        <ImageListItem
-          component={Grid}
-          key={item.guid}
-          sx={{
-            cursor: 'pointer',
-            display: 'flex',
-            flexDirection: 'column',
-            flexGrow: 1,
-            paddingLeft: '8px !important',
-            paddingRight: '8px',
-            paddingTop: '8px',
-            borderRadiusTopLeft: '10px',
-            borderRadiusTopRight: '10px',
-            height: 'auto',
-            backgroundColor: (theme) =>
-              props.modalIndex === props.index
-                ? darkMode
-                  ? theme.palette.grey[800]
-                  : theme.palette.grey[400]
-                : 'transparent',
-            transition: 'background-color 350ms linear !important',
-            ...style,
-          }}
-          onClick={
-            hasChildren
-              ? handleClick
-              : (event: MouseEvent<HTMLDivElement>) => handleItem(event)
-          }
-          ref={ref}
-        >
-          {isInViewport && ( // To do: Eventually turn this itno isNearViewport so images load before they hit the viewport
-            <img
-              src={`${server.uri}${item.thumb}?X-Plex-Token=${server.accessToken}`}
-              width={100}
-              style={{ borderRadius: '5%', height: 'auto' }}
-            />
-          )}
-          <ImageListItemBar
-            title={item.title}
-            subtitle={
-              item.type !== 'movie' ? (
-                <span>{`${
-                  !isNaN(extractChildCount(item)) && extractChildCount(item)
-                } items`}</span>
-              ) : (
-                <span>{prettyItemDuration(item.duration)}</span>
-              )
+        <div>
+          <ImageListItem
+            component={Grid}
+            key={item.guid}
+            sx={{
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              flexGrow: 1,
+              paddingLeft: '8px !important',
+              paddingRight: '8px',
+              paddingTop: '8px',
+              borderRadiusTopLeft: '10px',
+              borderRadiusTopRight: '10px',
+              height: 'auto',
+              backgroundColor: (theme) =>
+                props.modalIndex === props.index
+                  ? darkMode
+                    ? theme.palette.grey[800]
+                    : theme.palette.grey[400]
+                  : 'transparent',
+              transition: 'background-color 350ms linear !important',
+              ...style,
+            }}
+            onClick={
+              hasChildren
+                ? handleClick
+                : (event: MouseEvent<HTMLDivElement>) => handleItem(event)
             }
-            position="below"
-            actionIcon={
-              <IconButton
-                sx={{ color: 'black' }}
-                aria-label={`star ${item.title}`}
-                onClick={(event: MouseEvent<HTMLButtonElement>) =>
-                  handleItem(event)
-                }
-              >
-                {selectedMediaIds.includes(item.guid) ? (
-                  <CheckCircle sx={{ color: darkMode ? '#fff' : '#000' }} />
+            ref={ref}
+          >
+            {isInViewport && ( // To do: Eventually turn this itno isNearViewport so images load before they hit the viewport
+              <img
+                src={`${server.uri}${item.thumb}?X-Plex-Token=${server.accessToken}`}
+                width={100}
+                style={{ borderRadius: '5%', height: 'auto' }}
+                onLoad={() => setImageLoaded(true)}
+              />
+            )}
+            <ImageListItemBar
+              title={item.title}
+              subtitle={
+                item.type !== 'movie' ? (
+                  <span>{`${
+                    !isNaN(extractChildCount(item)) && extractChildCount(item)
+                  } items`}</span>
                 ) : (
-                  <RadioButtonUnchecked
-                    sx={{ color: darkMode ? '#fff' : '#000' }}
-                  />
-                )}
-              </IconButton>
-            }
-            actionPosition="right"
-          />
-        </ImageListItem>
+                  <span>{prettyItemDuration(item.duration)}</span>
+                )
+              }
+              position="below"
+              actionIcon={
+                <IconButton
+                  sx={{ color: 'black' }}
+                  aria-label={`star ${item.title}`}
+                  onClick={(event: MouseEvent<HTMLButtonElement>) =>
+                    handleItem(event)
+                  }
+                >
+                  {selectedMediaIds.includes(item.guid) ? (
+                    <CheckCircle sx={{ color: darkMode ? '#fff' : '#000' }} />
+                  ) : (
+                    <RadioButtonUnchecked
+                      sx={{ color: darkMode ? '#fff' : '#000' }}
+                    />
+                  )}
+                </IconButton>
+              }
+              actionPosition="right"
+            />
+          </ImageListItem>
+        </div>
       </Fade>
     );
   },

--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -4,15 +4,17 @@ export function getImagesPerRow(
   containerWidth: number,
   imageWidth: number,
 ): number {
+  const roundedImageWidth = Math.round(imageWidth * 100) / 100;
+
   if (!imageWidth || !containerWidth) {
     return 9; // some default value
   }
-  return Math.floor(containerWidth / imageWidth);
+  return Math.round(((containerWidth / roundedImageWidth) * 100) / 100);
 }
 
 // Estimate the modal height to prevent div collapse while new modal images load
 export function getEstimatedModalHeight(
-  rowSize: number,
+  itemsPerRow: number,
   containerWidth: number,
   imageContainerWidth: number,
   listSize: number,
@@ -27,9 +29,6 @@ export function getEstimatedModalHeight(
     return 294; //default modal height for 1 row
   }
 
-  // const columns = getImagesPerRow(containerWidth, imageContainerWidth);
-  const columns = rowSize;
-
   // Magic Numbers
   // to do: eventually grab this data via refs just in case it changes in the future
   const inlineModalTopPadding = 16;
@@ -41,7 +40,7 @@ export function getEstimatedModalHeight(
   const heightPerItem =
     heightPerImage + listItemBarContainerHeight + imageContainerXPadding; // 54px
 
-  const rows = listSize < columns ? 1 : Math.ceil(listSize / columns);
+  const rows = listSize < itemsPerRow ? 1 : Math.ceil(listSize / itemsPerRow);
   //This is min-height so we only need to adjust it for visible rows since we
   //use interesectionObserver to load them in
   const maxRows = rows >= 3 ? 3 : rows;


### PR DESCRIPTION
- Fade now correctly works for PlexGridtem component
- Updated PlexGridItem to initiate Fade after the image has fully loaded (so Fade is visible to user)
- Fixes issue where rowSize calculation would be wrong, now rounding the number to make it match Grid calc.
-Cleaned up some variable naming in the modal utilities to make it easier to understand