### PR TITLE
Use child/leaf counts in Plex programming selector. Fixes #241

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       match-sorter:
         specifier: ^6.3.1
         version: 6.3.1
+      pluralize:
+        specifier: ^8.0.0
+        version: 8.0.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -488,6 +491,9 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.10
         version: 4.17.10
+      '@types/pluralize':
+        specifier: ^0.0.33
+        version: 0.0.33
       '@types/react':
         specifier: ^18.2.15
         version: 18.2.15
@@ -3012,6 +3018,10 @@ packages:
   /@types/parse-json@4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
     dev: false
+
+  /@types/pluralize@0.0.33:
+    resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
+    dev: true
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
@@ -8993,6 +9003,11 @@ packages:
       - encoding
       - supports-color
     dev: true
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /pony-cause@2.1.10:
     resolution: {integrity: sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==}

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -54,7 +54,15 @@ export function forProgramType<T>(
   };
 }
 
-export const forPlexMedia = <T>(choices: PerTypeCallback<PlexMedia, T>) => {
+export function forPlexMedia<T>(
+  choices:
+    | Omit<Required<PerTypeCallback<PlexMedia, T>>, 'default'>
+    | MarkRequired<PerTypeCallback<PlexMedia, T>, 'default'>,
+): (m: PlexMedia) => NonNullable<T>;
+export function forPlexMedia<T>(
+  choices: PerTypeCallback<PlexMedia, T>,
+): (m: PlexMedia) => T | null;
+export function forPlexMedia<T>(choices: PerTypeCallback<PlexMedia, T>) {
   return (m: PlexMedia) => {
     switch (m.type) {
       case 'movie':
@@ -89,4 +97,4 @@ export const forPlexMedia = <T>(choices: PerTypeCallback<PlexMedia, T>) => {
 
     return null;
   };
-};
+}

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
     "match-sorter": "^6.3.1",
+    "pluralize": "^8.0.0",
     "react": "^18.2.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.10",
+    "@types/pluralize": "^0.0.33",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/react-window": "^1.8.8",

--- a/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
+++ b/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
@@ -73,6 +73,7 @@ export function CustomShowProgrammingSelector() {
           type: 'custom-show',
           customShowId: selectedCustomShow.library.id,
           program: item,
+          childCount: selectedCustomShow.library.contentCount,
         });
       }
     },

--- a/web/src/store/programmingSelector/actions.ts
+++ b/web/src/store/programmingSelector/actions.ts
@@ -14,6 +14,7 @@ import {
 } from '../../helpers/plexSearchUtil.ts';
 import { forSelectedMediaType, groupSelectedMedia } from '../../helpers/util';
 import { SelectedLibrary, SelectedMedia } from './store';
+import { forPlexMedia } from '@tunarr/shared/util';
 
 export const setProgrammingListingServer = (
   server: PlexServerSettings | undefined,
@@ -89,6 +90,16 @@ export const addKnownMediaForServer = (
     return state;
   });
 
+const plexChildCount = forPlexMedia({
+  default: 1,
+  season: (s) => s.leafCount,
+  show: (s) => s.leafCount,
+  collection: (s) => {
+    const num = parseInt(s.childCount);
+    return isNaN(num) ? 1 : num;
+  },
+});
+
 export const addPlexSelectedMedia = (
   serverName: string,
   media: (PlexLibrarySection | PlexMedia)[],
@@ -98,6 +109,7 @@ export const addPlexSelectedMedia = (
       type: 'plex',
       server: serverName,
       guid: isPlexDirectory(m) ? m.uuid : m.guid,
+      childCount: isPlexDirectory(m) ? 1 : plexChildCount(m),
     }));
     state.selectedMedia = [...state.selectedMedia, ...newSelectedMedia];
   });

--- a/web/src/store/programmingSelector/store.ts
+++ b/web/src/store/programmingSelector/store.ts
@@ -10,12 +10,14 @@ export type PlexSelectedMedia = {
   type: 'plex';
   server: ServerName;
   guid: PlexItemGuid;
+  childCount?: number;
 };
 
 export type CustomShowSelectedMedia = {
   type: 'custom-show';
   customShowId: string;
   program: CustomProgram;
+  childCount?: number;
 };
 
 export type SelectedMedia = PlexSelectedMedia | CustomShowSelectedMedia;


### PR DESCRIPTION
Introduces 'pluralize' package since we were doing a lot of custom pluralization logic previously.

TODO: This doesn't handle custom shows - will add another commit for that.

Preview: 
<img width="997" alt="Screenshot 2024-04-07 at 1 14 21 PM" src="https://github.com/chrisbenincasa/tunarr/assets/1640671/d89f7b20-0271-4005-98a2-b9fcaea823ca">
