### PR TITLE
Fix modal image

### DIFF
--- a/web/src/components/ProgramDetailsDialog.tsx
+++ b/web/src/components/ProgramDetailsDialog.tsx
@@ -10,12 +10,12 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import { createExternalId } from '@tunarr/shared';
 import { forProgramType } from '@tunarr/shared/util';
 import { ChannelProgram } from '@tunarr/types';
 import { isUndefined } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { prettyItemDuration } from '../helpers/util';
-import { createExternalId } from '@tunarr/shared';
 
 type Props = {
   open: boolean;
@@ -40,6 +40,7 @@ export default function ProgramDetailsDialog({
   const [thumbLoadState, setThumbLoadState] =
     useState<ThumbLoadState>('loading');
   const imageRef = useRef<HTMLImageElement>(null);
+  console.log(thumbLoadState);
 
   const rating = useMemo(
     () =>
@@ -127,6 +128,8 @@ export default function ProgramDetailsDialog({
   }, [thumbUrl]);
 
   const onLoad = useCallback(() => {
+    console.log('test');
+
     setThumbLoadState('success');
   }, [setThumbLoadState]);
 
@@ -163,7 +166,6 @@ export default function ProgramDetailsDialog({
                   width={240}
                   src={thumbUrl ?? ''}
                   alt={formattedTitle(program)}
-                  loading="lazy"
                   onLoad={onLoad}
                   ref={imageRef}
                   sx={{

--- a/web/src/components/ProgramDetailsDialog.tsx
+++ b/web/src/components/ProgramDetailsDialog.tsx
@@ -40,7 +40,6 @@ export default function ProgramDetailsDialog({
   const [thumbLoadState, setThumbLoadState] =
     useState<ThumbLoadState>('loading');
   const imageRef = useRef<HTMLImageElement>(null);
-  console.log(thumbLoadState);
 
   const rating = useMemo(
     () =>
@@ -128,8 +127,6 @@ export default function ProgramDetailsDialog({
   }, [thumbUrl]);
 
   const onLoad = useCallback(() => {
-    console.log('test');
-
     setThumbLoadState('success');
   }, [setThumbLoadState]);
 


### PR DESCRIPTION
Images in modal stopped loading for some reason when this attribute was present.  The dialog is only mounted when an icon is clicked, so the Dialog will always be visible so the attribute shouldn't be a necessary optimization.  Removing it fixed the issue I was seeing.

Before:
<img width="670" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/544f4bbf-bf81-4904-a318-237cc79254f8">

After:
<img width="642" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/3b0e137d-b05c-41a9-b43f-017c37793471">

I confirmed via Network tab that no images load on page load and they only load individually when dialog is opened
