### PR TITLE
Simplify & optimize TV Guide + show album artwork for tracks in program modal

### DIFF
--- a/web/src/components/ProgramDetailsDialog.tsx
+++ b/web/src/components/ProgramDetailsDialog.tsx
@@ -14,8 +14,15 @@ import { createExternalId } from '@tunarr/shared';
 import { forProgramType } from '@tunarr/shared/util';
 import { ChannelProgram } from '@tunarr/types';
 import { isUndefined } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { prettyItemDuration } from '../helpers/util';
+import {
+  ReactEventHandler,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { isNonEmptyString, prettyItemDuration } from '../helpers/util';
 
 type Props = {
   open: boolean;
@@ -88,8 +95,17 @@ export default function ProgramDetailsDialog({
     () =>
       forProgramType({
         content: (p) => {
-          if (p.id && p.persisted) {
-            return `http://localhost:8000/api/programs/${p.id}/thumb?proxy=true`;
+          let url: string | undefined;
+          if (p.persisted) {
+            let id: string | undefined = p.id;
+            if (p.subtype === 'track' && isNonEmptyString(p.albumId)) {
+              id = p.albumId;
+            }
+            url = `http://localhost:8000/api/programs/${id}/thumb?proxy=true`;
+          }
+
+          if (isNonEmptyString(url)) {
+            return url;
           }
 
           let key = p.uniqueId;
@@ -119,6 +135,7 @@ export default function ProgramDetailsDialog({
   );
 
   const thumbUrl = program ? thumbnailImage(program) : null;
+  console.log(thumbUrl);
   const externalUrl = program ? externalLink(program) : null;
   const programSummary = program ? summary(program) : null;
 
@@ -130,7 +147,8 @@ export default function ProgramDetailsDialog({
     setThumbLoadState('success');
   }, [setThumbLoadState]);
 
-  const onError = useCallback(() => {
+  const onError: ReactEventHandler<HTMLImageElement> = useCallback((e) => {
+    console.error(e);
     setThumbLoadState('error');
   }, []);
 

--- a/web/src/helpers/util.ts
+++ b/web/src/helpers/util.ts
@@ -17,6 +17,7 @@ import duration from 'dayjs/plugin/duration';
 import {
   flatMap,
   isNumber,
+  isString,
   map,
   property,
   range,
@@ -412,4 +413,8 @@ export function scale(
   factor: number,
 ): number[] {
   return map(coll, (c) => c * factor);
+}
+
+export function isNonEmptyString(s: unknown): s is string {
+  return isString(s) && s.length > 0;
 }


### PR DESCRIPTION
* Consolidate types in TV Guide service to massively simplify the
  special cases there
* Reuse program conversion that the channel DB does so there is minimal
  divergence on what data is returned in the API
* Fix really nasty bug in the program helpers that calculates / updates
  groupings for new lineups --- it was disregarding tracks (and breaking
other things). All of this upsert logic should be solid, but it could
really use a cleanup. Funny enough, it's still pretty fast.
* Random code health things here and there
