### PR TITLE
Specific routes for channel edit tabs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
+    "topo": {
+      "dependsOn": ["^topo"]
+    },
     "clean": {},
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["build/**", "dist/**"]
-    },
-    "clean-build": {
-      "dependsOn": ["clean", "build"],
       "outputs": ["build/**", "dist/**"]
     },
     "bundle": {

--- a/web/src/components/channel_config/ChannelEpgConfig.tsx
+++ b/web/src/components/channel_config/ChannelEpgConfig.tsx
@@ -44,6 +44,7 @@ export default function ChannelEpgConfig() {
                 label="Placeholder Program Title"
                 margin="normal"
                 {...field}
+                value={field.value ?? ''}
               />
             )}
           />

--- a/web/src/hooks/useRouteName.ts
+++ b/web/src/hooks/useRouteName.ts
@@ -30,6 +30,18 @@ const namedRoutes: Route[] = [
     name: 'Edit',
   },
   {
+    matcher: channelsPageMatcher('edit/flex'),
+    name: 'Flex',
+  },
+  {
+    matcher: channelsPageMatcher('edit/ffmpeg'),
+    name: 'FFMPEG',
+  },
+  {
+    matcher: channelsPageMatcher('edit/epg'),
+    name: 'EPG',
+  },
+  {
     matcher: customShowsPageMatcher('edit'),
     name: 'Edit',
   },

--- a/web/src/preloaders/channelLoaders.ts
+++ b/web/src/preloaders/channelLoaders.ts
@@ -19,10 +19,7 @@ export const newChannelLoader: Preloader<Channel[]> = createPreloader(() =>
 );
 
 // Default channel values that aren't dynamic
-export const DefaultChannel: Omit<
-  Channel,
-  'id' | 'name' | 'number' | 'startTime'
-> = {
+export const DefaultChannel = {
   duration: 0,
   icon: {
     duration: 0,
@@ -39,7 +36,7 @@ export const DefaultChannel: Omit<
     mode: 'pic',
     picture: 'http://localhost:8000/images/generic-offline-screen.png',
   },
-};
+} as const;
 
 export function defaultNewChannel(num: number): Channel {
   return {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -39,6 +39,7 @@ import {
   newFillerListLoader,
 } from './preloaders/fillerListLoader.ts';
 import { queryCache } from './queryClient.ts';
+import { map } from 'lodash-es';
 
 const queryClient = new QueryClient({ queryCache });
 
@@ -78,6 +79,11 @@ export const router = createBrowserRouter(
           element: <EditChannelPage isNew={false} />,
           loader: editChannelLoader(false)(queryClient),
         },
+        ...map(['flex', 'epg', 'ffmpeg'] as const, (panel) => ({
+          path: '/channels/:id/edit/' + panel,
+          element: <EditChannelPage isNew={false} initialTab={panel} />,
+          loader: editChannelLoader(false)(queryClient),
+        })),
         {
           path: '/channels/new',
           element: <EditChannelPage isNew={true} />,

--- a/web/turbo.json
+++ b/web/turbo.json
@@ -5,6 +5,9 @@
     "build-dev": {
       "dependsOn": ["^build"]
     },
+    "clean-build": {
+      "dependsOn": ["^build"]
+    },
     "bundle": {
       "dependsOn": ["^bundle"]
     },


### PR DESCRIPTION
* In "edit" mode only (existing channel), each tab now has its own route. This is so we can potentially deep-link to specific settings for channels from other parts of the app
* Updates breadcrumbs for these pages
* Reorders the flex edit page; puts filler content above fallback
* Disables the 'clip' filler fallback option and mentions that it is currently unimplemented
* Fixes a bug in handling the filler cooldown value coming from the server (milliseconds) vs what can be configured / displayed in the frontend (seconds). Also adds validation to that form input
