### PR TITLE
Fixes missing channel edit actions for FFMPEG

### DIFF
--- a/web/src/components/channel_config/ChannelEditActions.tsx
+++ b/web/src/components/channel_config/ChannelEditActions.tsx
@@ -1,9 +1,9 @@
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
-import { useContext } from 'react';
-import { ChannelEditContext } from '../../pages/channels/EditChannelContext.ts';
-import { useFormContext } from 'react-hook-form';
 import { SaveChannelRequest } from '@tunarr/types';
+import { useContext } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ChannelEditContext } from '../../pages/channels/EditChannelContext.ts';
 
 export default function ChannelEditActions() {
   const { channelEditorState } = useContext(ChannelEditContext)!;
@@ -17,7 +17,7 @@ export default function ChannelEditActions() {
       {!channelEditorState.isNewChannel ? (
         <>
           <Button onClick={() => reset()} variant="outlined">
-            Reset Options
+            Reset Changes
           </Button>
           <Button disabled={!isValid} variant="contained" type="submit">
             Save

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
 import { SaveChannelRequest, Watermark } from '@tunarr/types';
 import { isEmpty, isNil, isUndefined, map, round } from 'lodash-es';
 import { useEffect, useState } from 'react';
@@ -25,13 +26,13 @@ import {
   typedProperty,
 } from '../../helpers/util.ts';
 import { useFfmpegSettings } from '../../hooks/settingsHooks.ts';
+import useStore from '../../store/index.ts';
+import { ImageUploadInput } from '../settings/ImageUploadInput.tsx';
 import {
   CheckboxFormController,
   NumericFormControllerText,
 } from '../util/TypedController.tsx';
-import { ImageUploadInput } from '../settings/ImageUploadInput.tsx';
-import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
-import useStore from '../../store/index.ts';
+import ChannelEditActions from './ChannelEditActions.tsx';
 
 const resolutionOptions = [
   { value: '420x420', label: '420x420 (1:1)' },
@@ -421,6 +422,7 @@ export default function ChannelTranscodingConfig() {
             )}
           </FormControl>
         </Stack>
+        <ChannelEditActions />
       </Box>
     )
   );


### PR DESCRIPTION
There was previously no way to save the FFMPEG settings as there were no edit actions on that screen

Before Fix:
<img width="1386" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/2fd9395c-3858-4ab4-b8ca-c47ed52a4587">

With Fix:
<img width="1400" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/f27690ad-5490-46db-a631-2aaf14c7a8dc">

Note: I am going to add the same logic here that I did on the main setting pages (disable save when not needed etc).  I'll do it in another PR tho, just wanted to get this fix in.