### PR TITLE
User Actions on Programming Page

### DIFF
--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -1,14 +1,10 @@
-import { Box, Button, Paper, Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
 import { createContext, useState } from 'react';
 import { useSlideSchedule } from '../../hooks/programming_controls/useSlideSchedule.ts';
 import { usePreloadedChannelEdit } from '../../hooks/usePreloadedChannel.ts';
-import {
-  resetLineup,
-  setChannelStartTime,
-} from '../../store/channelEditor/actions.ts';
-import useStore from '../../store/index.ts';
+import { setChannelStartTime } from '../../store/channelEditor/actions.ts';
 import AddProgrammingButton from './AddProgrammingButton.tsx';
 import AdjustScheduleControls from './AdjustScheduleControls.tsx';
 import ChannelProgrammingList from './ChannelProgrammingList.tsx';
@@ -28,7 +24,6 @@ export const ScheduleControlsContext = createContext<ScheduleControlsType>({
 export function ChannelProgrammingConfig() {
   const { currentEntity: channel } = usePreloadedChannelEdit();
 
-  const programsDirty = useStore((s) => s.channelEditor.dirty.programs);
   const slideSchedule = useSlideSchedule();
 
   const handleStartTimeChange = (value: Dayjs | null) => {
@@ -56,60 +51,52 @@ export function ChannelProgrammingConfig() {
       }}
     >
       <Box display="flex" flexDirection="column">
-        <Paper sx={{ p: 2 }}>
-          <Box display="flex" justifyContent={'flex-start'}></Box>
+        <Box display="flex" justifyContent={'flex-start'}></Box>
 
-          <Stack
-            direction={{ xs: 'column', sm: 'row' }}
-            gap={{ xs: 1 }}
-            sx={{
-              display: 'flex',
-              pt: 1,
-              mb: 2,
-              columnGap: 1,
-              alignItems: 'center',
-            }}
-          >
-            <Box sx={{ mr: { sm: 2 }, flexGrow: 1 }}>
-              <DateTimePicker
-                label="Programming Start"
-                value={startTime}
-                onChange={(newDateTime) => handleStartTimeChange(newDateTime)}
-                slotProps={{ textField: { size: 'small' } }}
-              />
-            </Box>
-            {showScheduleControls && (
-              <Stack
-                direction={{ xs: 'column', sm: 'row' }}
-                sx={{
-                  display: 'flex',
-                  pt: 1,
-                  mb: 2,
-                  columnGap: 1,
-                  alignItems: 'center',
-                  justifyContent: 'flex-end',
-                  flexGrow: 1,
-                }}
-              >
-                <AdjustScheduleControls />
-              </Stack>
-            )}
-            <Button
-              variant="contained"
-              onClick={() => resetLineup()}
-              disabled={!programsDirty}
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          gap={{ xs: 1 }}
+          sx={{
+            display: 'flex',
+            pt: 1,
+            mb: 2,
+            columnGap: 1,
+            alignItems: 'center',
+          }}
+        >
+          <Box sx={{ mr: { sm: 2 }, flexGrow: 1 }}>
+            <DateTimePicker
+              label="Programming Start"
+              value={startTime}
+              onChange={(newDateTime) => handleStartTimeChange(newDateTime)}
+              slotProps={{ textField: { size: 'small' } }}
+            />
+          </Box>
+          {showScheduleControls && (
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              sx={{
+                display: 'flex',
+                pt: 1,
+                mb: 2,
+                columnGap: 1,
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                flexGrow: 1,
+              }}
             >
-              Reset
-            </Button>
-            <ChannelProgrammingTools />
-            <ChannelProgrammingSort />
-            <AddProgrammingButton />
-          </Stack>
+              <AdjustScheduleControls />
+            </Stack>
+          )}
 
-          <ChannelProgrammingList
-            virtualListProps={{ width: '100%', height: 600, itemSize: 35 }}
-          />
-        </Paper>
+          <ChannelProgrammingTools />
+          <ChannelProgrammingSort />
+          <AddProgrammingButton />
+        </Stack>
+
+        <ChannelProgrammingList
+          virtualListProps={{ width: '100%', height: 600, itemSize: 35 }}
+        />
       </Box>
     </ScheduleControlsContext.Provider>
   );

--- a/web/src/pages/channels/ChannelProgrammingPage.tsx
+++ b/web/src/pages/channels/ChannelProgrammingPage.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  Paper,
   Snackbar,
   Typography,
 } from '@mui/material';
@@ -11,14 +12,17 @@ import { UpdateChannelProgrammingRequest } from '@tunarr/types/api';
 import { ZodiosError } from '@zodios/core';
 import { chain, findIndex, first, isUndefined, map } from 'lodash-es';
 import { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
 import { ChannelProgrammingConfig } from '../../components/channel_config/ChannelProgrammingConfig.tsx';
 import { apiClient } from '../../external/api.ts';
 import { channelProgramUniqueId } from '../../helpers/util.ts';
 import { usePreloadedChannelEdit } from '../../hooks/usePreloadedChannel.ts';
 import { useUpdateChannel } from '../../hooks/useUpdateChannel.ts';
-import { resetCurrentLineup } from '../../store/channelEditor/actions.ts';
+import {
+  resetCurrentLineup,
+  resetLineup,
+} from '../../store/channelEditor/actions.ts';
+import useStore from '../../store/index.ts';
 
 type MutateArgs = {
   channelId: string;
@@ -37,6 +41,8 @@ export default function ChannelProgrammingPage() {
     originalEntity: originalChannel,
     programList: newLineup,
   } = usePreloadedChannelEdit();
+
+  const programsDirty = useStore((s) => s.channelEditor.dirty.programs);
 
   const queryClient = useQueryClient();
   const theme = useTheme();
@@ -148,15 +154,30 @@ export default function ChannelProgrammingPage() {
       <Typography variant="h4" sx={{ mb: 2 }}>
         Channel {channel.number} Programming
       </Typography>
-      <ChannelProgrammingConfig />
-      <Box sx={{ display: 'flex', justifyContent: 'end', pt: 1, columnGap: 1 }}>
-        <Button variant="contained" to="/channels" component={RouterLink}>
-          Cancel
-        </Button>
-        <Button variant="contained" onClick={() => onSave()}>
-          Save
-        </Button>
-      </Box>
+      <Paper sx={{ p: 2 }}>
+        <ChannelProgrammingConfig />
+
+        <Box
+          sx={{ display: 'flex', justifyContent: 'end', pt: 1, columnGap: 1 }}
+        >
+          {programsDirty && (
+            <Button
+              variant="contained"
+              onClick={() => resetLineup()}
+              disabled={!programsDirty}
+            >
+              Reset Changes
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            onClick={() => onSave()}
+            disabled={!programsDirty}
+          >
+            Save
+          </Button>
+        </Box>
+      </Paper>
     </div>
   );
 }


### PR DESCRIPTION
- Moved user Actions (Save/Reset) inside of the Paper element to be more consistent with the rest of the App
- Removed the "Cancel" button
- Moved the "Reset" button from the top nav of the programming to be next to "Save".  This feels a little more consistant with the rest of the Apps.  An argument could be made here on having something to reset at the top as well, this page is tricky because of the fixed height container of programming elements 
- Disable the Save button when nothing has changed

Screenshot (after making a change):
<img width="1265" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/579085b6-4eca-46ed-941f-13fbdfebc826">

Screenshot before a change is made:
<img width="1257" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/f1541000-e330-48f6-ad79-9d79c7df2ee9">

