### PR TITLE
docker ffmpeg updates

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -55,15 +55,21 @@ RUN pnpm turbo --filter=@tunarr/server bundle
 FROM sources AS build-web
 # Install deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-# Build common modules
+# Build and bundle
 RUN pnpm turbo --filter=@tunarr/web bundle
+
+### Experimental: Build a SEA
+FROM build-server AS build-exec
+COPY --from=build-server /tunarr/server/node_modules /tunarr/server/node_modules
+COPY --from=build-server /tunarr/server/build /tunarr/server/build
+RUN pnpm run --filter=server make-exec
+###
 
 FROM sources as build-full-stack
 # Install deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 # Build common modules
 RUN pnpm turbo bundle
-
 
 ### Begin server run ###
 FROM ffmpeg-base AS server

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,15 +1,35 @@
-FROM node:20-alpine3.19 AS base
+# Setup a node + ffmpeg base
+FROM jasongdove/ersatztv-ffmpeg:7.0 AS ffmpeg-base
 
-# Update
-RUN apk add --no-cache libc6-compat
-RUN apk update
+ENV NODE_MAJOR=20
+ENV TUNARR_BIND_ADDR=0.0.0.0
+EXPOSE 8000
 
+# Install musl for native node bindings (sqlite)
+RUN apt-get update --fix-missing
+RUN apt-get install -y musl-dev
+RUN ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
+
+# Install node
+RUN <<EOF 
+apt-get update && apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+apt-get update && apt-get install nodejs -y
+EOF
+
+# Install pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-
 RUN corepack enable
 
-FROM base as sources
+EXPOSE 8000
+RUN ln -s /usr/local/bin/ffmpeg /usr/bin/ffmpeg
+ENTRYPOINT [ "node" ]
+
+# Add Tunarr sources
+FROM ffmpeg-base as sources
 WORKDIR /tunarr
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY server/ ./server
@@ -35,29 +55,34 @@ RUN pnpm turbo --filter=@tunarr/server bundle
 FROM sources AS build-web
 # Install deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-# Build and bundle
+# Build common modules
 RUN pnpm turbo --filter=@tunarr/web bundle
 
-### Experimental: Build a SEA
-FROM build-server AS build-exec
-COPY --from=build-server /tunarr/server/node_modules /tunarr/server/node_modules
-COPY --from=build-server /tunarr/server/build /tunarr/server/build
-RUN pnpm run --filter=server make-exec
-###
+FROM sources as build-full-stack
+# Install deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+# Build common modules
+RUN pnpm turbo bundle
+
 
 ### Begin server run ###
-FROM base AS server
+FROM ffmpeg-base AS server
 COPY --from=prod-deps /tunarr/node_modules /tunarr/node_modules
 COPY --from=prod-deps /tunarr/server/node_modules /tunarr/server/node_modules
 COPY --from=build-server /tunarr/types /tunarr/types
 COPY --from=build-server /tunarr/shared /tunarr/shared
 COPY --from=build-server /tunarr/server/package.json /tunarr/server/package.json
 COPY --from=build-server /tunarr/server/build /tunarr/server/build
-ENV TUNARR_BIND_ADDR=0.0.0.0
-EXPOSE 8000
 CMD [ "/tunarr/server/build/bundle.js" ]
 ### Begin server run
 
 ### Full stack ###
-FROM server AS full-stack
-COPY --from=build-web /tunarr/web/dist /tunarr/server/build/web
+FROM ffmpeg-base AS full-stack
+COPY --from=prod-deps /tunarr/node_modules /tunarr/node_modules
+COPY --from=prod-deps /tunarr/server/node_modules /tunarr/server/node_modules
+COPY --from=build-full-stack /tunarr/types /tunarr/types
+COPY --from=build-full-stack /tunarr/shared /tunarr/shared
+COPY --from=build-full-stack /tunarr/server/package.json /tunarr/server/package.json
+COPY --from=build-full-stack /tunarr/server/build /tunarr/server/build
+COPY --from=build-full-stack /tunarr/web/dist /tunarr/server/build/web
+CMD [ "/tunarr/server/build/bundle.js" ]

--- a/nvidia.Dockerfile
+++ b/nvidia.Dockerfile
@@ -37,6 +37,14 @@ COPY types ./types
 COPY web ./web
 COPY patches ./patches
 
+FROM ffmpeg-base as dev
+EXPOSE 5173
+WORKDIR /tunarr
+COPY . .
+RUN pnpm install --frozen-lockfile
+ENTRYPOINT [ "pnpm" ]
+CMD [ "turbo", "dev" ]
+
 FROM sources AS prod-deps
 ARG NODE_ENVIRONMENT
 ENV NODE_ENV=${NODE_ENVIRONMENT:-production}


### PR DESCRIPTION
This updates the base (edge) docker image to include ffmpeg, and to look more like the NVIDIA one that appears to be working. I ran into entrypoint problems (would drop me in node or ffmpeg) without the same full-stack stuff at the end.

It also updates the NVIDIA docker image to use a base image compiled against CUDA 11 https://github.com/ErsatzTV/ErsatzTV-ffmpeg/blob/ae3e97bc86a5c1eb78dbe401a4c4a04cca4d8938/nvidia.Dockerfile#L1 vs CUDA 12 https://github.com/jrottenberg/ffmpeg/blob/416b0cae4ab3f251385eee9f89c22e66efca6bfd/docker-images/6.1/nvidia2204/Dockerfile#L9 which greatly lowers the NVIDIA driver requirements. Note that this also changes from Ubuntu 22.04 to Ubuntu 20.04.