### PR TITLE
Fix static /web routing when webapp served from backend

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,3 +5,5 @@ out/
 temp/
 streams/
 *.log
+**/web/
+*.zip


### PR DESCRIPTION
Fixes #318

This previously only worked if the user first hit the '/web' path, but
not any other paths directly, such as '/web/channels'. The fix takes
advantage of fastify's setNotFoundHandler function to serve the default
index file for any path where a static asset (e.g. CSS/JS) is not found.

Tested on a local docker image build and confirmed I could hit various
web pages directly.
