### PR TITLE
Fix 'Remove Duplicates' Functionality

### DIFF
--- a/web/src/hooks/programming_controls/useRemoveDuplicates.ts
+++ b/web/src/hooks/programming_controls/useRemoveDuplicates.ts
@@ -9,7 +9,7 @@ export const useRemoveDuplicates = () => {
   return () => {
     if (programs.length > 0) {
       const newPrograms = removeDuplicatePrograms(programs);
-      setCurrentLineup(newPrograms);
+      setCurrentLineup(newPrograms, true);
     }
   };
 };
@@ -30,6 +30,6 @@ export const removeDuplicatePrograms = (programs: ChannelProgram[]) => {
       return false;
     }
 
-    return seenCount[uniqueId]++ === 1;
+    return seenCount[uniqueId]++ === 0;
   });
 };


### PR DESCRIPTION
- Makes the list dirty after duplicates are removed so user can undo it if necessary
- Start at 0 to ensure we aren't deleting anything that only has 1 occurrence. 

Remove Duplicate Functionality is still broken when dealing with dirty lists.  Once issue https://github.com/chrisbenincasa/tunarr/issues/327 is resolved I will update this PR to include that fix as well