### PR TITLE
use relative paths in hls playlist to fix remote playback

### DIFF
--- a/server/src/ffmpeg.ts
+++ b/server/src/ffmpeg.ts
@@ -233,9 +233,6 @@ export class FFMPEG extends (events.EventEmitter as new () => TypedEventEmitter<
         'mpegts',
         '-hls_flags',
         'delete_segments',
-        '-hls_base_url',
-        // TODO We should be smarter about which host we use here.
-        `http://localhost:8000/streams/${hlsOpts.streamBasePath}/`,
         '-hls_segment_filename',
         path.join('streams', hlsOpts.streamBasePath, hlsOpts.segmentNameFormat),
         '-master_pl_name',


### PR DESCRIPTION
This shouldn't be needed because playlist paths are assumed to be relative, if not absolute.

> A URI in a Playlist, whether it is a URI line or part of a tag, MAY
>    be relative.  Any relative URI is considered to be relative to the
>    URI of the Playlist that contains it.

Before this change, watching the channel in the browser would fail against a remote tunarr instance.

---

Note that I also had to disable the pre-commit hook to commit this; I probably have something configured incorrectly, but end up with:

```shell
% git commit -m "use relative paths in hls playlist to fix remote playback"

> @tunarr/server@0.1.0 lint-staged /home/jason/code/jasongdove/tunarr/server
> lint-staged

✔ Preparing lint-staged...
⚠ Running tasks for staged files...
  ❯ package.json — 1 file
    ❯ *.ts — 1 file
      ✖ eslint --fix --no-warn-ignored [FAILED]
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ eslint --fix --no-warn-ignored:

/home/jason/code/jasongdove/tunarr/server/src/ffmpeg.ts
  0:0  error  Parsing error: Cannot read file '/home/jason/code/jasongdove/tunarr/server/server/tsconfig.json'

✖ 1 problem (1 error, 0 warnings)

/home/jason/code/jasongdove/tunarr/server:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @tunarr/server@0.1.0 lint-staged: `lint-staged`
Exit status 1
```