### PR TITLE
Serve HLS segments on /hls prefix in addition to /streams. Fixes #339

### DIFF
--- a/server/src/stream/session.ts
+++ b/server/src/stream/session.ts
@@ -277,6 +277,10 @@ export class StreamSession {
     }, delay);
   }
 
+  get workingDirectory() {
+    return this.#outPath;
+  }
+
   get streamPath() {
     return this.#streamPath;
   }

--- a/server/src/types/fastify.d.ts
+++ b/server/src/types/fastify.d.ts
@@ -6,6 +6,10 @@ declare module 'fastify' {
     serverCtx: ServerContext;
     entityManager: EntityManager;
 
+    // Present when the request is identified as part of
+    // an HLS session.
     streamChannel?: string;
+
+    disableRequestLogging?: boolean;
   }
 }

--- a/web/src/components/Video.tsx
+++ b/web/src/components/Video.tsx
@@ -68,7 +68,7 @@ export default function Video({ channelId }: VideoProps) {
     if ((autoPlayEnabled || manuallyStarted) && video && hls && canLoadStream) {
       setLoadedStream(true);
       apiClient
-        .startHlsStream({ params: { channel: channelId } })
+        .startHlsStream(undefined, { params: { channel: channelId } })
         .then(({ streamPath }) => {
           hls.loadSource(`${backendUri}${streamPath}`);
           hls.attachMedia(video);

--- a/web/src/external/api.ts
+++ b/web/src/external/api.ts
@@ -313,11 +313,12 @@ export const api = makeApi([
     response: FillerListSchema,
   },
   {
-    method: 'get',
+    method: 'put',
     path: '/media-player/:channel/hls',
     alias: 'startHlsStream',
     parameters: parametersBuilder()
       .addPath('channel', z.coerce.number().or(z.string().uuid()))
+      .addBody(z.undefined())
       .build(),
     status: 200,
     response: z.object({ streamPath: z.string() }),


### PR DESCRIPTION
In addition, we change the URLs a little:

* GET /media-player/:channelId/hls -- this will now get/start an HLS
  stream and return the playlist file directly
* PUT /media-player/:channelId/hls -- this will get/start an HLS stream
  but return a JSON result of the stream URL. Suitable for browser and
  HLS.js
* GET /media-player/:channelId/hls/:file -- the main part of the change,
  serves the HLS segments directly as referenced relatively by the
playlist
