### PR TITLE
Support music tracks in program_grouping backfill. Fixes #340 

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -84,6 +84,7 @@ export async function initServer(opts: ServerOptions) {
 
   const ctx = await serverContext();
 
+  console.log(ctx.settings, opts);
   if (
     hadLegacyDb &&
     (ctx.settings.needsLegacyMigration() || opts.force_migration)

--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -1,5 +1,6 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import Edit from '@mui/icons-material/Edit';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import MusicNote from '@mui/icons-material/MusicNote';
 import TheatersIcon from '@mui/icons-material/Theaters';
@@ -13,16 +14,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { forProgramType } from '@tunarr/shared/util';
 import { ChannelProgram } from '@tunarr/types';
 import dayjs from 'dayjs';
-import {
-  findIndex,
-  isEmpty,
-  isNil,
-  isUndefined,
-  join,
-  map,
-  overSome,
-  reject,
-} from 'lodash-es';
+import { findIndex, isUndefined, join, map, negate, reject } from 'lodash-es';
 import { CSSProperties, useCallback, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import {
@@ -31,7 +23,11 @@ import {
   ListChildComponentProps,
 } from 'react-window';
 import { betterHumanize } from '../../helpers/dayjs.ts';
-import { alternateColors, channelProgramUniqueId } from '../../helpers/util.ts';
+import {
+  alternateColors,
+  channelProgramUniqueId,
+  isNonEmptyString,
+} from '../../helpers/util.ts';
 import {
   deleteProgram,
   moveProgramInCurrentChannel,
@@ -44,7 +40,6 @@ import {
   UIRedirectProgram,
 } from '../../types/index.ts';
 import ProgramDetailsDialog from '../ProgramDetailsDialog.tsx';
-import Edit from '@mui/icons-material/Edit';
 import AddFlexModal from '../programming_controls/AddFlexModal.tsx';
 import AddRedirectModal from '../programming_controls/AddRedirectModal.tsx';
 
@@ -107,7 +102,7 @@ const programListItemTitleFormatter = (() => {
           return join(
             reject(
               [p.artistName, p.albumName, p.title],
-              overSome(isNil, isEmpty),
+              negate(isNonEmptyString),
             ),
             ' - ',
           );

--- a/web/src/store/channelEditor/actions.ts
+++ b/web/src/store/channelEditor/actions.ts
@@ -282,6 +282,8 @@ const plexMediaToContentProgram = (
     episodeTitle: media.type === 'episode' ? media.title : undefined,
     episodeNumber: media.type === 'episode' ? media.index : undefined,
     seasonNumber: media.type === 'episode' ? media.parentIndex : undefined,
+    artistName: media.type === 'track' ? media.grandparentTitle : undefined,
+    albumName: media.type === 'track' ? media.parentTitle : undefined,
     showId:
       media.showId ??
       (media.type === 'episode'


### PR DESCRIPTION
- **Fill in artist/album name details for unpersisted Plex items in Program list**
- **Support music tracks in program_grouping backfill. Fixes #340**
