### PR TITLE
Use 'hls/' as hls_base_url

### DIFF
--- a/server/src/api/hlsApi.ts
+++ b/server/src/api/hlsApi.ts
@@ -173,7 +173,6 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
       }
 
       if (req.query.direct) {
-        console.log(session.serverPath);
         return res.redirect(302, `${session.serverPath}?token=${token}`);
       }
 

--- a/server/src/api/hlsApi.ts
+++ b/server/src/api/hlsApi.ts
@@ -132,7 +132,9 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         return res.status(500).send('Error starting session');
       }
 
-      return res.type('text').send(await fs.readFile(session.streamPath));
+      return res
+        .type('application/vnd.apple.mpegurl')
+        .send(await fs.readFile(session.streamPath));
     },
   );
 
@@ -142,9 +144,6 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
       schema: {
         params: z.object({
           channelId: z.coerce.number().or(z.string().uuid()),
-        }),
-        querystring: z.object({
-          direct: TruthyQueryParam.optional().default('0'),
         }),
       },
     },
@@ -170,10 +169,6 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
 
       if (isNil(session)) {
         return res.status(500).send('Error starting session');
-      }
-
-      if (req.query.direct) {
-        return res.redirect(302, `${session.serverPath}?token=${token}`);
       }
 
       return res.send({

--- a/server/src/ffmpeg.ts
+++ b/server/src/ffmpeg.ts
@@ -233,6 +233,8 @@ export class FFMPEG extends (events.EventEmitter as new () => TypedEventEmitter<
         'mpegts',
         '-hls_flags',
         'delete_segments',
+        '-hls_base_url',
+        'hls/',
         '-hls_segment_filename',
         path.join('streams', hlsOpts.streamBasePath, hlsOpts.segmentNameFormat),
         '-master_pl_name',

--- a/server/src/stream/session.ts
+++ b/server/src/stream/session.ts
@@ -47,7 +47,8 @@ export class StreamSession {
       `stream_${this.#channel.uuid}`,
     );
     this.#streamPath = join(this.#outPath, 'stream.m3u8');
-    this.#serverPath = `/streams/stream_${this.#channel.uuid}/stream.m3u8`;
+    // Direct players back to the /hls URL which will return the playlist
+    this.#serverPath = `/media-player/${this.#channel.uuid}/hls`;
   }
 
   static create(channel: Channel, ffmpegSettings: FfmpegSettings) {


### PR DESCRIPTION
Changes the session to return /media-player/:channelId/hls as the 'serverPath' used by clients who start their HLS session using the PUT /media-player/:channelId/hls endpoint (in theory we could probably get rid of this completely now and just have the client reissue a GET request to the same endpoint, but this gives us some future flexibility)

Sessions started directly on GET /media-player/:channelId/hls should
work as intended now, too.

![image](https://github.com/chrisbenincasa/tunarr/assets/1640671/a7f9849a-ba09-4005-bc0e-745f568da0f7)

