### PR TITLE
Adds loading indicator when adding media

### DIFF
--- a/web/src/components/channel_config/AddSelectedMediaButton.tsx
+++ b/web/src/components/channel_config/AddSelectedMediaButton.tsx
@@ -1,17 +1,18 @@
-import { Tooltip } from '@mui/material';
+import { AddCircle } from '@mui/icons-material';
+import { CircularProgress, Tooltip } from '@mui/material';
 import Button, { ButtonProps } from '@mui/material/Button';
 import { flattenDeep, map } from 'lodash-es';
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useState } from 'react';
 import {
   forSelectedMediaType,
   sequentialPromises,
 } from '../../helpers/util.ts';
 import { enumeratePlexItem } from '../../hooks/plexHooks.ts';
+import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
 import useStore from '../../store/index.ts';
 import { clearSelectedMedia } from '../../store/programmingSelector/actions.ts';
 import { CustomShowSelectedMedia } from '../../store/programmingSelector/store.ts';
 import { AddedCustomShowProgram, AddedMedia } from '../../types/index.ts';
-import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
 
 type Props = {
   onAdd: (items: AddedMedia[]) => void;
@@ -26,10 +27,12 @@ export default function AddSelectedMediaButton({
   const apiClient = useTunarrApi();
   const knownMedia = useStore((s) => s.knownMediaByServer);
   const selectedMedia = useStore((s) => s.selectedMedia);
+  const [isLoading, setIsLoading] = useState(false);
 
   const addSelectedItems: MouseEventHandler = (e) => {
     e.preventDefault();
     e.stopPropagation();
+    setIsLoading(true);
     sequentialPromises(
       selectedMedia,
       forSelectedMediaType<Promise<AddedMedia[]>>({
@@ -61,6 +64,7 @@ export default function AddSelectedMediaButton({
       .then(onAdd)
       .then(() => {
         clearSelectedMedia();
+        setIsLoading(false);
         onSuccess();
       })
       .catch(console.error);
@@ -71,8 +75,15 @@ export default function AddSelectedMediaButton({
       <span>
         <Button
           onClick={(e) => addSelectedItems(e)}
-          disabled={selectedMedia.length === 0}
+          disabled={selectedMedia.length === 0 || isLoading}
           {...(rest ?? {})}
+          startIcon={
+            isLoading ? (
+              <CircularProgress size="20px" sx={{ mx: 1, color: '#fff' }} />
+            ) : (
+              <AddCircle />
+            )
+          }
         >
           Add All
         </Button>

--- a/web/src/components/channel_config/ChannelEditActions.tsx
+++ b/web/src/components/channel_config/ChannelEditActions.tsx
@@ -1,3 +1,5 @@
+import { Save } from '@mui/icons-material';
+import { CircularProgress } from '@mui/material';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import { SaveChannelRequest } from '@tunarr/types';
@@ -8,7 +10,7 @@ import { ChannelEditContext } from '../../pages/channels/EditChannelContext.ts';
 export default function ChannelEditActions() {
   const { channelEditorState } = useContext(ChannelEditContext)!;
   const {
-    formState: { isValid, isDirty },
+    formState: { isValid, isDirty, isSubmitting },
     reset,
   } = useFormContext<SaveChannelRequest>();
 
@@ -22,16 +24,34 @@ export default function ChannelEditActions() {
             </Button>
           )}
           <Button
-            disabled={!isValid || !isDirty}
+            disabled={!isValid || !isDirty || isSubmitting}
             variant="contained"
             type="submit"
+            startIcon={
+              isSubmitting ? (
+                <CircularProgress size="20px" sx={{ mx: 1, color: '#fff' }} />
+              ) : (
+                <Save />
+              )
+            }
           >
             Save
           </Button>
         </>
       ) : (
         <>
-          <Button disabled={!isValid} variant="contained" type="submit">
+          <Button
+            disabled={!isValid || isSubmitting}
+            variant="contained"
+            type="submit"
+            startIcon={
+              isSubmitting ? (
+                <CircularProgress size="20px" sx={{ mx: 1, color: '#fff' }} />
+              ) : (
+                <Save />
+              )
+            }
+          >
             Save
           </Button>
         </>

--- a/web/src/components/channel_config/SelectedProgrammingList.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingList.tsx
@@ -1,4 +1,4 @@
-import { AddCircle, Delete } from '@mui/icons-material';
+import { Delete } from '@mui/icons-material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {
   Box,
@@ -171,7 +171,6 @@ export default function SelectedProgrammingList({
 
           <AddSelectedMediaButton
             onAdd={onAddSelectedMedia}
-            startIcon={<AddCircle />}
             onSuccess={onAddMediaSuccess}
             sx={{
               color: '#fff',

--- a/web/src/pages/channels/ChannelProgrammingPage.tsx
+++ b/web/src/pages/channels/ChannelProgrammingPage.tsx
@@ -1,3 +1,4 @@
+import { Save } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -48,6 +49,7 @@ export default function ChannelProgrammingPage() {
   const apiClient = useTunarrApi();
   const queryClient = useQueryClient();
   const theme = useTheme();
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const [snackStatus, setSnackStatus] = useState<SnackBar>({
     display: false,
@@ -65,6 +67,7 @@ export default function ChannelProgrammingPage() {
     },
     onSuccess: async (data, { channelId: channelNumber }) => {
       resetCurrentLineup(data.lineup, data.programs);
+      setIsSubmitting(false);
       setSnackStatus({
         display: true,
         message: 'Programs Saved!',
@@ -75,6 +78,7 @@ export default function ChannelProgrammingPage() {
       });
     },
     onError: (error) => {
+      setIsSubmitting(false);
       setSnackStatus({
         display: true,
         message: error.message,
@@ -92,6 +96,7 @@ export default function ChannelProgrammingPage() {
   };
 
   const onSave = () => {
+    setIsSubmitting(true);
     if (
       !isUndefined(channel) &&
       !isUndefined(originalChannel) &&
@@ -177,7 +182,14 @@ export default function ChannelProgrammingPage() {
           <Button
             variant="contained"
             onClick={() => onSave()}
-            disabled={!programsDirty}
+            disabled={!programsDirty || isSubmitting}
+            startIcon={
+              isSubmitting ? (
+                <CircularProgress size="20px" sx={{ mx: 1, color: '#fff' }} />
+              ) : (
+                <Save />
+              )
+            }
           >
             Save
           </Button>


### PR DESCRIPTION
- When adding hundreds or thousands of items to a channel it can take a few seconds to load.  This disables the Add button and adds a loading indicator.  This is applied to buttons for adding programming and saving programming to channels as well as saving channel settings.
- Fixes: https://github.com/chrisbenincasa/tunarr/issues/285