### PR TITLE
Fix safari drag and drop bug

### DIFF
--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -235,8 +235,10 @@ const ProgramListItem = ({
               onClick={() => deleteProgram(index)}
               edge="end"
               aria-label="delete"
+              size="small"
+              sx={{ maxHeight: '25px' }}
             >
-              <DeleteIcon />
+              <DeleteIcon fontSize="small" />
             </IconButton>
           </>
         )


### PR DESCRIPTION
Fixes: https://github.com/chrisbenincasa/tunarr/issues/359

Issue was caused by height of the delete button clickable area and Safari handled it a little differently than Chrome