### PR TITLE
Allow program order selection in time slot config. Fixes #251

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,4 @@
-import { ExternalId } from '@tunarr/types';
+import { ExternalId, MultiExternalId } from '@tunarr/types';
 
 export { scheduleRandomSlots } from './services/randomSlotsService.js';
 export { scheduleTimeSlots } from './services/timeSlotService.js';
@@ -11,6 +11,10 @@ export function createExternalId(
   itemId: string,
 ): `${string}|${string}|${string}` {
   return `${sourceType}|${sourceId}|${itemId}`;
+}
+
+export function createExternalIdFromMulti(multi: MultiExternalId) {
+  return createExternalId(multi.source, multi.sourceId, multi.id);
 }
 
 // We could type this better if we reuse the other ExternalId

--- a/shared/src/services/ProgramIterator.ts
+++ b/shared/src/services/ProgramIterator.ts
@@ -63,6 +63,7 @@ export class ProgramOrderer implements ProgramIterator {
     orderer: (program: ContentProgram) => string | number = getProgramOrder,
   ) {
     this.#programs = sortBy(programs, orderer);
+    console.log(this.#programs);
   }
 
   current(): ChannelProgram | null {
@@ -80,7 +81,7 @@ export function getProgramOrder(program: ContentProgram): string | number {
       return program.title;
     case 'episode':
       // Hacky thing from original code...
-      return program.seasonNumber! * 100000 + program.episodeNumber!;
+      return program.seasonNumber! * 1e5 + program.episodeNumber!;
     case 'track':
       // A-z for now
       return program.title;

--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -96,8 +96,21 @@ const programListItemTitleFormatter = (() => {
       switch (p.subtype) {
         case 'movie':
           return p.title;
-        case 'episode':
-          return p.episodeTitle ? `${p.title} - ${p.episodeTitle}` : p.title;
+        case 'episode': {
+          // TODO: this makes some assumptions about number of seasons
+          // and episodes... it may break
+          const epPart =
+            p.seasonNumber && p.episodeNumber
+              ? ` S${p.seasonNumber
+                  .toString()
+                  .padStart(2, '0')}E${p.episodeNumber
+                  .toString()
+                  .padStart(2, '0')}`
+              : '';
+          return p.episodeTitle
+            ? `${p.title}${epPart} - ${p.episodeTitle}`
+            : p.title;
+        }
         case 'track': {
           return join(
             reject(

--- a/web/src/pages/channels/TimeSlotEditorPage.tsx
+++ b/web/src/pages/channels/TimeSlotEditorPage.tsx
@@ -137,6 +137,17 @@ const defaultTimeSlotSchedule: TimeSlotSchedule = {
   timeZoneOffset: new Date().getTimezoneOffset(),
 };
 
+const showOrderOptions = [
+  {
+    value: 'next',
+    description: 'Next Episode',
+  },
+  {
+    value: 'shuffle',
+    description: 'Shuffle',
+  },
+];
+
 const lineupItemAppearsInSchedule = (
   slots: TimeSlot[],
   item: ChannelProgram,
@@ -314,8 +325,15 @@ const TimeSlotRow = ({
       break;
     }
   }
-  const showInputSize = currentPeriod === 'week' ? 7 : 9;
+
+  const isShowType = slot.programming.type === 'show';
+  let showInputSize = currentPeriod === 'week' ? 7 : 9;
+  if (isShowType) {
+    showInputSize -= 3;
+  }
+
   const dayOfTheWeek = Math.floor(slot.startTime / OneDayMillis);
+
   return (
     <Fragment key={`${slot.startTime}_${index}`}>
       {currentPeriod === 'week' ? (
@@ -358,6 +376,26 @@ const TimeSlotRow = ({
           </Select>
         </FormControl>
       </Grid>
+      {isShowType && (
+        <Grid item xs={3}>
+          <FormControl fullWidth>
+            <InputLabel>Order</InputLabel>
+            <Controller
+              control={control}
+              name={`slots.${index}.order`}
+              render={({ field }) => (
+                <Select label="Order" {...field}>
+                  {map(showOrderOptions, ({ description, value }) => (
+                    <MenuItem key={value} value={value}>
+                      {description}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+          </FormControl>
+        </Grid>
+      )}
       <Grid item xs={1}>
         <IconButton onClick={() => removeSlot(index)} color="error">
           <Delete />


### PR DESCRIPTION
Also fixes a bug in the slotting algorithms where duplicate programs
wouldn't be removed before scheduling, causing weird effects. The fix
will now check all available IDs for duplicates before generating the
schedule.

Before:
![Screenshot from 2024-04-26 13-01-12](https://github.com/chrisbenincasa/tunarr/assets/1640671/77344a6e-3bdc-49d6-9455-cb85f6cfd3ac)


After:
![Screenshot from 2024-04-26 13-03-53](https://github.com/chrisbenincasa/tunarr/assets/1640671/4283edfa-efee-4405-a04f-e7cb4a913f9c)


Lastly, we add season/episode number in the Programming list, when
available.
