### PR TITLE
Squashing bugs in PlexProgrammingSelector

### DIFF
--- a/types/src/plex/index.ts
+++ b/types/src/plex/index.ts
@@ -101,6 +101,8 @@ const basePlexCollectionSchema = z.object({
   mediaTagVersion: z.number(),
   nocache: z.boolean().optional(),
   size: z.number(),
+  totalSize: z.number().optional(), // Present when paging
+  offset: z.number().optional(),
   thumb: z.string(),
   title1: z.string(),
   title2: z.string(),
@@ -561,9 +563,16 @@ export const isPlexMedia = (
   return false;
 };
 
+// An item that has children
+export function isPlexParentItem(
+  item: PlexMedia | PlexLibrarySection,
+): item is PlexLibrarySection | PlexParentMediaType {
+  return !isTerminalItem(item);
+}
+
 export function isTerminalItem(
   item: PlexMedia | PlexLibrarySection,
-): item is PlexMovie | PlexEpisode {
+): item is PlexTerminalMedia {
   return (
     !isPlexDirectory(item) &&
     (isPlexMovie(item) || isPlexEpisode(item) || isPlexMusicTrack(item))
@@ -637,7 +646,13 @@ type PlexMediaToChildType = [
   [PlexTvSeason, PlexEpisode],
   [PlexMusicAlbum, PlexMusicArtist],
   [PlexMusicTrack, PlexMusicAlbum],
+  [PlexLibraryCollection, PlexMovie | PlexTvShow],
 ];
+
+export type PlexMetadataType<
+  M extends PlexMedia,
+  T extends { Metadata: M[] } = { Metadata: M[] },
+> = T['Metadata'][0];
 
 type FindChild0<Target, Arr extends unknown[] = []> = Arr extends [
   [infer Head, infer Child],

--- a/web/src/components/InlineModal.tsx
+++ b/web/src/components/InlineModal.tsx
@@ -1,96 +1,114 @@
 import { Collapse, List } from '@mui/material';
-import { PlexMedia } from '@tunarr/types/plex';
+import { PlexMedia, isPlexMedia, isTerminalItem } from '@tunarr/types/plex';
 import { usePrevious } from '@uidotdev/usehooks';
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   extractLastIndexes,
   firstItemInNextRow,
   getEstimatedModalHeight,
+  getImagesPerRow,
 } from '../helpers/inlineModalUtil';
+import _ from 'lodash-es';
 import useStore from '../store';
-import PlexGridItem from './channel_config/PlexGridItem';
+import { PlexGridItem } from './channel_config/PlexGridItem';
+import { useIntersectionObserver } from 'usehooks-ts';
+import { toggle } from '../helpers/util.ts';
 
 type InlineModalProps = {
+  itemGuid: string;
   modalIndex: number;
-  modalChildren?: PlexMedia[];
+  // modalChildren?: PlexMedia[];
   open?: boolean;
   rowSize: number;
   type: PlexMedia['type'] | 'all';
 };
 
-function InlineModal(props: InlineModalProps) {
-  const { modalChildren, modalIndex, open, rowSize, type } = props;
-  const [containerWidth, setContainerWidth] = useState<number>(0);
-  const [itemWidth, setItemWidth] = useState<number>(0);
-  const [isOpen, setIsOpen] = useState<boolean | undefined>(open);
-  const previousData = usePrevious(props);
+export function InlineModal(props: InlineModalProps) {
+  const { itemGuid, modalIndex, open, rowSize, type } = props;
+  const previousItemGuid = usePrevious(itemGuid);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [itemWidth, setItemWidth] = useState(0);
+  const [isOpen, setIsOpen] = useState(open ?? false);
   const ref = useRef<HTMLUListElement>(null);
   const gridItemRef = useRef<HTMLDivElement>(null);
   const inlineModalRef = useRef<HTMLDivElement>(null);
   const darkMode = useStore((state) => state.theme.darkMode);
-  const modalHeight = getEstimatedModalHeight(
-    rowSize,
-    containerWidth,
-    itemWidth,
-    modalChildren?.length || 0,
-    type,
+  const [childLimit, setChildLimit] = useState(0);
+  const [imagesPerRow, setImagesPerRow] = useState(0);
+  const modalChildren: PlexMedia[] = useStore((s) => {
+    const known = s.contentHierarchyByServer[s.currentServer!.name];
+    if (known) {
+      const children = known[itemGuid];
+      if (children) {
+        return _.chain(children)
+          .map((id) => s.knownMediaByServer[s.currentServer!.name][id])
+          .filter(isPlexMedia)
+          .value();
+      }
+    }
+
+    return [];
+  });
+
+  const modalHeight = useMemo(
+    () =>
+      getEstimatedModalHeight(
+        rowSize,
+        containerWidth,
+        itemWidth,
+        modalChildren?.length || 0,
+        type,
+      ),
+    [containerWidth, itemWidth, modalChildren?.length, rowSize, type],
   );
 
-  const toggleModal = () => {
-    setIsOpen(!isOpen);
-  };
+  const toggleModal = useCallback(() => {
+    setIsOpen(toggle);
+  }, []);
 
   useEffect(() => {
-    if (
-      ref.current &&
-      previousData &&
-      previousData.modalChildren !== modalChildren
-    ) {
+    if (ref.current && previousItemGuid !== itemGuid) {
       const containerWidth = ref?.current?.getBoundingClientRect().width || 0;
       const itemWidth =
         gridItemRef?.current?.getBoundingClientRect().width || 0;
 
       setItemWidth(itemWidth);
       setContainerWidth(containerWidth);
+      setImagesPerRow(getImagesPerRow(containerWidth, itemWidth));
     }
-  }, [ref, modalChildren, gridItemRef]);
+  }, [ref, gridItemRef, previousItemGuid, itemGuid]);
 
-  useEffect(() => {
-    if (ref.current && previousData && previousData.modalIndex !== modalIndex) {
-      setChildModalChildren([]);
-    }
-  }, [modalIndex]);
-
-  const [childModalIndex, setChildModalIndex] = useState<number>(-1);
-  const [childModalIsPending, setChildModalIsPending] = useState<boolean>(true);
-  const [childModalChildren, setChildModalChildren] = useState<PlexMedia[]>([]);
+  const [childModalIndex, setChildModalIndex] = useState(-1);
 
   const handleMoveModal = useCallback(
     (index: number) => {
       if (index === childModalIndex) {
-        handleModalChildren([]);
         setChildModalIndex(-1);
       } else {
-        handleModalChildren([]);
         setChildModalIndex(index);
       }
     },
     [childModalIndex],
   );
 
-  const handleModalChildren = useCallback(
-    (children: PlexMedia[]) => {
-      setChildModalChildren(children);
+  // TODO: Complete this by updating the limit below, not doing this
+  // right now because already working with a huge changeset.
+  const { ref: intersectionRef } = useIntersectionObserver({
+    onChange: (_, entry) => {
+      if (entry.isIntersecting) {
+        if (childLimit < modalChildren.length) {
+          setChildLimit((prev) => prev + imagesPerRow * 2);
+        }
+      }
     },
-    [childModalChildren],
-  );
-
-  const handleModalIsPending = useCallback(
-    (isPending: boolean) => {
-      setChildModalIsPending(isPending);
-    },
-    [childModalIsPending],
-  );
+    threshold: 0.5,
+  });
 
   const isFinalChildModalOpen = modalChildren
     ? extractLastIndexes(
@@ -120,7 +138,7 @@ function InlineModal(props: InlineModalProps) {
         onExited={toggleModal}
       >
         <List
-          component={'ul'}
+          component="ul"
           sx={{
             pl: 4,
             display: 'grid',
@@ -136,49 +154,47 @@ function InlineModal(props: InlineModalProps) {
           }}
           ref={ref}
         >
-          {modalChildren?.map((child: PlexMedia, idx: number) => (
-            <React.Fragment key={child.guid}>
-              <InlineModal
-                modalIndex={childModalIndex}
-                modalChildren={childModalChildren}
-                open={
-                  idx ===
-                  firstItemInNextRow(
-                    childModalIndex,
-                    rowSize,
-                    modalChildren?.length || 0,
-                  )
-                }
-                rowSize={rowSize}
-                type={child.type}
-              />
-              <PlexGridItem
-                item={child}
-                index={idx}
-                modalIndex={modalIndex || childModalIndex}
-                ref={gridItemRef}
-                moveModal={() => handleMoveModal(idx)}
-                modalChildren={(children: PlexMedia[]) =>
-                  handleModalChildren(children)
-                }
-                modalIsPending={(isPending: boolean) =>
-                  handleModalIsPending(isPending)
-                }
-              />
-            </React.Fragment>
-          ))}
+          {_.chain(modalChildren)
+            .filter(isPlexMedia)
+            .map((child: PlexMedia, idx: number) => (
+              <React.Fragment key={child.guid}>
+                {!isTerminalItem(child) && (
+                  <InlineModal
+                    itemGuid={child.guid}
+                    modalIndex={childModalIndex}
+                    open={
+                      idx ===
+                      firstItemInNextRow(
+                        childModalIndex,
+                        rowSize,
+                        modalChildren?.length || 0,
+                      )
+                    }
+                    rowSize={rowSize}
+                    type={child.type}
+                  />
+                )}
+                <PlexGridItem
+                  item={child}
+                  index={idx}
+                  modalIndex={modalIndex || childModalIndex}
+                  ref={gridItemRef}
+                  moveModal={handleMoveModal}
+                />
+              </React.Fragment>
+            ))
+            .value()}
           {/* This Modal is for last row items because they can't be inserted using the above inline modal */}
           <InlineModal
+            itemGuid={itemGuid}
             modalIndex={childModalIndex}
-            modalChildren={childModalChildren}
             rowSize={rowSize}
             open={isFinalChildModalOpen}
             type={'season'}
           />
+          <li style={{ height: 40 }} ref={intersectionRef}></li>
         </List>
       </Collapse>
     </div>
   );
 }
-
-export default memo(InlineModal);

--- a/web/src/components/channel_config/PlexGridItem.tsx
+++ b/web/src/components/channel_config/PlexGridItem.tsx
@@ -27,6 +27,7 @@ import {
   forPlexMedia,
   isNonEmptyString,
   prettyItemDuration,
+  toggle,
 } from '../../helpers/util.ts';
 import { usePlexTyped } from '../../hooks/plexHooks.ts';
 import useStore from '../../store/index.ts';
@@ -44,7 +45,6 @@ export interface PlexGridItemProps<T extends PlexMedia> {
   index?: number;
   parent?: string;
   moveModal?: (index: number, item: T) => void;
-  // setModalChildren?: (children: PlexMedia[]) => void;
   modalIndex?: number;
   onClick?: () => void;
   ref?: React.RefObject<HTMLDivElement>;
@@ -74,7 +74,7 @@ export const PlexGridItem = forwardRef(
     const selectedMediaIds = selectedMedia.map((item) => item.guid);
 
     const handleClick = () => {
-      setOpen(!open);
+      setOpen(toggle);
 
       if (!isUndefined(index) && !isUndefined(moveModal)) {
         moveModal(index, item);
@@ -150,6 +150,8 @@ export const PlexGridItem = forwardRef(
                     : theme.palette.grey[400]
                   : 'transparent',
               transition: 'background-color 350ms linear !important',
+              borderTopLeftRadius: '0.5em',
+              borderTopRightRadius: '0.5em',
               ...style,
             }}
             onClick={
@@ -175,6 +177,13 @@ export const PlexGridItem = forwardRef(
                   height={250}
                 />
               ))}
+            {!imageLoaded && (
+              <Skeleton
+                variant="rectangular"
+                sx={{ borderRadius: '5%' }}
+                height={250}
+              />
+            )}
             <ImageListItemBar
               title={item.title}
               subtitle={

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -51,7 +51,7 @@ import {
 } from 'usehooks-ts';
 import {
   extractLastIndexes,
-  firstItemInNextRow,
+  findFirstItemInNextRowIndex,
   getImagesPerRow,
   isNewModalAbove,
 } from '../../helpers/inlineModalUtil';
@@ -381,9 +381,19 @@ export default function PlexProgrammingSelector() {
     threshold: 0.5,
   });
 
-  const firstItemInNextRowIndex = useMemo(
+  const firstItemInNexLibraryRowIndex = useMemo(
     () =>
-      firstItemInNextRow(
+      findFirstItemInNextRowIndex(
+        modalIndex,
+        rowSize,
+        sumBy(searchData?.pages, (p) => p.size) ?? 0,
+      ),
+    [searchData, rowSize, modalIndex],
+  );
+
+  const firstItemInNextCollectionRowIndex = useMemo(
+    () =>
+      findFirstItemInNextRowIndex(
         modalIndex,
         rowSize,
         sumBy(collectionsData?.pages, (p) => p.size) ?? 0,
@@ -392,11 +402,15 @@ export default function PlexProgrammingSelector() {
   );
 
   const renderGridItems = (item: PlexMedia, index: number) => {
-    const isOpen = index === firstItemInNextRowIndex;
+    const isOpen =
+      index ===
+      (tabValue === 0
+        ? firstItemInNexLibraryRowIndex
+        : firstItemInNextCollectionRowIndex);
 
     return (
       <React.Fragment key={item.guid}>
-        {isPlexParentItem(item) && isOpen && (
+        {isPlexParentItem(item) && (
           <InlineModal
             itemGuid={modalGuid}
             modalIndex={modalIndex}

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -13,7 +13,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from '@mui/material';
-import { DataTag, useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { DataTag, useInfiniteQuery } from '@tanstack/react-query';
 import {
   PlexLibraryCollections,
   PlexLibraryMovies,
@@ -23,10 +23,27 @@ import {
   PlexMovie,
   PlexMusicArtist,
   PlexTvShow,
+  isPlexParentItem,
 } from '@tunarr/types/plex';
 import { usePrevious } from '@uidotdev/usehooks';
-import _, { chain, first, forEach, isNil, isUndefined, map } from 'lodash-es';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import _, {
+  chain,
+  compact,
+  first,
+  flatMap,
+  forEach,
+  isNil,
+  isUndefined,
+  map,
+  sumBy,
+} from 'lodash-es';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   useDebounceCallback,
   useIntersectionObserver,
@@ -38,19 +55,19 @@ import {
   getImagesPerRow,
   isNewModalAbove,
 } from '../../helpers/inlineModalUtil';
-import { toggle } from '../../helpers/util';
+import { isNonEmptyString, toggle } from '../../helpers/util';
 import { fetchPlexPath, usePlex } from '../../hooks/plexHooks';
 import { usePlexServerSettings } from '../../hooks/settingsHooks';
 import useStore from '../../store';
 import { addKnownMediaForServer } from '../../store/programmingSelector/actions';
 import { setProgrammingSelectorViewState } from '../../store/themeEditor/actions';
 import { ProgramSelectorViewType } from '../../types';
-import InlineModal from '../InlineModal';
+import { InlineModal } from '../InlineModal';
 import CustomTabPanel from '../TabPanel';
 import StandaloneToggleButton from '../base/StandaloneToggleButton.tsx';
 import ConnectPlex from '../settings/ConnectPlex';
 import { PlexFilterBuilder } from './PlexFilterBuilder.tsx';
-import PlexGridItem from './PlexGridItem';
+import { PlexGridItem } from './PlexGridItem';
 import { PlexListItem } from './PlexListItem';
 import { PlexSortField } from './PlexSortField.tsx';
 import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
@@ -62,7 +79,7 @@ function a11yProps(index: number) {
   };
 }
 
-type refObject = {
+type RefMap = {
   [k: string]: HTMLDivElement | null;
 };
 
@@ -80,16 +97,14 @@ export default function PlexProgrammingSelector() {
   );
   const viewType = useStore((state) => state.theme.programmingSelectorView);
   const [tabValue, setTabValue] = useState(0);
-  const [modalChildren, setModalChildren] = useState<PlexMedia[]>([]);
-  const [rowSize, setRowSize] = useState<number>(16);
-  const [modalIndex, setModalIndex] = useState<number>(-1);
+  const [rowSize, setRowSize] = useState(16);
+  const [modalIndex, setModalIndex] = useState(-1);
   const [modalGuid, setModalGuid] = useState<string>('');
-  const [, setModalIsPending] = useState<boolean>(true);
   const [scrollParams, setScrollParams] = useState({ limit: 0, max: -1 });
   const [searchVisible, setSearchVisible] = useState(false);
   const [useAdvancedSearch, setUseAdvancedSearch] = useState(false);
   const gridContainerRef = useRef<HTMLDivElement>(null);
-  const gridImageRefs = useRef<refObject>({});
+  const gridImageRefs = useRef<RefMap>({});
   const previousModalIndex = usePrevious(modalIndex);
 
   const [{ width }, setSize] = useState<Size>({
@@ -106,7 +121,7 @@ export default function PlexProgrammingSelector() {
 
   useEffect(() => {
     if (viewType === 'grid') {
-      let imageRef;
+      let imageRef: HTMLDivElement | null = null;
 
       if (modalGuid === '') {
         // Grab the first non-null ref for an image
@@ -119,6 +134,7 @@ export default function PlexProgrammingSelector() {
       } else {
         imageRef = _.get(gridImageRefs.current, modalGuid);
       }
+
       const imageWidth = imageRef?.getBoundingClientRect().width;
 
       // 16 is additional padding available in the parent container
@@ -126,15 +142,10 @@ export default function PlexProgrammingSelector() {
     }
   }, [width, tabValue, viewType, modalGuid]);
 
-  const handleModalChildren = useCallback((children: PlexMedia[]) => {
-    setModalChildren(children);
-  }, []);
-
   useEffect(() => {
     setModalIndex(-1);
     setModalGuid('');
-    handleModalChildren([]);
-  }, [handleModalChildren, tabValue]);
+  }, [tabValue]);
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
@@ -176,9 +187,7 @@ export default function PlexProgrammingSelector() {
   }, [modalGuid, modalIndex, scrollToGridItem]);
 
   const handleMoveModal = useCallback(
-    (item: PlexMedia, index: number) => {
-      handleModalChildren([]); // reset children to prevent flashing of previous models images
-
+    (index: number, item: PlexMedia) => {
       if (index === modalIndex) {
         setModalIndex(-1);
         setModalGuid('');
@@ -187,12 +196,8 @@ export default function PlexProgrammingSelector() {
         setModalGuid(item.guid);
       }
     },
-    [handleModalChildren, modalIndex],
+    [modalIndex],
   );
-
-  const handleModalIsPending = useCallback((isPending: boolean) => {
-    setModalIsPending(isPending);
-  }, []);
 
   const { data: directoryChildren } = usePlex(
     selectedServer?.name ?? '',
@@ -211,21 +216,43 @@ export default function PlexProgrammingSelector() {
     setViewType(newFormats);
   };
 
-  const { isLoading: isCollectionLoading, data: collectionsData } = useQuery({
+  const {
+    isLoading: isCollectionLoading,
+    data: collectionsData,
+    fetchNextPage: fetchNextCollectionsPage,
+    isFetchingNextPage: isFetchingNextCollectionsPage,
+    hasNextPage: hasNextCollectionsPage,
+  } = useInfiniteQuery({
     queryKey: [
       'plex',
       selectedServer?.name,
       selectedLibrary?.library.key,
       'collections',
     ],
-    queryFn: () => {
+    queryFn: ({ pageParam }) => {
+      const plexQuery = new URLSearchParams({
+        'X-Plex-Container-Start': pageParam.toString(),
+        'X-Plex-Container-Size': (rowSize * 4).toString(),
+      });
+
       return fetchPlexPath<PlexLibraryCollections>(
         apiClient,
         selectedServer!.name,
-        `/library/sections/${selectedLibrary?.library.key}/collections?`,
+        `/library/sections/${selectedLibrary?.library
+          .key}/collections?${plexQuery.toString()}`,
       )();
     },
     enabled: !isNil(selectedServer) && !isNil(selectedLibrary),
+    initialPageParam: 0,
+    getNextPageParam: (res, all, last) => {
+      const total = sumBy(all, (page) => page.size);
+      if (total >= (res.totalSize ?? res.size)) {
+        return null;
+      }
+
+      // Next offset is the last + how many items we got back.
+      return last + res.size;
+    },
   });
 
   useEffect(() => {
@@ -239,7 +266,13 @@ export default function PlexProgrammingSelector() {
     ({ plexSearch: plexQuery }) => plexQuery,
   );
 
-  const { isLoading: searchLoading, data: searchData } = useInfiniteQuery({
+  const {
+    isLoading: searchLoading,
+    data: searchData,
+    fetchNextPage: fetchNextItemsPage,
+    hasNextPage: hasNextItemsPage,
+    isFetchingNextPage: isFetchingNextItemsPage,
+  } = useInfiniteQuery({
     queryKey: [
       'plex-search',
       selectedServer?.name,
@@ -253,8 +286,8 @@ export default function PlexProgrammingSelector() {
     initialPageParam: 0,
     queryFn: ({ pageParam }) => {
       const plexQuery = new URLSearchParams({
-        'Plex-Container-Start': pageParam.toString(),
-        'Plex-Container-Size': (rowSize * 4).toString(),
+        'X-Plex-Container-Start': pageParam.toString(),
+        'X-Plex-Container-Size': (rowSize * 4).toString(),
       });
       // HACK for now
       forEach(searchKey?.split('&'), (keyval) => {
@@ -263,10 +296,6 @@ export default function PlexProgrammingSelector() {
           plexQuery.append(keyval.substring(0, idx), keyval.substring(idx + 1));
         }
       });
-
-      // if (!isNil(debounceSearch) && !isEmpty(debounceSearch)) {
-      //   plexQuery.set('title<', debounceSearch);
-      // }
 
       return fetchPlexPath<
         PlexLibraryMovies | PlexLibraryShows | PlexLibraryMusic
@@ -278,22 +307,25 @@ export default function PlexProgrammingSelector() {
         }/all?${plexQuery.toString()}`,
       )();
     },
-    getNextPageParam: (res, _, last) => {
-      if (res.size < rowSize * 4) {
+    getNextPageParam: (res, all, last) => {
+      const total = sumBy(all, (page) => page.size);
+      if (total >= (res.totalSize ?? res.size)) {
         return null;
       }
 
-      return last + rowSize * 4;
+      // Next offset is the last + how many items we got back.
+      return last + res.size;
     },
   });
 
   useEffect(() => {
-    if (searchData) {
+    if (!isUndefined(searchData)) {
       // We're using this as an analogue for detecting the start of a new 'query'
       if (searchData.pages.length === 1) {
+        const max = searchData.pages[0].totalSize ?? searchData.pages[0].size;
         setScrollParams({
           limit: rowSize * 4,
-          max: first(searchData.pages)!.size,
+          max,
         });
       }
 
@@ -311,52 +343,75 @@ export default function PlexProgrammingSelector() {
   }, [selectedServer, searchData, setScrollParams, rowSize]);
 
   useEffect(() => {
-    if (selectedServer?.name && collectionsData && collectionsData.Metadata) {
-      addKnownMediaForServer(selectedServer.name, collectionsData.Metadata);
+    if (
+      isNonEmptyString(selectedServer?.name) &&
+      !isUndefined(collectionsData)
+    ) {
+      const allCollections = chain(collectionsData.pages)
+        .reject((page) => page.size === 0)
+        .map((page) => page.Metadata)
+        .compact()
+        .flatten()
+        .value();
+      addKnownMediaForServer(selectedServer.name, allCollections);
     }
   }, [selectedServer?.name, collectionsData]);
 
   const { ref } = useIntersectionObserver({
     onChange: (_, entry) => {
-      if (entry.isIntersecting && scrollParams.limit < scrollParams.max) {
-        setScrollParams(({ limit: prevLimit, max }) => ({
-          max,
-          limit: prevLimit + rowSize * 4,
-        }));
+      if (entry.isIntersecting) {
+        if (scrollParams.limit < scrollParams.max) {
+          setScrollParams(({ limit: prevLimit, max }) => ({
+            max,
+            limit: prevLimit + rowSize * 4,
+          }));
+        }
+        if (tabValue === 0 && hasNextItemsPage && !isFetchingNextItemsPage) {
+          fetchNextItemsPage().catch(console.error);
+        }
+        if (
+          tabValue === 1 &&
+          hasNextCollectionsPage &&
+          !isFetchingNextCollectionsPage
+        ) {
+          fetchNextCollectionsPage().catch(console.error);
+        }
       }
     },
     threshold: 0.5,
   });
 
-  const renderGridItems = (item: PlexMedia, index: number) => {
-    const isOpen =
-      index ===
+  const firstItemInNextRowIndex = useMemo(
+    () =>
       firstItemInNextRow(
         modalIndex,
         rowSize,
-        collectionsData?.Metadata?.length || 0,
-      );
+        sumBy(collectionsData?.pages, (p) => p.size) ?? 0,
+      ),
+    [collectionsData, rowSize, modalIndex],
+  );
+
+  const renderGridItems = (item: PlexMedia, index: number) => {
+    const isOpen = index === firstItemInNextRowIndex;
 
     return (
       <React.Fragment key={item.guid}>
-        <InlineModal
-          modalIndex={modalIndex}
-          modalChildren={modalChildren}
-          rowSize={rowSize}
-          open={isOpen}
-          type={item.type}
-        />
+        {isPlexParentItem(item) && isOpen && (
+          <InlineModal
+            itemGuid={modalGuid}
+            modalIndex={modalIndex}
+            rowSize={rowSize}
+            open={isOpen}
+            type={item.type}
+          />
+        )}
+        {/* TODO: Consider forking this to a separate component for non-parent items, because
+        currently it erroneously creates a lot of tracked queries in react-query that will never be enabled */}
         <PlexGridItem
           item={item}
           index={index}
           modalIndex={modalIndex}
-          moveModal={() => handleMoveModal(item, index)}
-          modalChildren={(children: PlexMedia[]) =>
-            handleModalChildren(children)
-          }
-          modalIsPending={(isPending: boolean) =>
-            handleModalIsPending(isPending)
-          }
+          moveModal={handleMoveModal}
           ref={(element) => (gridImageRefs.current[item.guid] = element)}
         />
       </React.Fragment>
@@ -364,13 +419,11 @@ export default function PlexProgrammingSelector() {
   };
 
   const renderFinalRowInlineModal = (arr: PlexMedia[]) => {
-    {
-      /* This Modal is for last row items because they can't be inserted using the above inline modal */
-    }
+    // /This Modal is for last row items because they can't be inserted using the above inline modal
     return (
       <InlineModal
+        itemGuid=""
         modalIndex={modalIndex}
-        modalChildren={modalChildren}
         rowSize={rowSize}
         open={extractLastIndexes(arr, arr.length % rowSize).includes(
           modalIndex,
@@ -383,11 +436,15 @@ export default function PlexProgrammingSelector() {
   const renderListItems = () => {
     const elements: JSX.Element[] = [];
 
-    if (collectionsData && collectionsData.size > 0 && tabValue === 1) {
+    if (
+      collectionsData &&
+      (first(collectionsData.pages)?.size ?? 0) > 0 &&
+      tabValue === 1
+    ) {
       elements.push(
         <CustomTabPanel value={tabValue} index={1} key="Collections">
           {map(
-            collectionsData.Metadata,
+            flatMap(collectionsData.pages, (page) => page.Metadata),
             (item: PlexMovie | PlexTvShow | PlexMusicArtist, index: number) =>
               viewType === 'list' ? (
                 <PlexListItem key={item.guid} item={item} />
@@ -395,8 +452,9 @@ export default function PlexProgrammingSelector() {
                 renderGridItems(item, index)
               ),
           )}
-          {collectionsData?.Metadata &&
-            renderFinalRowInlineModal(collectionsData?.Metadata)}
+          {renderFinalRowInlineModal(
+            compact(flatMap(collectionsData.pages, (page) => page.Metadata)),
+          )}
         </CustomTabPanel>,
       );
     }
@@ -515,12 +573,13 @@ export default function PlexProgrammingSelector() {
             <Tabs
               value={tabValue}
               onChange={handleChange}
-              aria-label="basic tabs example"
+              aria-label="Plex media selector tabs"
             >
               <Tab label="Library" {...a11yProps(0)} />
-              {collectionsData && collectionsData.size > 0 && (
-                <Tab label="Collections" {...a11yProps(1)} />
-              )}
+              {!isUndefined(collectionsData) &&
+                sumBy(collectionsData.pages, (page) => page.size) > 0 && (
+                  <Tab label="Collections" {...a11yProps(1)} />
+                )}
             </Tabs>
           </Box>
 

--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -1,14 +1,24 @@
 import { PlexMedia } from '@tunarr/types/plex';
+import { range } from 'lodash-es';
+
+// Magic Numbers
+// TODO: eventually grab this data via refs just in case it changes in the future
+const SeasonModalHeight = 143;
+const DefaultSingleRowModalHeight = 294;
+const inlineModalTopPadding = 16;
+const imageContainerXPadding = 8;
+const listItemBarContainerHeight = 54;
 
 export function getImagesPerRow(
   containerWidth: number,
   imageWidth: number,
 ): number {
-  const roundedImageWidth = Math.round(imageWidth * 100) / 100;
-
-  if (!imageWidth || !containerWidth) {
+  if (imageWidth <= 0 || containerWidth <= 0) {
     return 9; // some default value
   }
+
+  const roundedImageWidth = Math.round(imageWidth * 100) / 100;
+
   return Math.round(((containerWidth / roundedImageWidth) * 100) / 100);
 }
 
@@ -22,18 +32,12 @@ export function getEstimatedModalHeight(
 ): number {
   // Episode modals have smaller height, short circuit for  now
   if (type === 'season') {
-    return 143;
+    return SeasonModalHeight;
   }
   // Exit with defaults if container & image width are not provided
   if (containerWidth === 0 || imageContainerWidth === 0) {
-    return 294; //default modal height for 1 row
+    return DefaultSingleRowModalHeight; //default modal height for 1 row
   }
-
-  // Magic Numbers
-  // to do: eventually grab this data via refs just in case it changes in the future
-  const inlineModalTopPadding = 16;
-  const imageContainerXPadding = 8;
-  const listItemBarContainerHeight = 54;
 
   const imagewidth = imageContainerWidth - imageContainerXPadding * 2; // 16px padding on each item
   const heightPerImage = (3 * imagewidth) / 2; // Movie Posters are 2:3
@@ -87,7 +91,6 @@ export function firstItemInNextRow(
     numberOfItemsLastRow < itemsPerRow
   ) {
     return -1;
-    return numberOfItems - numberOfItemsLastRow;
   }
 
   // If the current item is not in the last row, return the index of the first item in the next row
@@ -104,13 +107,5 @@ export function firstItemInNextRow(
 }
 
 export function extractLastIndexes(arr: PlexMedia[], x: number): number[] {
-  if (x > arr.length) {
-    return arr.map((_, i) => i); // Return all indexes if x is too large
-  }
-
-  // Extract the last x elements
-  const lastElements = arr.slice(-x);
-
-  // Return last X indexes in new array
-  return lastElements.map((_) => arr.indexOf(_));
+  return range(x > arr.length ? 0 : x, arr.length);
 }

--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -69,7 +69,12 @@ export function isNewModalAbove(
   }
 }
 
-export function firstItemInNextRow(
+/**
+ * Returns the index to insert the InlineModal
+ * Will return -1 if the modal is not open or if there
+ * are no items
+ */
+export function findFirstItemInNextRowIndex(
   modalIndex: number,
   itemsPerRow: number,
   numberOfItems: number,

--- a/web/src/store/programmingSelector/actions.ts
+++ b/web/src/store/programmingSelector/actions.ts
@@ -6,7 +6,7 @@ import {
   isPlexDirectory,
   isTerminalItem,
 } from '@tunarr/types/plex';
-import { map, reject, some } from 'lodash-es';
+import { map, reject, some, uniq } from 'lodash-es';
 import useStore from '..';
 import {
   buildPlexFilterKey,
@@ -71,6 +71,7 @@ export const addKnownMediaForServer = (
     const childrenByGuid = plexMedia
       .filter((m) => !isTerminalItem(m))
       .reduce((prev, media) => ({ ...prev, [uniqueId(media)]: [] }), {});
+
     state.contentHierarchyByServer[serverName] = {
       ...state.contentHierarchyByServer[serverName],
       ...childrenByGuid,
@@ -81,10 +82,10 @@ export const addKnownMediaForServer = (
         state.contentHierarchyByServer[serverName][parentId] = [];
       }
 
-      state.contentHierarchyByServer[serverName][parentId] = [
+      state.contentHierarchyByServer[serverName][parentId] = uniq([
         ...state.contentHierarchyByServer[serverName][parentId],
         ...plexMedia.map(uniqueId),
-      ];
+      ]);
     }
 
     return state;


### PR DESCRIPTION
1. Fixes #392 - this was caused by an infinite render loop relating to
   how modalChildren was passed around
2. Enhancements for InlineModal:
    1. No more callbacks between PlexGridItem and InlineModal
       coordinated via parent component. InlineModal now pulls its items
       from the local state via the content hierarchy we already built
    2. Sprinkling useCallback and useMemo in a lot of places to speed
       things up and help reduce render cycles
    3. Logic cleanup
3. Fixes infinite scroll for Library items and adds it for collection
   items
4. Only renders InlineModal if it's open, which reduces a lot of
   business logic / effects that run in the component

Still TODO:

1. Opening the inline modal can be reallllyyyy laggy if you have a lot
   of items. It loads them all at once. We could either:
   1. Add _another_ useInfiniteQuery in PlexGridItem to incrementally
      load more items in
   2. Load all items into memory like we do today and use
      useIntersectionObserver in InlineModal to incrementally render
      children (I have this mostly setup in this code now)
2. Create a wrapper component that couples InlineModal and PlexGridItem
   -- these share a ton of common logic.
3. Spin off PlexGridItem into a 'terminal' item version that doesn't
   instantiate a query with react-query, since the query will never be
   enabled (terminal / leaf items have no children)
