### PR TITLE
Fixes browser upload input issue

### DIFF
--- a/web/src/components/settings/ImageUploadInput.tsx
+++ b/web/src/components/settings/ImageUploadInput.tsx
@@ -5,7 +5,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import OutlinedInput, { OutlinedInputProps } from '@mui/material/OutlinedInput';
 import { styled } from '@mui/material/styles';
-import React, { ChangeEvent, useCallback } from 'react';
+import React, { ChangeEvent, useCallback, useRef } from 'react';
 import { useTunarrApi } from '../../hooks/useTunarrApi';
 
 const VisuallyHiddenInput = styled('input')({
@@ -41,6 +41,7 @@ export function ImageUploadInput({
   value,
   children,
 }: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const apiClient = useTunarrApi();
   const handleFileUpload = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -89,8 +90,9 @@ export function ImageUploadInput({
         endAdornment={
           <InputAdornment position="end">
             <IconButton component="label">
-              <CloudUpload />
+              <CloudUpload onClick={() => (fileInputRef.current!.value = '')} />
               <VisuallyHiddenInput
+                ref={fileInputRef}
                 onChange={(e) => {
                   handleFileUpload(e);
                 }}


### PR DESCRIPTION
Fixes: https://github.com/chrisbenincasa/tunarr/issues/357

Fixes issue where browsers intentionally don't let you choose the same file to upload again.  This created a weird scenario where if you reset your form fields, you couldnt choose the same file again.  This resets the field every time you go to upload a file again and works around the browser limitation.