### PR TITLE
Upsert programs before calculating groupings

### DIFF
--- a/web/src/components/channel_config/PlexGridItem.tsx
+++ b/web/src/components/channel_config/PlexGridItem.tsx
@@ -83,6 +83,7 @@ export const PlexGridItem = forwardRef(
 
     useEffect(() => {
       if (!isUndefined(children?.Metadata)) {
+        console.log(item.guid, children.Metadata);
         addKnownMediaForServer(server.name, children.Metadata, item.guid);
       }
     }, [item.guid, server.name, children]);

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -138,7 +138,9 @@ export default function PlexProgrammingSelector() {
       const imageWidth = imageRef?.getBoundingClientRect().width;
 
       // 16 is additional padding available in the parent container
-      setRowSize(getImagesPerRow(width ? width + 16 : 0, imageWidth || 0));
+      const rowSize = getImagesPerRow(width ? width + 16 : 0, imageWidth || 0);
+      setRowSize(rowSize);
+      setScrollParams(({ max }) => ({ max, limit: rowSize * 4 }));
     }
   }, [width, tabValue, viewType, modalGuid]);
 
@@ -319,19 +321,24 @@ export default function PlexProgrammingSelector() {
   });
 
   useEffect(() => {
-    if (!isUndefined(searchData)) {
-      // We're using this as an analogue for detecting the start of a new 'query'
-      if (scrollParams.max === -1 || searchData.pages.length === 1) {
-        const max = searchData.pages[0].totalSize ?? searchData.pages[0].size;
-        setScrollParams({
-          limit: rowSize * 4,
-          max,
-        });
+    if (searchData?.pages.length === 1) {
+      const size = searchData.pages[0].totalSize ?? searchData.pages[0].size;
+      if (scrollParams.max !== size) {
+        console.log('herehereh');
+        setScrollParams(({ limit }) => ({
+          limit,
+          max: size,
+        }));
       }
+    }
+  }, [searchData?.pages, scrollParams.max]);
 
+  useEffect(() => {
+    if (!isUndefined(searchData)) {
       // We probably wouldn't have made it this far if we didnt have a server, but
       // putting this here to prevent crashes
       if (selectedServer) {
+        console.log('still in this one');
         const allMedia = chain(searchData.pages)
           .reject((page) => page.size === 0)
           .map((page) => page.Metadata)
@@ -407,7 +414,6 @@ export default function PlexProgrammingSelector() {
       (tabValue === 0
         ? firstItemInNexLibraryRowIndex
         : firstItemInNextCollectionRowIndex);
-
     return (
       <React.Fragment key={item.guid}>
         {isPlexParentItem(item) && (

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -321,7 +321,7 @@ export default function PlexProgrammingSelector() {
   useEffect(() => {
     if (!isUndefined(searchData)) {
       // We're using this as an analogue for detecting the start of a new 'query'
-      if (searchData.pages.length === 1) {
+      if (scrollParams.max === -1 || searchData.pages.length === 1) {
         const max = searchData.pages[0].totalSize ?? searchData.pages[0].size;
         setScrollParams({
           limit: rowSize * 4,
@@ -340,7 +340,7 @@ export default function PlexProgrammingSelector() {
         addKnownMediaForServer(selectedServer.name, allMedia);
       }
     }
-  }, [selectedServer, searchData, setScrollParams, rowSize]);
+  }, [scrollParams, selectedServer, searchData, rowSize]);
 
   useEffect(() => {
     if (

--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -112,5 +112,10 @@ export function findFirstItemInNextRowIndex(
 }
 
 export function extractLastIndexes(arr: PlexMedia[], x: number): number[] {
-  return range(x > arr.length ? 0 : x, arr.length);
+  const indexes = range(0, arr.length);
+  if (x > arr.length) {
+    return indexes;
+  }
+
+  return indexes.slice(-x);
 }

--- a/web/src/store/programmingSelector/actions.ts
+++ b/web/src/store/programmingSelector/actions.ts
@@ -4,7 +4,6 @@ import {
   PlexLibrarySection,
   PlexMedia,
   isPlexDirectory,
-  isTerminalItem,
 } from '@tunarr/types/plex';
 import { map, reject, some, uniq } from 'lodash-es';
 import useStore from '..';
@@ -68,19 +67,22 @@ export const addKnownMediaForServer = (
       hierarchy = state.contentHierarchyByServer[serverName];
     }
 
-    const childrenByGuid = plexMedia
-      .filter((m) => !isTerminalItem(m))
-      .reduce((prev, media) => ({ ...prev, [uniqueId(media)]: [] }), {});
-
-    state.contentHierarchyByServer[serverName] = {
-      ...state.contentHierarchyByServer[serverName],
-      ...childrenByGuid,
-    };
+    // plexMedia
+    //   .filter((m) => !isTerminalItem(m))
+    //   .map(uniqueId)
+    //   .forEach((id) => {
+    //     if (!has(state.contentHierarchyByServer[serverName], id)) {
+    //       state.contentHierarchyByServer[serverName][id] = [];
+    //     }
+    //   });
 
     if (parentId) {
+      console.log('setting parent id', parentId);
       if (!state.contentHierarchyByServer[serverName][parentId]) {
         state.contentHierarchyByServer[serverName][parentId] = [];
       }
+
+      console.log(plexMedia.map(uniqueId));
 
       state.contentHierarchyByServer[serverName][parentId] = uniq([
         ...state.contentHierarchyByServer[serverName][parentId],


### PR DESCRIPTION
This seems to resolve an issue where in the grouping upsert code, the
entity manager attempts to insert programs that it finds in its entity
map (it sees the objects as created and ready to be persisted). However,
we need special upsert code for the programs due to various unique key
constraints. This simply reoders the operations to save the programs
first and then calculate their groupings.

Also fixes a weird state bug I was experiencing in the program selector
