### PR TITLE
Fixes nested InlineModals which were passing the wrong childItemGuid

### DIFF
--- a/web/src/components/InlineModal.tsx
+++ b/web/src/components/InlineModal.tsx
@@ -117,8 +117,6 @@ export function InlineModal(props: InlineModalProps) {
       ).includes(childModalIndex)
     : false;
 
-  console.log('my children, should be open', type, modalChildren);
-
   return (
     <Box
       ref={inlineModalRef}
@@ -167,7 +165,7 @@ export function InlineModal(props: InlineModalProps) {
               <React.Fragment key={child.guid}>
                 {isPlexParentItem(child) && (
                   <InlineModal
-                    itemGuid={child.guid}
+                    itemGuid={childItemGuid ?? ''}
                     modalIndex={childModalIndex}
                     open={idx === firstItemInNextRowIndex}
                     rowSize={rowSize}

--- a/web/src/components/channel_config/PlexGridItem.tsx
+++ b/web/src/components/channel_config/PlexGridItem.tsx
@@ -83,7 +83,6 @@ export const PlexGridItem = forwardRef(
 
     useEffect(() => {
       if (!isUndefined(children?.Metadata)) {
-        console.log(item.guid, children.Metadata);
         addKnownMediaForServer(server.name, children.Metadata, item.guid);
       }
     }, [item.guid, server.name, children]);

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -147,6 +147,7 @@ export default function PlexProgrammingSelector() {
   useEffect(() => {
     setModalIndex(-1);
     setModalGuid('');
+    setTabValue(0);
   }, [tabValue, selectedLibrary]);
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
@@ -324,7 +325,6 @@ export default function PlexProgrammingSelector() {
     if (searchData?.pages.length === 1) {
       const size = searchData.pages[0].totalSize ?? searchData.pages[0].size;
       if (scrollParams.max !== size) {
-        console.log('herehereh');
         setScrollParams(({ limit }) => ({
           limit,
           max: size,
@@ -338,7 +338,6 @@ export default function PlexProgrammingSelector() {
       // We probably wouldn't have made it this far if we didnt have a server, but
       // putting this here to prevent crashes
       if (selectedServer) {
-        console.log('still in this one');
         const allMedia = chain(searchData.pages)
           .reject((page) => page.size === 0)
           .map((page) => page.Metadata)


### PR DESCRIPTION
Kudos for the key insight from @markdavella here -- sibline
InlineModal/PlexGridItems do **not** have any relation to one another,
in terms of which item they are 'pointing' to.

This meant that we were binding the wrong child item GUID to each
InlineModal. In fact, we have to render InlineModals at each index to
allow it to be injected at any point within the grid. HOWEVER, they
should always point to the _open_ child item GUID, which is controlled
by the parent element.

Testing:

Opened TV Collection > Show > Season > Episodes -- a complete hierarchy.
