### PR TITLE
Automatically fix duration mismatches between DB and lineup

### DIFF
--- a/server/src/dao/programHelpers.ts
+++ b/server/src/dao/programHelpers.ts
@@ -56,6 +56,9 @@ import {
 import { ProgramGroupingExternalId } from './entities/ProgramGroupingExternalId.js';
 import { Loaded } from '@mikro-orm/core';
 import { createExternalId } from '@tunarr/shared';
+import { GlobalScheduler } from '../services/scheduler.js';
+import { ReconcileProgramDurationsTask } from '../tasks/ReconcileProgramDurationsTask.js';
+import dayjs from 'dayjs';
 
 const logger = createLogger(import.meta);
 
@@ -221,6 +224,12 @@ export async function upsertContentPrograms(
   });
 
   await em.flush();
+
+  GlobalScheduler.scheduleOneOffTask(
+    ReconcileProgramDurationsTask.name,
+    dayjs().add(500, 'ms'),
+    new ReconcileProgramDurationsTask(),
+  );
 
   return upsertedPrograms;
 }

--- a/server/src/tasks/ReconcileProgramDurationsTask.ts
+++ b/server/src/tasks/ReconcileProgramDurationsTask.ts
@@ -1,0 +1,119 @@
+import {
+  chunk,
+  differenceWith,
+  filter,
+  forEach,
+  isUndefined,
+  keys,
+  map,
+  once,
+  uniqBy,
+} from 'lodash-es';
+import { ChannelDB } from '../dao/channelDb';
+import { getEm } from '../dao/dataSource';
+import { isContentItem } from '../dao/derived_types/Lineup';
+import { Program } from '../dao/entities/Program';
+import { flatMapAsyncSeq, isNonEmptyString } from '../util';
+import { Task } from './Task';
+import createLogger from '../logger';
+
+// This task is fired off whenever programs are updated. It goes through
+// all channel lineups that contain the program and ensure that their
+// lineup JSON files have the correct durations for the program.
+// Program durations can change when the underlying file in a media server has
+// changed, ex. replacing a movie with an extended edition (or sometimes a)
+// different versions varies in length by a few seconds).
+export class ReconcileProgramDurationsTask extends Task {
+  static ID = ReconcileProgramDurationsTask.name;
+  ID = ReconcileProgramDurationsTask.ID;
+  taskName = ReconcileProgramDurationsTask.name;
+
+  // Optionally provide the channel ID that was updated on the triggering
+  // operation, since theoretically we don't have to check it.
+  constructor(private channelId?: string) {
+    super();
+  }
+
+  private get logger() {
+    return this.makeLogger();
+  }
+
+  private makeLogger = once(() => createLogger(import.meta));
+
+  protected async runInternal(): Promise<unknown> {
+    const em = getEm();
+    // TODO put this in the constructor
+    const channelDB = new ChannelDB();
+
+    // Programs previously loaded from the DB, keyed by ID, value
+    // is the source-of-truth duration.
+    const cachedPrograms: Record<string, number> = {};
+
+    for (const channel of await channelDB.getAllChannels()) {
+      if (isNonEmptyString(this.channelId) && channel.uuid === this.channelId) {
+        continue;
+      }
+
+      const lineup = await channelDB.loadLineup(channel.uuid);
+      const uniqueProgramIds = uniqBy(
+        filter(lineup.items, isContentItem),
+        (item) => item.id,
+      );
+      const missingKeys = differenceWith(
+        uniqueProgramIds,
+        keys(cachedPrograms),
+        (item, id) => item.id === id,
+      );
+
+      const missingPrograms = await flatMapAsyncSeq(
+        chunk(missingKeys, 25),
+        async (items) => {
+          return await em.repo(Program).find({
+            uuid: {
+              $in: map(items, 'id'),
+            },
+          });
+        },
+      );
+
+      forEach(missingPrograms, (program) => {
+        cachedPrograms[program.uuid] = program.duration;
+      });
+
+      let changed = false;
+      const newLineupItems = map(lineup.items, (item) => {
+        if (isContentItem(item)) {
+          const dbItemDuration = cachedPrograms[item.id];
+          if (
+            !isUndefined(dbItemDuration) &&
+            dbItemDuration !== item.durationMs
+          ) {
+            console.debug('Found duration mismatch: %s', item.id);
+            changed = true;
+            return {
+              ...item,
+              durationMs: dbItemDuration,
+            };
+          }
+
+          return item;
+        } else {
+          return item;
+        }
+      });
+
+      if (changed) {
+        this.logger.debug(
+          'Channel %s had a program duration discrepancy, updating lineup!',
+          channel.uuid,
+        );
+        await channelDB.saveLineup(channel.uuid, {
+          ...lineup,
+          items: newLineupItems,
+        });
+      }
+    }
+
+    return;
+  }
+}

--- a/server/src/tasks/Task.ts
+++ b/server/src/tasks/Task.ts
@@ -11,7 +11,7 @@ export type TaskId =
   | 'cleanup-sessions'
   | 'schedule-dynamic-channels';
 
-export abstract class Task<Data> {
+export abstract class Task<Data = unknown> {
   private onCompleteListeners = new Set<() => void>();
   private running_ = false;
 


### PR DESCRIPTION
A consequence of decoupling lineups from the DB items is that sometimes
things can get out of sync. In this case, I experienced the following
scenario:

1. Program 1 added to the DB with duration D
2. Program 1 was added to Channel A and Custom Show X
3. Outside of Tunarr, a new version of this Program was imported to my
   media server, which had duration D-1
4. Channel A was updated, and with it, associated program metadata was
   updated from the media server source. In the DB, Program 1 now had
duration D-1. Channel A's lineup was also correctly updated
5. Channel B, which uses Custom Show X in its lineup (containing Program
   1) did _not_ have its lineup updated, because it was not aware that
      Program 1 had changed in the DB.

The solution here is twofold:

1. In guide building, account for scenarios where the item's duration in
   the DB is _less than_ the reported duration in the lineup file by
adding flex. We've also added logging to capture the opposite scenario
(DB time is longer than lineup time)
2. Add a new task that reconciles durations. This fires on a schedule
   (for now) and also after the main path where programs are
inserted/updated in the DB.
