### PR TITLE
Fix mobile styles for lists

### DIFF
--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -1,7 +1,14 @@
-import { Alert, Box, Link, Stack } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Link,
+  Stack,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
+import { Link as RouterLink } from 'react-router-dom';
 import { useSlideSchedule } from '../../hooks/programming_controls/useSlideSchedule.ts';
 import { usePreloadedChannelEdit } from '../../hooks/usePreloadedChannel.ts';
 import { setChannelStartTime } from '../../store/channelEditor/actions.ts';
@@ -12,6 +19,8 @@ import { ChannelProgrammingTools } from './ChannelProgrammingTools.tsx';
 
 export function ChannelProgrammingConfig() {
   const { currentEntity: channel, schedule } = usePreloadedChannelEdit();
+  const theme = useTheme();
+  const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
 
   const slideSchedule = useSlideSchedule();
 
@@ -74,7 +83,11 @@ export function ChannelProgrammingConfig() {
       </Stack>
 
       <ChannelProgrammingList
-        virtualListProps={{ width: '100%', height: 600, itemSize: 35 }}
+        virtualListProps={{
+          width: '100%',
+          height: 600,
+          itemSize: smallViewport ? 70 : 35,
+        }}
       />
     </Box>
   );

--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -5,7 +5,13 @@ import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import MusicNote from '@mui/icons-material/MusicNote';
 import TheatersIcon from '@mui/icons-material/Theaters';
 import TvIcon from '@mui/icons-material/Tv';
-import { ListItemIcon, Typography, lighten } from '@mui/material';
+import {
+  ListItemIcon,
+  Typography,
+  lighten,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
@@ -175,6 +181,9 @@ const ProgramListItem = ({
     },
   }));
 
+  const theme = useTheme();
+  const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
+
   const startTime = ListItemTimeFormatter.format(startTimeDate);
   // console.log(ListItemTimeFormatter.formatToParts(startTimeDate));
 
@@ -235,7 +244,8 @@ const ProgramListItem = ({
       secondaryAction={
         enableDrag && isDragging ? null : (
           <>
-            {program.type === 'flex' || program.type === 'redirect' ? (
+            {(!smallViewport && program.type === 'flex') ||
+            program.type === 'redirect' ? (
               <IconButton
                 onClick={() => onEditClicked({ ...program, index })}
                 edge="end"
@@ -264,21 +274,28 @@ const ProgramListItem = ({
       ) : (
         <>
           <ListItemIcon
-            sx={{ minWidth: program.type === 'content' ? 35 : null }}
+            sx={{
+              minWidth: smallViewport || program.type === 'content' ? 35 : null,
+            }}
           >
             <DragIndicatorIcon />
           </ListItemIcon>
-          {program.type === 'content' ? (
-            <ListItemIcon
-              onClick={handleInfoButtonClick}
-              sx={{ cursor: 'pointer', minWidth: 0, pr: 1 }}
-            >
-              <InfoOutlined />
-            </ListItemIcon>
-          ) : (
-            <Box sx={{ pr: 1, width: 24 }} />
-          )}
-          {icon ?? <Box sx={{ pr: 1, width: 20 }} />}
+
+          {!smallViewport ? (
+            program.type === 'content' ? (
+              <ListItemIcon
+                onClick={handleInfoButtonClick}
+                sx={{ cursor: 'pointer', minWidth: 0, pr: 1 }}
+              >
+                <InfoOutlined />
+              </ListItemIcon>
+            ) : (
+              <Box sx={{ pr: 1, width: 20 }} />
+            )
+          ) : null}
+
+          {!smallViewport ? icon ?? <Box sx={{ pr: 1, width: 20 }} /> : null}
+
           <ListItemText
             primary={title}
             sx={{

--- a/web/src/pages/channels/TimeSlotEditorPage.tsx
+++ b/web/src/pages/channels/TimeSlotEditorPage.tsx
@@ -16,6 +16,8 @@ import {
   SelectChangeEvent,
   Snackbar,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { dayjsMod, scheduleTimeSlots } from '@tunarr/shared';
@@ -419,6 +421,8 @@ export default function TimeSlotEditorPage() {
   );
 
   const updateLineupMutation = useUpdateLineup();
+  const theme = useTheme();
+  const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
 
   // TODO: This can be shared between random / time slots
   const programOptions: ProgramOption[] = useMemo(() => {
@@ -824,7 +828,7 @@ export default function TimeSlotEditorPage() {
           virtualListProps={{
             width: '100%',
             height: 400,
-            itemSize: 35,
+            itemSize: smallViewport ? 70 : 35,
             overscanCount: 5,
           }}
         />


### PR DESCRIPTION
- On mobile viewports I needed to remove some buttons and increase the height to ensure we could actually see what was going on in mobile
- Fixes https://github.com/chrisbenincasa/tunarr/issues/420
- There is room for more improvements in how it looks but this makes it so it can be usable on mobile for now


New fix (will re-style drop downs in a future PR):
<img width="434" alt="image" src="https://github.com/chrisbenincasa/tunarr/assets/6005331/965b806b-cfe2-4b31-8a9a-49bf9c14ccc6">
