### PR TITLE
Assorted bug fixes

### DIFF
--- a/server/src/api/videoApi.ts
+++ b/server/src/api/videoApi.ts
@@ -95,19 +95,16 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
   );
 
   fastify.get(
-    '/radio',
+    '/channels/:id/radio',
     {
       schema: {
-        querystring: z.object({
-          channel: z.coerce.number().or(z.string()),
+        params: z.object({
+          id: z.coerce.number().or(z.string()),
         }),
       },
     },
     async (req, res) => {
-      const result = await new ConcatStream().startStream(
-        req.query.channel,
-        false,
-      );
+      const result = await new ConcatStream().startStream(req.params.id, false);
       if (result.type === 'error') {
         return res.send(result.httpStatus).send(result.message);
       }
@@ -163,11 +160,11 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
   );
 
   fastify.get(
-    '/m3u8',
+    '/channels/:id/m3u8',
     {
       schema: {
-        querystring: z.object({
-          channel: z.coerce.number().or(z.string().uuid()),
+        params: z.object({
+          id: z.coerce.number().or(z.string()),
         }),
       },
     },
@@ -175,11 +172,11 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
       const sessionId = StreamCount++;
 
       // Check if channel queried is valid
-      if (isUndefined(req.query.channel)) {
+      if (isUndefined(req.params.id)) {
         return res.status(400).send('No Channel Specified');
       }
 
-      if (isNil(await req.serverCtx.channelDB.getChannel(req.query.channel))) {
+      if (isNil(await req.serverCtx.channelDB.getChannel(req.params.id))) {
         return res.status(404).send("Channel doesn't exist");
       }
 
@@ -189,7 +186,7 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
           await req.serverCtx.m3uService.buildChannelM3U(
             req.protocol,
             req.hostname,
-            req.query.channel,
+            req.params.id,
             sessionId,
           ),
         );
@@ -275,7 +272,7 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
       '#EXT-X-ALLOW-CACHE:YES',
       '#EXT-X-TARGETDURATION:60',
       '#EXT-X-PLAYLIST-TYPE:VOD',
-      `${req.protocol}://${req.hostname}/${path}?channel=${channelNum}`,
+      `${req.protocol}://${req.hostname}/channels/${channelNum}/${path}`,
     ];
 
     return res

--- a/server/src/ffmpeg/ffmpeg.ts
+++ b/server/src/ffmpeg/ffmpeg.ts
@@ -103,7 +103,7 @@ export class FFMPEG extends (events.EventEmitter as new () => TypedEventEmitter<
     super();
     this.logger = LoggerFactory.child({
       caller: import.meta,
-      channe: channel.uuid,
+      channel: channel.uuid,
     });
     this.opts = opts;
     this.errorPicturePath = `http://localhost:${

--- a/server/src/util/logging/LoggerFactory.ts
+++ b/server/src/util/logging/LoggerFactory.ts
@@ -147,7 +147,7 @@ class LoggerFactoryImpl {
     const { caller, ...rest } = opts;
     const newChild = this.rootLogger.child({
       ...rest,
-      caller: caller ? getCaller(caller) : undefined,
+      caller: isProduction ? undefined : caller ? getCaller(caller) : undefined,
     });
     this.children.push(newChild);
     return newChild;

--- a/web/src/pages/channels/ChannelsPage.tsx
+++ b/web/src/pages/channels/ChannelsPage.tsx
@@ -35,6 +35,7 @@ import NoChannelsCreated from '../../components/channel_config/NoChannelsCreated
 import { useChannels } from '../../hooks/useChannels.ts';
 import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
 import { useSettings } from '../../store/settings/selectors.ts';
+import { isNonEmptyString } from '../../helpers/util.ts';
 
 export default function ChannelsPage() {
   const { backendUri } = useSettings();
@@ -135,7 +136,9 @@ export default function ChannelsPage() {
         <TableCell sx={{ textAlign: 'right' }}>
           <Tooltip title="Get Channel M3U File" placement="top">
             <IconButton
-              href={`${backendUri}/media-player/${channel.number}.m3u`}
+              href={`${
+                isNonEmptyString(backendUri) ? `${backendUri}/` : ''
+              }media-player/${channel.number}.m3u`}
               onClick={(e) => e.stopPropagation()}
             >
               <TextSnippetIcon />


### PR DESCRIPTION
* Fixes m3u link generation on ChannelsPage: Fixes #430
* Fixes m3u generation on media-player endpoint
* Changes radio/m3u paths to mimic how video path works (/channels/num/video)
* Fixes some typos in logging in ffmpeg
* Does not attach caller in prod mode, this removes empty <> from new logs
