### PR TITLE
Splits HDHR service into API and actual service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1
       fastify-print-routes:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.0
+        version: 3.2.0
       fastify-type-provider-zod:
         specifier: ^1.1.9
         version: 1.1.9(fastify@4.26.2)(zod@3.22.4)
@@ -3764,8 +3764,8 @@ packages:
     hasBin: true
     dev: true
 
-  /acquerello@2.0.7:
-    resolution: {integrity: sha512-Tuwr7Ozm/Ze+Sx7GqR8A6zlMUwk2xxQ0FRlhD/bettQnVeERC8cq2I7mky7+A1h/hfPSMZtguuka48KSyS7x8Q==}
+  /acquerello@2.0.8:
+    resolution: {integrity: sha512-+Xm1S7eutT6OzPVuW4jhpS0YlhdnEFVHOZOiVghLGDk7rLoQc1MQmT4jsVkuDCTbqIZy21gnsrTXY9Ya2sQvtw==}
     engines: {node: '>= 18.18.0'}
     dev: false
 
@@ -6003,13 +6003,13 @@ packages:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
     dev: false
 
-  /fastify-print-routes@3.1.1:
-    resolution: {integrity: sha512-iY209IY6AMH/a6UDZ6R7QsUaaQI9ioyN6qS/JF0ADo6vbfs9Hi2qiM338P0WmCevlQ8DREgjAeuhtAp+yz4XFg==}
+  /fastify-print-routes@3.2.0:
+    resolution: {integrity: sha512-vbNliaT+SlZlH9sPYR1FYe3AJptbadf20/SjmramOxoeS6fdrAkMQu0H0/ZENaU4ruBlxCrUs0hUfV2J0dGyZw==}
     engines: {node: '>= 18.18.0'}
     dependencies:
-      acquerello: 2.0.7
+      acquerello: 2.0.8
       fastify-plugin: 4.5.1
-      table: 6.8.1
+      table: 6.8.2
     dev: false
 
   /fastify-type-provider-zod@1.1.9(fastify@4.26.2)(zod@3.22.4):
@@ -10163,8 +10163,8 @@ packages:
       acorn-node: 1.8.2
     dev: true
 
-  /table@6.8.1:
-    resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
+  /table@6.8.2:
+    resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
     dependencies:
       ajv: 8.12.0

--- a/server/package.json
+++ b/server/package.json
@@ -50,7 +50,7 @@
     "fast-xml-parser": "^4.3.5",
     "fastify": "^4.26.0",
     "fastify-plugin": "^4.5.1",
-    "fastify-print-routes": "^3.1.1",
+    "fastify-print-routes": "^3.2.0",
     "fastify-type-provider-zod": "^1.1.9",
     "lodash-es": "^4.17.21",
     "lowdb": "^7.0.0",

--- a/server/src/api/ffmpegSettingsApi.ts
+++ b/server/src/api/ffmpegSettingsApi.ts
@@ -13,7 +13,7 @@ export const ffmpegSettingsRouter: RouterPluginCallback = (
 ) => {
   const logger = LoggerFactory.child({ caller: import.meta });
 
-  fastify.get('/api/ffmpeg-settings', (req, res) => {
+  fastify.get('/ffmpeg-settings', (req, res) => {
     try {
       const ffmpeg = req.serverCtx.settings.ffmpegSettings();
       return res.send(ffmpeg);
@@ -24,7 +24,7 @@ export const ffmpegSettingsRouter: RouterPluginCallback = (
   });
 
   fastify.put(
-    '/api/ffmpeg-settings',
+    '/ffmpeg-settings',
     {
       schema: {
         body: FfmpegSettingsSchema,
@@ -71,7 +71,7 @@ export const ffmpegSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.post<{ Body: { ffmpegPath: string } }>(
-    '/api/ffmpeg-settings',
+    '/ffmpeg-settings',
     async (req, res) => {
       // RESET
       try {

--- a/server/src/api/guideApi.ts
+++ b/server/src/api/guideApi.ts
@@ -8,7 +8,7 @@ import { LoggerFactory } from '../util/logging/LoggerFactory.js';
 export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
   const logger = LoggerFactory.child({ caller: import.meta });
 
-  fastify.get('/api/guide/status', async (req, res) => {
+  fastify.get('/guide/status', async (req, res) => {
     try {
       const s = await req.serverCtx.guideService.getStatus();
       return res.send(s);
@@ -18,7 +18,7 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
     }
   });
 
-  fastify.get('/api/guide/debug', async (req, res) => {
+  fastify.get('/guide/debug', async (req, res) => {
     try {
       const s = await req.serverCtx.guideService.get();
       return res.send(s);
@@ -29,7 +29,7 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
   });
 
   fastify.get(
-    '/api/guide/channels',
+    '/guide/channels',
     {
       schema: {
         querystring: z.object({
@@ -70,7 +70,7 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
   fastify.get<{
     Params: { id: string };
     Querystring: { dateFrom: string; dateTo: string };
-  }>('/api/guide/channels/:number', async (req, res) => {
+  }>('/guide/channels/:number', async (req, res) => {
     try {
       // TODO determine if these params are numbers or strings
       const dateFrom = new Date(req.query.dateFrom);
@@ -81,7 +81,6 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
         dateTo,
       );
       if (lineup == null) {
-        logger.info(`GET /api/guide/channels/${req.params.id} : 404 Not Found`);
         return res.status(404).send('Channel not found in TV guide');
       } else {
         return res.send(lineup);

--- a/server/src/api/hdhrApi.ts
+++ b/server/src/api/hdhrApi.ts
@@ -1,0 +1,86 @@
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { LoggerFactory } from '../util/logging/LoggerFactory';
+
+const HdhrLineupSchema = z.object({
+  GuideNumber: z.string(),
+  GuideName: z.string(),
+  URL: z.string().url(),
+});
+
+type HdhrLineupItem = z.infer<typeof HdhrLineupSchema>;
+
+export class HdhrApiRouter {
+  private logger = LoggerFactory.child({ caller: import.meta });
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  router: FastifyPluginAsync = async (fastify) => {
+    fastify
+      .addHook('onError', (req, _, error, done) => {
+        this.logger.error({ url: req.routeOptions.config.url, error });
+        done();
+      })
+      .addHook('onRequest', (req, _, done) => {
+        req.disableRequestLogging = true;
+        done();
+      });
+
+    fastify.get('/device.xml', (req, res) => {
+      const host = req.protocol + '://' + req.hostname;
+      return res
+        .type('application/xml')
+        .send(req.serverCtx.hdhrService.getHdhrDeviceXml(host));
+    });
+
+    fastify.get('/discover.json', (req, res) => {
+      return res.send(
+        req.serverCtx.hdhrService.getHdhrDevice(
+          req.protocol + '://' + req.hostname,
+        ),
+      );
+    });
+
+    fastify.get('/lineup_status.json', (_, res) => {
+      return res.send({
+        ScanInProgress: 0,
+        ScanPossible: 1,
+        Source: 'Cable',
+        SourceList: ['Cable'],
+      });
+    });
+
+    fastify.get(
+      '/lineup.json',
+      {
+        schema: {
+          response: {
+            200: z.array(HdhrLineupSchema),
+          },
+        },
+      },
+      async (req, res) => {
+        const lineup: HdhrLineupItem[] = [];
+        const channels = await req.serverCtx.channelDB.getAllChannels();
+        for (const channel of channels) {
+          if (channel.stealth) {
+            continue;
+          }
+
+          lineup.push({
+            GuideNumber: channel.number.toString(),
+            GuideName: channel.name,
+            URL: `${req.protocol}://${req.hostname}/channels/${channel.number}/video`,
+          });
+        }
+        if (lineup.length === 0)
+          lineup.push({
+            GuideNumber: '1',
+            GuideName: 'Tunarr',
+            URL: `${req.protocol}://${req.hostname}/setup`,
+          });
+
+        return res.send(lineup);
+      },
+    );
+  };
+}

--- a/server/src/api/hdhrSettingsApi.ts
+++ b/server/src/api/hdhrSettingsApi.ts
@@ -15,7 +15,7 @@ export const hdhrSettingsRouter: RouterPluginCallback = (
   const logger = LoggerFactory.child({ caller: import.meta });
 
   fastify.get(
-    '/api/hdhr-settings',
+    '/hdhr-settings',
     {
       schema: {
         response: {
@@ -36,7 +36,7 @@ export const hdhrSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.put(
-    '/api/hdhr-settings',
+    '/hdhr-settings',
     {
       schema: {
         body: HdhrSettingsSchema,
@@ -78,7 +78,7 @@ export const hdhrSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.post(
-    '/api/hdhr-settings',
+    '/hdhr-settings',
     {
       schema: {
         response: {

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -21,6 +21,12 @@ import { fillerListsApi } from './fillerListsApi.js';
 import { metadataApiRouter } from './metadataApi.js';
 import { programmingApi } from './programmingApi.js';
 import { tasksApiRouter } from './tasksApi.js';
+import { ffmpegSettingsRouter } from './ffmpegSettingsApi.js';
+import { guideRouter } from './guideApi.js';
+import { hdhrSettingsRouter } from './hdhrSettingsApi.js';
+import { plexServersRouter } from './plexServersApi.js';
+import { plexSettingsRouter } from './plexSettingsApi.js';
+import { xmlTvSettingsRouter } from './xmltvSettingsApi.js';
 
 export const apiRouter: RouterPluginAsyncCallback = async (fastify) => {
   const logger = LoggerFactory.child({ caller: import.meta });
@@ -41,7 +47,13 @@ export const apiRouter: RouterPluginAsyncCallback = async (fastify) => {
     .register(fillerListsApi)
     .register(programmingApi)
     .register(debugApi)
-    .register(metadataApiRouter);
+    .register(metadataApiRouter)
+    .register(plexServersRouter)
+    .register(ffmpegSettingsRouter)
+    .register(plexSettingsRouter)
+    .register(xmlTvSettingsRouter)
+    .register(hdhrSettingsRouter)
+    .register(guideRouter);
 
   fastify.get(
     '/version',

--- a/server/src/api/plexServersApi.ts
+++ b/server/src/api/plexServersApi.ts
@@ -22,7 +22,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   const logger = LoggerFactory.child({ caller: import.meta });
 
   fastify.get(
-    '/api/plex-servers',
+    '/plex-servers',
     {
       schema: {
         response: {
@@ -44,7 +44,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.get(
-    '/api/plex-servers/:id/status',
+    '/plex-servers/:id/status',
     {
       schema: {
         params: BasicIdParamSchema,
@@ -89,7 +89,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.post(
-    '/api/plex-servers/foreignstatus',
+    '/plex-servers/foreignstatus',
     {
       schema: {
         body: z.object({
@@ -133,7 +133,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.delete(
-    '/api/plex-servers/:id',
+    '/plex-servers/:id',
     {
       schema: {
         params: BasicIdParamSchema,
@@ -192,7 +192,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.put(
-    '/api/plex-servers/:id',
+    '/plex-servers/:id',
     {
       schema: {
         params: BasicIdParamSchema,
@@ -245,7 +245,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.post(
-    '/api/plex-servers',
+    '/plex-servers',
     {
       schema: {
         body: InsertPlexServerRequestSchema,
@@ -294,7 +294,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
   );
 
   fastify.get(
-    '/api/plex/status',
+    '/plex/status',
     {
       schema: {
         querystring: z.object({

--- a/server/src/api/plexSettingsApi.ts
+++ b/server/src/api/plexSettingsApi.ts
@@ -15,7 +15,7 @@ export const plexSettingsRouter: RouterPluginCallback = (
   const logger = LoggerFactory.child({ caller: import.meta });
 
   fastify.get(
-    '/api/plex-settings',
+    '/plex-settings',
     {
       schema: {
         response: {
@@ -38,7 +38,7 @@ export const plexSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.put(
-    '/api/plex-settings',
+    '/plex-settings',
     {
       schema: {
         body: PlexStreamSettingsSchema,
@@ -80,7 +80,7 @@ export const plexSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.post(
-    '/api/plex-settings',
+    '/plex-settings',
     {
       schema: {
         response: {

--- a/server/src/api/xmltvSettingsApi.ts
+++ b/server/src/api/xmltvSettingsApi.ts
@@ -1,5 +1,4 @@
 import { XmlTvSettings } from '@tunarr/types';
-import { BaseErrorSchema } from '@tunarr/types/api';
 import { XmlTvSettingsSchema } from '@tunarr/types/schemas';
 import { isError } from 'lodash-es';
 import { z } from 'zod';
@@ -10,6 +9,7 @@ import { UpdateXmlTvTask } from '../tasks/updateXmlTvTask.js';
 import { RouterPluginCallback } from '../types/serverType.js';
 import { firstDefined } from '../util/index.js';
 import { LoggerFactory } from '../util/logging/LoggerFactory.js';
+import { BaseErrorSchema } from '@tunarr/types/api';
 
 export const xmlTvSettingsRouter: RouterPluginCallback = (
   fastify,
@@ -19,7 +19,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
   const logger = LoggerFactory.child({ caller: import.meta });
 
   fastify.get(
-    '/api/xmltv-settings',
+    '/xmltv-settings',
     {
       schema: {
         response: {
@@ -38,7 +38,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.put(
-    '/api/xmltv-settings',
+    '/xmltv-settings',
     {
       schema: {
         response: {
@@ -88,7 +88,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
   );
 
   fastify.post(
-    '/api/xmltv-settings',
+    '/xmltv-settings',
     {
       schema: {
         response: {

--- a/server/src/hdhr.ts
+++ b/server/src/hdhr.ts
@@ -1,28 +1,13 @@
-import { FastifyPluginAsync } from 'fastify';
 import { Server as SSDP } from 'node-ssdp';
-import { z } from 'zod';
-import { ChannelDB } from './dao/channelDb.js';
 import { SettingsDB } from './dao/settings.js';
 import { serverOptions } from './globals.js';
-import { LoggerFactory } from './util/logging/LoggerFactory.js';
-
-const LineupSchema = z.object({
-  GuideNumber: z.string(),
-  GuideName: z.string(),
-  URL: z.string().url(),
-});
-
-type LineupItem = z.infer<typeof LineupSchema>;
 
 export class HdhrService {
-  private logger = LoggerFactory.child({ caller: import.meta });
   private db: SettingsDB;
-  private channelDB: ChannelDB;
   private server: SSDP;
 
-  constructor(db: SettingsDB, channelDB: ChannelDB) {
+  constructor(db: SettingsDB) {
     this.db = db;
-    this.channelDB = channelDB;
     this.server = new SSDP({
       location: {
         port: serverOptions().port,
@@ -45,109 +30,38 @@ export class HdhrService {
     return this.server;
   }
 
-  createRouter(): FastifyPluginAsync {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    return async (fastify) => {
-      fastify.addHook('onError', (req, _, error, done) => {
-        this.logger.error({ url: req.routeOptions.config.url, error });
-        done();
-      });
-
-      fastify.get('/device.xml', (req, res) => {
-        req.disableRequestLogging = true;
-        const device = getDevice(this.db, req.protocol + '://' + req.hostname);
-        const data = device.getXml();
-        return res.header('Content-Type', 'application/xml').send(data);
-      });
-
-      fastify.get('/discover.json', (req, res) => {
-        req.disableRequestLogging = true;
-        const device = getDevice(this.db, req.protocol + '://' + req.hostname);
-        return res.send(device);
-      });
-
-      fastify.get('/lineup_status.json', (req, res) => {
-        req.disableRequestLogging = true;
-        return res.send({
-          ScanInProgress: 0,
-          ScanPossible: 1,
-          Source: 'Cable',
-          SourceList: ['Cable'],
-        });
-      });
-
-      fastify.get(
-        '/lineup.json',
-        {
-          onRequest(req, _, done) {
-            req.disableRequestLogging = true;
-            done();
-          },
-          schema: {
-            response: {
-              200: z.array(LineupSchema),
-            },
-          },
-        },
-        async (req, res) => {
-          const lineup: LineupItem[] = [];
-          const channels = await this.channelDB.getAllChannels();
-          for (const channel of channels) {
-            if (channel.stealth) {
-              continue;
-            }
-
-            lineup.push({
-              GuideNumber: channel.number.toString(),
-              GuideName: channel.name,
-              URL: `${req.protocol}://${req.hostname}/channels/${channel.number}/video`,
-            });
-          }
-          if (lineup.length === 0)
-            lineup.push({
-              GuideNumber: '1',
-              GuideName: 'Tunarr',
-              URL: `${req.protocol}://${req.hostname}/setup`,
-            });
-
-          return res.send(lineup);
-        },
-      );
+  getHdhrDevice(host: string) {
+    return {
+      FriendlyName: 'Tunarr',
+      Manufacturer: 'Tunarr - Silicondust',
+      ManufacturerURL: 'https://github.com/chrisbenincasa/tunarr',
+      ModelNumber: 'HDTC-2US',
+      FirmwareName: 'hdhomeruntc_atsc',
+      TunerCount: this.db.hdhrSettings().tunerCount,
+      FirmwareVersion: '20170930',
+      DeviceID: 'Tunarr',
+      DeviceAuth: '',
+      BaseURL: `${host}`,
+      LineupURL: `${host}/lineup.json`,
     };
   }
-}
 
-function getDevice(db: SettingsDB, host: string) {
-  const hdhrSettings = db.hdhrSettings();
-  return {
-    FriendlyName: 'Tunarr',
-    Manufacturer: 'Tunarr - Silicondust',
-    ManufacturerURL: 'https://github.com/chrisbenincasa/tunarr',
-    ModelNumber: 'HDTC-2US',
-    FirmwareName: 'hdhomeruntc_atsc',
-    TunerCount: hdhrSettings.tunerCount,
-    FirmwareVersion: '20170930',
-    DeviceID: 'Tunarr',
-    DeviceAuth: '',
-    BaseURL: `${host}`,
-    LineupURL: `${host}/lineup.json`,
-    getXml: () => {
-      return `<root xmlns="urn:schemas-upnp-org:device-1-0">
-        <URLBase>${host}</URLBase>
-        <specVersion>
-          <major>1</major>
-          <minor>0</minor>
-        </specVersion>
-        <device>
-          <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
-          <friendlyName>Tunarr</friendlyName>
-          <manufacturer>Silicondust</manufacturer>
-          <modelName>HDTC-2US</modelName>
-          <modelNumber>HDTC-2US</modelNumber>
-          <serialNumber/>
-          <UDN>uuid:d936e232-6671-4cd7-a8ab-34b5956ff4d6</UDN>
-        </device>
-        </root>`;
-    },
-  };
+  getHdhrDeviceXml(host: string) {
+    return `<root xmlns="urn:schemas-upnp-org:device-1-0">
+          <URLBase>${host}</URLBase>
+          <specVersion>
+            <major>1</major>
+            <minor>0</minor>
+          </specVersion>
+          <device>
+            <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
+            <friendlyName>Tunarr</friendlyName>
+            <manufacturer>Silicondust</manufacturer>
+            <modelName>HDTC-2US</modelName>
+            <modelNumber>HDTC-2US</modelNumber>
+            <serialNumber/>
+            <UDN>uuid:d936e232-6671-4cd7-a8ab-34b5956ff4d6</UDN>
+          </device>
+          </root>`;
+  }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,7 +71,7 @@ yargs(hideBin(process.argv))
         })
         .option('printRoutes', {
           type: 'boolean',
-          default: false,
+          default: Boolean(process.env['TUNARR_SERVER_PRINT_ROUTES']),
         });
     },
     async (args: ArgumentsCamelCase<ServerOptions>) => {

--- a/server/src/serverContext.ts
+++ b/server/src/serverContext.ts
@@ -64,7 +64,7 @@ export const serverContext: () => ServerContext = once(() => {
     m3uService,
     eventService,
     guideService,
-    hdhrService: new HdhrService(settings, channelDB),
+    hdhrService: new HdhrService(settings),
     customShowDB,
     channelCache,
     plexServerDB: new PlexServerDB(channelDB),


### PR DESCRIPTION
Also bumps verison of fastify-print-routes which includes fix for
printing routes in configurations like ours. This is hidden behind a
server option / env variable.

Moves mounting of routes prefixed with /api into the top-level
api-controller. One step towards cleaning up server initialization more.
