### PR TITLE
FFMPEG Concat stream rewrite - still a WIP

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,8 +339,8 @@ importers:
         specifier: ^7.5.0
         version: 7.5.0(eslint@8.56.0)(typescript@5.4.3)
       vitest:
-        specifier: ^1.2.0
-        version: 1.2.0(@types/node@20.8.9)
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@20.8.9)
 
   shared:
     dependencies:
@@ -565,7 +565,7 @@ importers:
         version: 4.4.5
       vitest:
         specifier: ^1.2.0
-        version: 1.2.0(@types/node@20.8.9)
+        version: 1.2.0
 
 packages:
 
@@ -3430,10 +3430,26 @@ packages:
       chai: 4.3.10
     dev: true
 
+  /@vitest/expect@1.6.0:
+    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
+    dependencies:
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      chai: 4.3.10
+    dev: true
+
   /@vitest/runner@1.2.0:
     resolution: {integrity: sha512-vaJkDoQaNUTroT70OhM0NPznP7H3WyRwt4LvGwCVYs/llLaqhoSLnlIhUClZpbF5RgAee29KRcNz0FEhYcgxqA==}
     dependencies:
       '@vitest/utils': 1.2.0
+      p-limit: 5.0.0
+      pathe: 1.1.1
+    dev: true
+
+  /@vitest/runner@1.6.0:
+    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+    dependencies:
+      '@vitest/utils': 1.6.0
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: true
@@ -3446,14 +3462,37 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /@vitest/snapshot@1.6.0:
+    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+    dependencies:
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      pretty-format: 29.7.0
+    dev: true
+
   /@vitest/spy@1.2.0:
     resolution: {integrity: sha512-MNxSAfxUaCeowqyyGwC293yZgk7cECZU9wGb8N1pYQ0yOn/SIr8t0l9XnGRdQZvNV/ZHBYu6GO/W3tj5K3VN1Q==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
+  /@vitest/spy@1.6.0:
+    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+    dependencies:
+      tinyspy: 2.2.0
+    dev: true
+
   /@vitest/utils@1.2.0:
     resolution: {integrity: sha512-FyD5bpugsXlwVpTcGLDf3wSPYy8g541fQt14qtzo8mJ4LdEpDKZ9mQy2+qdJm2TZRpjY5JLXihXCgIxiRJgi5g==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/utils@1.6.0:
+    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -7210,6 +7249,10 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-tokens@9.0.0:
+    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+    dev: true
+
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -10099,6 +10142,12 @@ packages:
       acorn: 8.11.3
     dev: true
 
+  /strip-literal@2.1.0:
+    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
+    dependencies:
+      js-tokens: 9.0.0
+    dev: true
+
   /strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
@@ -10331,6 +10380,11 @@ packages:
 
   /tinypool@0.8.1:
     resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -10992,8 +11046,29 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite-node@1.2.0(@types/node@20.8.9):
+  /vite-node@1.2.0:
     resolution: {integrity: sha512-ETnQTHeAbbOxl7/pyBck9oAPZZZo+kYnFt1uQDD+hPReOc+wCjXw4r4jHriBRuVDB5isHmPXxrfc1yJnfBERqg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@5.5.0)
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.11(@types/node@20.8.9)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-node@1.6.0(@types/node@20.8.9):
+    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -11084,7 +11159,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.0(@types/node@20.8.9):
+  /vitest@1.2.0:
     resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -11109,7 +11184,6 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.8.9
       '@vitest/expect': 1.2.0
       '@vitest/runner': 1.2.0
       '@vitest/snapshot': 1.2.0
@@ -11129,7 +11203,63 @@ packages:
       tinybench: 2.5.1
       tinypool: 0.8.1
       vite: 5.0.11(@types/node@20.8.9)
-      vite-node: 1.2.0(@types/node@20.8.9)
+      vite-node: 1.2.0
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.6.0(@types/node@20.8.9):
+    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.0
+      '@vitest/ui': 1.6.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.8.9
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.2
+      chai: 4.3.10
+      debug: 4.3.4(supports-color@5.5.0)
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.5.1
+      tinypool: 0.8.4
+      vite: 5.0.11(@types/node@20.8.9)
+      vite-node: 1.6.0(@types/node@20.8.9)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/server/package.json
+++ b/server/package.json
@@ -118,7 +118,7 @@
     "typed-emitter": "^2.1.0",
     "typescript": "5.4.3",
     "typescript-eslint": "^7.5.0",
-    "vitest": "^1.2.0"
+    "vitest": "^1.6.0"
   },
   "mikro-orm": {
     "configPaths": [

--- a/server/src/api/hlsApi.ts
+++ b/server/src/api/hlsApi.ts
@@ -24,7 +24,7 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         const channelId = matches[1];
         req.streamChannel = channelId;
         const token = query['token'];
-        const session = sessionManager.getSession(channelId);
+        const session = sessionManager.getHlsSession(channelId);
         if (isNil(session)) {
           void res.status(404).send();
           return;
@@ -54,7 +54,7 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         !isNil(token) &&
         !isNil(req.streamChannel)
       ) {
-        const session = sessionManager.getSession(req.streamChannel);
+        const session = sessionManager.getHlsSession(req.streamChannel);
         session?.recordHeartbeat(req.ip);
         if (!isNil(session) && session.isKnownConnection(token)) {
           session.recordHeartbeat(token);
@@ -81,7 +81,7 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         },
       },
       async (req, res) => {
-        const session = sessionManager.getSession(req.params.id);
+        const session = sessionManager.getHlsSession(req.params.id);
         if (isUndefined(session)) {
           return res.status(404).send();
         }
@@ -118,12 +118,14 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
       // How should we handle this...
       // const token = req.query.token ?? v4();
 
-      const session = await sessionManager.getOrCreateSession(
+      const session = await sessionManager.getOrCreateHlsSession(
         req.params.id,
-        req.serverCtx.settings.ffmpegSettings(),
         req.ip,
         {
           ip: req.ip,
+        },
+        {
+          sessionType: 'hls',
         },
       );
 
@@ -157,12 +159,14 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
 
       const token = v4();
 
-      const session = await sessionManager.getOrCreateSession(
+      const session = await sessionManager.getOrCreateHlsSession(
         channel.uuid,
-        req.serverCtx.settings.ffmpegSettings(),
         token,
         {
           ip: req.ip,
+        },
+        {
+          sessionType: 'hls',
         },
       );
 
@@ -193,7 +197,7 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         return res.status(404).send("Channel doesn't exist");
       }
 
-      const session = sessionManager.getSession(channel.uuid);
+      const session = sessionManager.getHlsSession(channel.uuid);
 
       return res.send({
         channelId: channel.uuid,
@@ -224,7 +228,7 @@ export const hlsApi: RouterPluginAsyncCallback = async (fastify) => {
         return res.status(404).send("Channel doesn't exist");
       }
 
-      const session = sessionManager.getSession(channel.uuid);
+      const session = sessionManager.getHlsSession(channel.uuid);
 
       if (isNil(session)) {
         return res.status(404).send('No sessions for channel');

--- a/server/src/stream/ConcatSession.ts
+++ b/server/src/stream/ConcatSession.ts
@@ -1,0 +1,38 @@
+import { isUndefined } from 'lodash-es';
+import { Maybe } from '../types/util';
+import { ConcatStream, VideoStreamResult } from './ConcatStream';
+import { SessionOptions, StreamSession } from './session';
+import { Channel } from '../dao/entities/Channel';
+
+export class ConcatSession extends StreamSession {
+  private streamStopFunc: Maybe<() => void>;
+
+  protected constructor(channel: Channel, options: SessionOptions) {
+    super(channel, options);
+  }
+
+  static create(channel: Channel, options: SessionOptions) {
+    return new ConcatSession(channel, options);
+  }
+
+  protected async initializeStream(): Promise<VideoStreamResult> {
+    const result = await new ConcatStream().startStream(
+      this.channel.uuid,
+      /* audioOnly */ false,
+    );
+
+    if (result.type === 'success') {
+      this.streamStopFunc = result.stop.bind(result) as () => void;
+    }
+
+    return result;
+  }
+
+  protected stopStream(): Promise<void> {
+    if (!isUndefined(this.streamStopFunc)) {
+      return Promise.resolve(this.streamStopFunc());
+    }
+
+    return Promise.resolve(void 0);
+  }
+}

--- a/server/src/stream/HlsSession.ts
+++ b/server/src/stream/HlsSession.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs/promises';
+import retry from 'async-retry';
+import { SessionOptions, StreamReadyResult, StreamSession } from './session';
+import { isNodeError } from '../util';
+import { isError, isString } from 'lodash-es';
+import { ConcatStream } from './ConcatStream';
+import { Channel } from '../dao/entities/Channel';
+import { join, resolve } from 'node:path';
+
+export type HlsSessionOptions = SessionOptions & {
+  sessionType: 'hls';
+};
+
+export class HlsSession extends StreamSession {
+  #outPath: string;
+  // Absolute path to the stream directory
+  #streamPath: string;
+  // The path to request streaming assets from the server
+  #serverPath: string;
+
+  constructor(channel: Channel, options: HlsSessionOptions) {
+    super(channel, options);
+    this.#outPath = resolve(
+      process.cwd(),
+      'streams',
+      `stream_${this.channel.uuid}`,
+    );
+    this.#streamPath = join(this.#outPath, 'stream.m3u8');
+    // Direct players back to the /hls URL which will return the playlist
+    this.#serverPath = `/media-player/${this.channel.uuid}/hls`;
+  }
+
+  get workingDirectory() {
+    return this.#outPath;
+  }
+
+  get streamPath() {
+    return this.#streamPath;
+  }
+
+  get serverPath() {
+    return this.#serverPath;
+  }
+
+  protected async initializeStream() {
+    this.logger.debug(`Creating stream directory: ${this.#outPath}`);
+
+    try {
+      await fs.stat(this.#outPath);
+      await this.cleanupDirectory();
+    } catch (e) {
+      if (isNodeError(e) && e.code === 'ENOENT') {
+        this.logger.debug("[Session %s]: Stream directory doesn't exist.");
+      }
+    } finally {
+      await fs.mkdir(this.#outPath);
+    }
+
+    return await new ConcatStream().startStream(
+      this.channel.uuid,
+      /* audioOnly */ false,
+      {
+        enableHls: true,
+        hlsOptions: {
+          streamBasePath: `stream_${this.channel.uuid}`,
+          hlsTime: 3,
+          hlsListSize: 8,
+        },
+        logOutput: false,
+      },
+    );
+  }
+
+  protected override async waitForStreamReady(): Promise<StreamReadyResult> {
+    // Wait for the stream to become ready
+    try {
+      await retry(
+        async (bail) => {
+          try {
+            await fs.stat(this.#streamPath);
+          } catch (e) {
+            if (isNodeError(e) && e.code === 'ENOENT') {
+              this.logger.debug('Still waiting for stream session to start.');
+              throw e; // Retry
+            } else {
+              this.state === 'error';
+              bail(isError(e) ? e : new Error('Unexplained error: ' + e));
+            }
+          }
+        },
+        {
+          retries: 10,
+          factor: 1.2,
+        },
+      );
+      return {
+        type: 'success',
+      };
+    } catch (e) {
+      this.logger.error(e, 'Error starting stream after retrying');
+      this.state = 'error';
+      return {
+        type: 'error',
+        error: isError(e) ? e : new Error(isString(e) ? e : 'Unknown error'),
+      };
+    }
+  }
+
+  protected async stopStream(): Promise<void> {
+    this.logger.debug(
+      `Cleaning out stream path for session: %s`,
+      this.#outPath,
+    );
+    return await this.cleanupDirectory();
+  }
+
+  private async cleanupDirectory() {
+    try {
+      return await fs.rm(this.#outPath, {
+        recursive: true,
+        force: true,
+      });
+    } catch (err) {
+      return this.logger.error(
+        err,
+        'Failed to cleanup stream: %s %O',
+        this.channel.uuid,
+      );
+    }
+  }
+}

--- a/server/src/stream/VideoStream.ts
+++ b/server/src/stream/VideoStream.ts
@@ -363,14 +363,14 @@ export class VideoStream {
     };
 
     try {
-      this.logger.info('About to play stream...');
+      this.logger.trace('About to play stream...');
       const ffmpegEmitter = await player.play(outStream);
       ffmpegEmitter?.on('error', (err) => {
         this.logger.error('Error while playing video: %O', err);
       });
 
       ffmpegEmitter?.on('end', () => {
-        this.logger.debug('playObj.end');
+        this.logger.trace('playObj.end');
         stop();
       });
     } catch (err) {
@@ -386,7 +386,7 @@ export class VideoStream {
 
     const logTimer = once(() => {
       const dur = performance.now() - start;
-      this.logger.debug('Video stream started in %d seconds', dur);
+      this.logger.debug('Video stream started in %d ms', dur);
       outStream.off('data', logTimer);
     });
     outStream.on('data', logTimer);

--- a/server/src/stream/plex/plexPlayer.ts
+++ b/server/src/stream/plex/plexPlayer.ts
@@ -136,12 +136,12 @@ export class PlexPlayer extends Player {
     });
 
     ffmpeg.on('end', () => {
-      this.logger.info('ffmpeg end');
+      this.logger.trace('ffmpeg end');
       emitter.emit('end');
     });
 
     ffmpeg.on('close', () => {
-      this.logger.info('ffmpeg close');
+      this.logger.trace('ffmpeg close');
       emitter.emit('close');
     });
 

--- a/server/src/tasks/cleanupSessionsTask.ts
+++ b/server/src/tasks/cleanupSessionsTask.ts
@@ -24,19 +24,38 @@ export class CleanupSessionsTask extends Task<void> {
     const now = new Date().getTime();
 
     forEach(sessions, (session) => {
-      const [aliveConnections, staleConnections] = ld
-        .chain(keys(session.connections()))
-        .partition(
-          (token) => now - session.lastHeartbeat(token) < ThirtySeconds,
-        )
-        .value();
+      // Handle HLS stale sessions differently
+      if (session.sessionType === 'hls') {
+        const [aliveConnections, staleConnections] = ld
+          .chain(keys(session.connections()))
+          .partition(
+            (token) => now - session.lastHeartbeat(token) < ThirtySeconds,
+          )
+          .value();
 
-      // Cleanup stale connections
+        // Cleanup stale connections
+        forEach(staleConnections, (conn) => session.removeConnection(conn));
 
-      forEach(staleConnections, (conn) => session.removeConnection(conn));
+        if (isEmpty(aliveConnections)) {
+          this.logger.debug(
+            'Scheduled cleanup on session (%s) %s in 40 seconds',
+            session.sessionType,
+            session.id,
+          );
+          session.scheduleCleanup(30000);
+        }
 
-      if (isEmpty(aliveConnections)) {
-        session.scheduleCleanup(30000);
+        return;
+      }
+
+      if (session.sessionType === 'concat' && isEmpty(session.connections())) {
+        // TODO Make this timeout configurable.
+        this.logger.debug(
+          'Scheduled cleanup on session (%s) %s in 15 seconds',
+          session.sessionType,
+          session.id,
+        );
+        session.scheduleCleanup(15000);
       }
     });
   }

--- a/web/src/hooks/programming_controls/useRemoveFlex.ts
+++ b/web/src/hooks/programming_controls/useRemoveFlex.ts
@@ -1,12 +1,20 @@
+import { reject } from 'lodash-es';
+import { setCurrentLineup } from '../../store/channelEditor/actions.ts';
 import useStore from '../../store/index.ts';
 import { materializedProgramListSelector } from '../../store/selectors.ts';
-import { setCurrentLineup } from '../../store/channelEditor/actions.ts';
-import _ from 'lodash-es';
 
 export function useRemoveFlex() {
   const programs = useStore(materializedProgramListSelector);
 
   return function () {
-    setCurrentLineup(_.filter(programs, (program) => program.type != 'flex'));
+    let changed = false;
+    const newLineup = reject(programs, (program) => {
+      if (program.type === 'flex') {
+        changed = true;
+        return true;
+      }
+      return false;
+    });
+    setCurrentLineup(newLineup, changed ? changed : undefined);
   };
 }


### PR DESCRIPTION
Rewrites the way that the concat (direct) streaming works, namely:

* Internal stream endpoints now output video/audio in raw formats (no encoding). These streams are outputted to an mkv, but we will also look into using nut as a possible intermediate container here as well.
* The concat stream (that the user interacts with) consumes raw output and encodes it, applying other normalization filters (bitrate, etc)
* The concat stream is now session based, so duplicate requests for the same direct stream will reuse the same underlying concat process

**NOTE**: These changes effectively make FFMPEG transcoding in Tunarr REQUIRED. We plan on changing the UI to show this, too.

Also includes a bunch of fixes to ffmpeg params to help make the stream more stable, including:

* Params to ensure that timestamps are always monotonically increasing -- this coincides with the change to make the concat stream do the encoding as well (thanks @jasongdove for the tips / guidance here!)
* mpegts initial_discontinuity flag
* pixel format flags
* audio resampling, pts flags

We are still investigating some things relating to stream stability on transitions and quality issues. 

TODO: 
* Ensure that in-browser HLS streaming still works as expected
* Continue work on stream stability and quality improvements
* Cleanup event emitting and logging among ffmpeg code -- this is really a mess and makes debugging difficult.
* UI updates to denote the FFMPEG is required to run Tunarr
* Soon, removing Plex transcoder and consolidating all normalization logic into Tunarr
