### PR TITLE
Remove ability to disable ffmpeg transcoding; Fixes #440

### DIFF
--- a/server/src/api/videoApi.ts
+++ b/server/src/api/videoApi.ts
@@ -283,7 +283,7 @@ export const videoRouter: RouterPluginAsyncCallback = async (fastify) => {
       return res
         .type('application/x-mpegURL')
         .send(
-          await req.serverCtx.m3uService.buildChannelM3U(
+          req.serverCtx.m3uService.buildChannelM3U(
             req.protocol,
             req.hostname,
             req.params.id,

--- a/server/src/dao/legacy_migration/legacyDbMigration.ts
+++ b/server/src/dao/legacy_migration/legacyDbMigration.ts
@@ -362,9 +362,8 @@ export class LegacyDbMigrator {
                 numThreads: ffmpegSettings['threads'] as number,
                 concatMuxDelay: ffmpegSettings['concatMuxDelay'] as number,
                 enableLogging: ffmpegSettings['logFfmpeg'] as boolean,
-                enableTranscoding: ffmpegSettings[
-                  'enableFFMPEGTranscoding'
-                ] as boolean,
+                // This is ignored now
+                enableTranscoding: true,
                 audioVolumePercent: ffmpegSettings[
                   'audioVolumePercent'
                 ] as number,

--- a/server/src/services/m3uService.ts
+++ b/server/src/services/m3uService.ts
@@ -1,7 +1,6 @@
 import { sortBy } from 'lodash-es';
 import { ChannelDB } from '../dao/channelDb.js';
 import { FileCacheService } from './fileCacheService.js';
-import { getSettings } from '../dao/settings.js';
 
 /**
  * Manager and Generate M3U content
@@ -80,13 +79,12 @@ export class M3uService {
     return this.replaceHostOnM3u(host, data);
   }
 
-  async buildChannelM3U(
+  buildChannelM3U(
     protocol: string,
     host: string,
     channel: string | number,
     sessionId: number,
   ) {
-    const settings = await getSettings();
     // Maximum number of streams to concatinate beyond channel starting
     // If someone passes this number then they probably watch too much television
     const maxStreamsToPlayInARow = 100;
@@ -101,13 +99,9 @@ export class M3uService {
       // `#EXT-X-STREAM-INF:BANDWIDTH=1123000`,
     ];
 
-    const ffmpegSettings = settings.ffmpegSettings();
-
-    if (ffmpegSettings.enableTranscoding) {
-      lines.push(
-        `${protocol}://${host}/stream?channel=${channel}&first=0&m3u8=1&session=${sessionId}`,
-      );
-    }
+    lines.push(
+      `${protocol}://${host}/stream?channel=${channel}&first=0&m3u8=1&session=${sessionId}`,
+    );
 
     lines.push(
       `${protocol}://${host}/stream?channel=${channel}&first=1&m3u8=1&session=${sessionId}`,

--- a/server/src/stream/plex/plexPlayer.ts
+++ b/server/src/stream/plex/plexPlayer.ts
@@ -12,11 +12,10 @@ import { Writable } from 'stream';
 import { isContentBackedLineupIteam } from '../../dao/derived_types/StreamLineup.js';
 import { PlexServerSettings } from '../../dao/entities/PlexServerSettings.js';
 import { FFMPEG, FfmpegEvents } from '../../ffmpeg/ffmpeg.js';
-import { Player } from '../player.js';
-import { PlexTranscoder } from './plexTranscoder.js';
-import { PlayerContext } from '../player.js';
 import { TypedEventEmitter } from '../../types/eventEmitter.js';
 import { LoggerFactory } from '../../util/logging/LoggerFactory.js';
+import { Player, PlayerContext } from '../player.js';
+import { PlexTranscoder } from './plexTranscoder.js';
 
 const USED_CLIENTS: Record<string, boolean> = {};
 export class PlexPlayer extends Player {
@@ -99,9 +98,8 @@ export class PlexPlayer extends Player {
     ) {
       streamDuration = lineupItem.streamDuration / 1000;
     }
-    const deinterlace = ffmpegSettings.enableTranscoding; //for now it will always deinterlace when transcoding is enabled but this is sub-optimal
 
-    const stream = await plexTranscoder.getStream(deinterlace);
+    const stream = await plexTranscoder.getStream(/* deinterlace=*/ true);
     if (this.killed) {
       return;
     }

--- a/server/src/stream/programPlayer.ts
+++ b/server/src/stream/programPlayer.ts
@@ -158,10 +158,7 @@ export class ProgramPlayer extends Player {
     channel: StreamContextChannel,
     type: string,
   ): Maybe<Watermark> {
-    if (
-      !ffmpegSettings.enableTranscoding ||
-      ffmpegSettings.disableChannelOverlay
-    ) {
+    if (ffmpegSettings.disableChannelOverlay) {
       return;
     }
 

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -14,6 +14,7 @@ export const FfmpegSettingsSchema = z.object({
   numThreads: z.number().default(4),
   concatMuxDelay: z.number().default(0),
   enableLogging: z.boolean().default(false),
+  // DEPRECATED
   enableTranscoding: z.boolean().default(true),
   audioVolumePercent: z.number().default(100),
   videoEncoder: z.string().default('mpeg2video'),

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -338,9 +338,7 @@ export default function ChannelTranscodingConfig() {
                 name="transcoding.targetResolution"
                 render={() => (
                   <Select<ResolutionOptionValues>
-                    disabled={
-                      isNil(ffmpegSettings) || !ffmpegSettings.enableTranscoding
-                    }
+                    disabled={isNil(ffmpegSettings)}
                     label="Channel Resolution"
                     value={targetResString}
                     onChange={(e) => handleResolutionChange(e)}
@@ -364,9 +362,7 @@ export default function ChannelTranscodingConfig() {
               <Controller
                 control={control}
                 name="transcoding.videoBitrate"
-                disabled={
-                  isNil(ffmpegSettings) || !ffmpegSettings.enableTranscoding
-                }
+                disabled={isNil(ffmpegSettings)}
                 rules={{ pattern: globalOrNumber }}
                 render={({ field, formState: { errors } }) => (
                   <TextField
@@ -391,9 +387,7 @@ export default function ChannelTranscodingConfig() {
               <Controller
                 control={control}
                 name="transcoding.videoBufferSize"
-                disabled={
-                  isNil(ffmpegSettings) || !ffmpegSettings.enableTranscoding
-                }
+                disabled={isNil(ffmpegSettings)}
                 rules={{ pattern: globalOrNumber }}
                 render={({ field, formState: { errors } }) => (
                   <TextField

--- a/web/src/pages/settings/FfmpegSettingsPage.tsx
+++ b/web/src/pages/settings/FfmpegSettingsPage.tsx
@@ -139,14 +139,11 @@ export default function FfmpegSettingsPage() {
     reset,
     control,
     formState: { isDirty, isValid, isSubmitting, defaultValues },
-    watch,
     handleSubmit,
   } = useForm<Omit<FfmpegSettings, 'configVersion'>>({
     defaultValues: defaultFfmpegSettings,
     mode: 'onBlur',
   });
-
-  const enableTranscoding = watch('enableTranscoding');
 
   useEffect(() => {
     if (data) {
@@ -644,148 +641,125 @@ export default function FfmpegSettingsPage() {
       <Typography variant="h6" sx={{ my: 2 }}>
         Transcoding Options
       </Typography>
-      <FormControl>
+      <Grid container spacing={2} columns={16}>
+        <Grid item sm={16} md={8}>
+          <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
+            Video Options
+          </Typography>
+          {videoFfmpegSettings()}
+        </Grid>
+        <Grid item sm={16} md={8}>
+          <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
+            Audio Options
+          </Typography>
+          {audioFfmpegSettings()}
+        </Grid>
+      </Grid>
+      <Divider sx={{ mt: 2 }} />
+      <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
+        Error Options
+      </Typography>
+      <Grid container spacing={2} columns={16}>
+        <Grid item sm={16} md={8}>
+          <FormControl sx={{ mt: 2 }}>
+            <InputLabel id="error-screen-label">Error Screen</InputLabel>
+            <Controller
+              control={control}
+              name="errorScreen"
+              render={({ field }) => (
+                <Select
+                  labelId="error-screen-label"
+                  id="error-screen"
+                  label="Error Screen"
+                  {...field}
+                >
+                  {supportedErrorScreens.map((error) => (
+                    <MenuItem key={error.value} value={error.value}>
+                      {error.string}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+
+            <FormHelperText>
+              If there are issues playing a video, Tunarr will try to use an
+              error screen as a placeholder while retrying loading the video
+              every 60 seconds.
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+        <Grid item sm={16} md={8}>
+          <FormControl sx={{ mt: 2 }}>
+            <InputLabel id="error-audio-label">Error Audio</InputLabel>
+            <Controller
+              control={control}
+              name="errorAudio"
+              render={({ field }) => (
+                <Select
+                  labelId="error-audio-label"
+                  id="error-screen"
+                  label="Error Audio"
+                  fullWidth
+                  {...field}
+                >
+                  {supportedErrorAudio.map((error) => (
+                    <MenuItem key={error.value} value={error.value}>
+                      {error.string}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+          </FormControl>
+        </Grid>
+      </Grid>
+      <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
+        Misc Options
+      </Typography>
+
+      <FormControl fullWidth>
         <FormControlLabel
           control={
             <Controller
               control={control}
-              name="enableTranscoding"
+              name="disableChannelOverlay"
               render={({ field }) => (
-                <Checkbox checked={field.value} {...field} />
+                <Checkbox {...field} checked={field.value} />
               )}
             />
           }
-          label="Enable FFMPEG Transcoding"
+          label="Disable Channel Watermark Globally"
         />
         <FormHelperText>
-          Transcoding is required for some features like channel overlay and
-          measures to prevent issues when switching episodes. The trade-off is
-          quality loss and additional computing resource requirements.
+          Toggling this option will disable channel watermarks regardless of
+          channel settings.
         </FormHelperText>
       </FormControl>
-      {enableTranscoding && (
-        <>
-          <Grid container spacing={2} columns={16}>
-            <Grid item sm={16} md={8}>
-              <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
-                Video Options
-              </Typography>
-              {videoFfmpegSettings()}
-            </Grid>
-            <Grid item sm={16} md={8}>
-              <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
-                Audio Options
-              </Typography>
-              {audioFfmpegSettings()}
-            </Grid>
-          </Grid>
-          <Divider sx={{ mt: 2 }} />
-          <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
-            Error Options
-          </Typography>
-          <Grid container spacing={2} columns={16}>
-            <Grid item sm={16} md={8}>
-              <FormControl sx={{ mt: 2 }}>
-                <InputLabel id="error-screen-label">Error Screen</InputLabel>
-                <Controller
-                  control={control}
-                  name="errorScreen"
-                  render={({ field }) => (
-                    <Select
-                      labelId="error-screen-label"
-                      id="error-screen"
-                      label="Error Screen"
-                      {...field}
-                    >
-                      {supportedErrorScreens.map((error) => (
-                        <MenuItem key={error.value} value={error.value}>
-                          {error.string}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  )}
-                />
 
-                <FormHelperText>
-                  If there are issues playing a video, Tunarr will try to use an
-                  error screen as a placeholder while retrying loading the video
-                  every 60 seconds.
-                </FormHelperText>
-              </FormControl>
-            </Grid>
-            <Grid item sm={16} md={8}>
-              <FormControl sx={{ mt: 2 }}>
-                <InputLabel id="error-audio-label">Error Audio</InputLabel>
-                <Controller
-                  control={control}
-                  name="errorAudio"
-                  render={({ field }) => (
-                    <Select
-                      labelId="error-audio-label"
-                      id="error-screen"
-                      label="Error Audio"
-                      fullWidth
-                      {...field}
-                    >
-                      {supportedErrorAudio.map((error) => (
-                        <MenuItem key={error.value} value={error.value}>
-                          {error.string}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  )}
-                />
-              </FormControl>
-            </Grid>
-          </Grid>
-          <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 1 }}>
-            Misc Options
-          </Typography>
-
-          <FormControl fullWidth>
-            <FormControlLabel
-              control={
-                <Controller
-                  control={control}
-                  name="disableChannelOverlay"
-                  render={({ field }) => (
-                    <Checkbox {...field} checked={field.value} />
-                  )}
-                />
-              }
-              label="Disable Channel Watermark Globally"
+      <FormControl fullWidth>
+        <FormControlLabel
+          control={
+            <Controller
+              control={control}
+              name="disableChannelPrelude"
+              render={({ field }) => (
+                <Checkbox {...field} checked={field.value} />
+              )}
             />
-            <FormHelperText>
-              Toggling this option will disable channel watermarks regardless of
-              channel settings.
-            </FormHelperText>
-          </FormControl>
+          }
+          label="Disable Channel Prelude"
+        />
+        <FormHelperText>
+          In an attempt to improve playback, Tunarr insets really short clips of
+          black screen between videos. The idea is that if the stream pauses
+          because Plex is taking too long to reply, it will pause during one of
+          those black screens instead of interrupting the last second of a
+          video. If you suspect these black screens are causing trouble instead
+          of helping, you can disable them with this option.
+        </FormHelperText>
+      </FormControl>
 
-          <FormControl fullWidth>
-            <FormControlLabel
-              control={
-                <Controller
-                  control={control}
-                  name="disableChannelPrelude"
-                  render={({ field }) => (
-                    <Checkbox {...field} checked={field.value} />
-                  )}
-                />
-              }
-              label="Disable Channel Prelude"
-            />
-            <FormHelperText>
-              In an attempt to improve playback, Tunarr insets really short
-              clips of black screen between videos. The idea is that if the
-              stream pauses because Plex is taking too long to reply, it will
-              pause during one of those black screens instead of interrupting
-              the last second of a video. If you suspect these black screens are
-              causing trouble instead of helping, you can disable them with this
-              option.
-            </FormHelperText>
-          </FormControl>
-        </>
-      )}
       <UnsavedNavigationAlert isDirty={isDirty} />
       <Stack spacing={2} direction="row" sx={{ mt: 2 }}>
         <Stack

--- a/web/src/pages/welcome/WelcomePage.tsx
+++ b/web/src/pages/welcome/WelcomePage.tsx
@@ -175,7 +175,7 @@ export default function WelcomePage() {
 
               {isFfmpegInstalled ? (
                 <Alert variant="filled" severity="success">
-                  FFMPEG is installed.
+                  FFMPEG is installed. Detected version {version?.ffmpeg}
                 </Alert>
               ) : (
                 <>


### PR DESCRIPTION
Removes the ability to disable ffmpeg transcoding throughout Tunarr. Defaults enableTranscoding to true in legacy DB migration and removes all read references from the settings value. We're opting to make FFMPEG transcoding a requirement for Tunarr because it simply provides a better overall experience. Many features are non-functional without ffmpeg, such as flex / offline, error screens, and watermarks. Additionally, with ffmpeg we can work to ensure a better quality and more stable streaming experience.
