### PR TITLE
Set sc_threshold to suggested 1000000000 for mpeg2 based encoders. Fixes #445

### DIFF
--- a/server/src/ffmpeg/ffmpeg.ts
+++ b/server/src/ffmpeg/ffmpeg.ts
@@ -172,18 +172,22 @@ export class FFMPEG extends (events.EventEmitter as new () => TypedEventEmitter<
       '-1',
       `-protocol_whitelist`,
       `file,http,tcp,https,tcp,tls`,
-      // '-copyts',
       `-probesize`,
       '32',
       `-i`,
       streamUrl,
     ];
 
+    // Workaround until new pipeline is in place...
+    const scThreshold = this.opts.videoEncoder.includes('mpeg2')
+      ? '1000000000'
+      : '0';
+
     ffmpegArgs.push(
       '-flags',
       'cgop',
       '-sc_threshold',
-      '0',
+      scThreshold,
       '-movflags',
       '+faststart',
     );


### PR DESCRIPTION
This manifests as the following error in the concat process:

```
[mpeg2video @ 0x636abf1fa140] closed gop with scene change detection are not supported yet, set threshold to 1000000000
[vost#0:0/mpeg2video @ 0x636abf1f9e40] Error initializing output stream: Error while opening encoder for output stream #0:0 -
maybe incorrect parameters such as bit_rate, rate, width or height
```

The fix is a workaround while we're rebuilding the FFMPEG pipeline.
