### PR TITLE
Fix infinite scroll initial load issue

### DIFF
--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -610,7 +610,7 @@ export default function PlexProgrammingSelector() {
           <Box ref={gridContainerRef} sx={{ width: '100%' }}>
             {renderListItems()}
           </Box>
-          <div style={{ height: 40 }} ref={ref}></div>
+          {!searchLoading && <div style={{ height: 96 }} ref={ref}></div>}
           <Divider sx={{ mt: 3, mb: 2 }} />
         </>
       )}


### PR DESCRIPTION
Don't add the intersectionObserver div to the DOM until the react-query has finished loading.  This ensures the correct params are available when insersectionObserver fires.

- Added 56px to intersection div to accommodate the bottom toolbar on mobile
- Fixes: https://github.com/chrisbenincasa/tunarr/issues/419

