### PR TITLE
Fixes dirty state when a schedule is cleared

### DIFF
--- a/web/src/hooks/programming_controls/useRemoveAllProgramming.ts
+++ b/web/src/hooks/programming_controls/useRemoveAllProgramming.ts
@@ -2,6 +2,6 @@ import { setCurrentLineup } from '../../store/channelEditor/actions.ts';
 
 export const useRemoveAllProgramming = () => {
   return () => {
-    setCurrentLineup([]);
+    setCurrentLineup([], true);
   };
 };

--- a/web/src/hooks/programming_controls/useRemoveSpecials.ts
+++ b/web/src/hooks/programming_controls/useRemoveSpecials.ts
@@ -10,7 +10,7 @@ export const useRemoveSpecials = () => {
   return () => {
     if (programs.length > 0) {
       const newPrograms = removeSpecials(programs);
-      setCurrentLineup(newPrograms);
+      setCurrentLineup(newPrograms, true);
     }
   };
 };


### PR DESCRIPTION
When you clear a schedule or remove specials, the state is now correctly marked as dirty, allowing you to save