### PR TITLE
Simplify FFMPEG video encoder settings. Fixes #442

### DIFF
--- a/server/src/ffmpeg/ffmpegInfo.ts
+++ b/server/src/ffmpeg/ffmpegInfo.ts
@@ -1,26 +1,43 @@
 import { FfmpegSettings } from '@tunarr/types';
 import { exec } from 'child_process';
 import { LoggerFactory } from '../util/logging/LoggerFactory';
+import { attempt } from '../util/index.js';
+import _, { isEmpty, isError, some, trim } from 'lodash-es';
+import NodeCache from 'node-cache';
+import PQueue from 'p-queue';
+import { cacheGetOrSet } from '../util/cache.js';
+
+const CacheKeys = {
+  ENCODERS: 'encoders',
+  HWACCELS: 'hwaccels',
+} as const;
+
+const execQueue = new PQueue({ concurrency: 2 });
+
+const VersionExtractionPattern = /version\s+([^\s]+)\s+.*Copyright/;
+const CoderExtractionPattern = /[A-Z.]+\s([a-z0-9_-]+)\s*(.*)$/;
 
 export class FFMPEGInfo {
   private logger = LoggerFactory.child({ caller: import.meta });
+
+  private static resultCache: NodeCache = new NodeCache({ stdTTL: 5 * 6000 });
+
+  private static makeCacheKey(
+    path: string,
+    command: keyof typeof CacheKeys,
+  ): string {
+    return `${path}_${CacheKeys[command]}`;
+  }
 
   private ffmpegPath: string;
   constructor(opts: FfmpegSettings) {
     this.ffmpegPath = opts.ffmpegExecutablePath;
   }
+
   async getVersion() {
     try {
-      const s: string = await new Promise((resolve, reject) => {
-        exec(`"${this.ffmpegPath}" -version`, function (error, stdout) {
-          if (error !== null) {
-            reject(error);
-          } else {
-            resolve(stdout);
-          }
-        });
-      });
-      const m = s.match(/version\s+([^\s]+)\s+.*Copyright/);
+      const s = await this.getFfmpegStdout(['-hide_banner', '-version']);
+      const m = s.match(VersionExtractionPattern);
       if (m == null) {
         this.logger.error(
           'ffmpeg -version command output not in the expected format: ' + s,
@@ -32,5 +49,86 @@ export class FFMPEGInfo {
       this.logger.error(err);
       return 'unknown';
     }
+  }
+
+  async getAvailableAudioEncoders() {
+    return attempt(async () => {
+      const out = await cacheGetOrSet(
+        FFMPEGInfo.resultCache,
+        this.cacheKey('ENCODERS'),
+        () => this.getFfmpegStdout(['-hide_banner', '-encoders']),
+      );
+
+      return _.chain(out)
+        .split('\n')
+        .filter((line) => /^\s*A/.test(line))
+        .map((line) => line.trim().match(CoderExtractionPattern))
+        .compact()
+        .reject((arr) => arr.length < 3)
+        .map((arr) => ({ ffmpegName: arr[1], name: arr[2] }))
+        .value();
+    });
+  }
+
+  async getAvailableVideoEncoders() {
+    return attempt(async () => {
+      const out = await cacheGetOrSet(
+        FFMPEGInfo.resultCache,
+        this.cacheKey('ENCODERS'),
+        () => this.getFfmpegStdout(['-hide_banner', '-encoders']),
+      );
+
+      return _.chain(out)
+        .split('\n')
+        .filter((line) => /^\s*V/.test(line))
+        .map((line) => line.trim().match(CoderExtractionPattern))
+        .compact()
+        .reject((arr) => arr.length < 3)
+        .map((arr) => ({ ffmpegName: arr[1], name: arr[2] }))
+        .value();
+    });
+  }
+
+  async hasVideoDecoder(name: string) {
+    const available = await this.getAvailableVideoEncoders();
+    // TODO should we be throwing here?
+    if (isError(available)) {
+      throw available;
+    }
+    return some(available, { name });
+  }
+
+  async getHwAccels() {
+    const res = await attempt(async () => {
+      const out = await cacheGetOrSet(
+        FFMPEGInfo.resultCache,
+        this.cacheKey('HWACCELS'),
+        () => this.getFfmpegStdout(['-hide_banner', '-hwaccels']),
+      );
+      return _.chain(out).split('\n').drop(1).map(trim).reject(isEmpty).value();
+    });
+    return isError(res) ? [] : res;
+  }
+
+  private getFfmpegStdout(args: string[]): Promise<string> {
+    return execQueue.add(
+      async () =>
+        await new Promise((resolve, reject) => {
+          exec(
+            `"${this.ffmpegPath}" ${args.join(' ')}`,
+            function (error, stdout) {
+              if (error !== null) {
+                reject(error);
+              }
+              resolve(stdout);
+            },
+          );
+        }),
+      { throwOnTimeout: true },
+    );
+  }
+
+  private cacheKey(key: keyof typeof CacheKeys): string {
+    return FFMPEGInfo.makeCacheKey(this.ffmpegPath, key);
   }
 }

--- a/server/src/util/cache.ts
+++ b/server/src/util/cache.ts
@@ -1,0 +1,15 @@
+import { isUndefined } from 'lodash-es';
+import NodeCache from 'node-cache';
+
+export async function cacheGetOrSet<T = unknown>(
+  cache: NodeCache,
+  key: string,
+  cacheFill: () => Promise<T>,
+): Promise<T> {
+  let res = cache.get<T>(key);
+  if (isUndefined(res)) {
+    res = await cacheFill();
+    cache.set(key, res);
+  }
+  return res;
+}

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -156,6 +156,17 @@ export const BaseErrorSchema = z.object({
   message: z.string(),
 });
 
+const FfmpegCoderDetails = z.object({
+  name: z.string(),
+  ffmpegName: z.string(),
+});
+
+export const FfmpegInfoResponse = z.object({
+  audioEncoders: z.array(FfmpegCoderDetails),
+  videoEncoders: z.array(FfmpegCoderDetails),
+  hardwareAccelerationTypes: z.array(z.string()),
+});
+
 export const SystemSettingsResponseSchema = SystemSettingsSchema.extend({
   logging: LoggingSettingsSchema.extend({
     environmentLogLevel: LogLevelsSchema.optional(),

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -1,5 +1,6 @@
 import z from 'zod';
 import { ResolutionSchema } from './miscSchemas.js';
+import { TupleToUnion } from '../util.js';
 
 export const XmlTvSettingsSchema = z.object({
   programmingHours: z.number().default(12),
@@ -8,6 +9,24 @@ export const XmlTvSettingsSchema = z.object({
   enableImageCache: z.boolean().default(false),
 });
 
+export const SupportedVideoFormats = ['h264', 'hevc', 'mpeg2'] as const;
+export type SupportedVideoFormats = TupleToUnion<typeof SupportedVideoFormats>;
+export const DefaultVideoFormat = 'h264';
+
+export const SupportedHardwareAccels = [
+  'none',
+  'cuda',
+  'vaapi',
+  'qsv',
+  'videotoolbox',
+] as const;
+
+export type SupportedHardwareAccels = TupleToUnion<
+  typeof SupportedHardwareAccels
+>;
+
+export const DefaultHardwareAccel = 'none';
+
 export const FfmpegSettingsSchema = z.object({
   configVersion: z.number().default(5),
   ffmpegExecutablePath: z.string().default('/usr/bin/ffmpeg'),
@@ -15,9 +34,22 @@ export const FfmpegSettingsSchema = z.object({
   concatMuxDelay: z.number().default(0),
   enableLogging: z.boolean().default(false),
   // DEPRECATED
-  enableTranscoding: z.boolean().default(true),
+  enableTranscoding: z.boolean().default(true).describe('DEPRECATED'),
   audioVolumePercent: z.number().default(100),
-  videoEncoder: z.string().default('libx264'),
+  // DEPRECATED
+  videoEncoder: z.string().default('libx264').describe('DEPRECATED'),
+  hardwareAccelerationMode: z
+    .union([
+      z.literal('none'),
+      z.literal('cuda'),
+      z.literal('vaapi'),
+      z.literal('qsv'),
+      z.literal('videotoolbox'),
+    ])
+    .default(DefaultHardwareAccel),
+  videoFormat: z
+    .union([z.literal('h264'), z.literal('hevc'), z.literal('mpeg2')])
+    .default(DefaultVideoFormat),
   audioEncoder: z.string().default('aac'),
   targetResolution: ResolutionSchema.default({ widthPx: 1920, heightPx: 1080 }),
   videoBitrate: z.number().default(2000),

--- a/web/src/external/api.ts
+++ b/web/src/external/api.ts
@@ -45,6 +45,7 @@ import {
   updateXmlTvSettings,
 } from './settingsApi.ts';
 import { isEmpty } from 'lodash-es';
+import { getFfmpegInfoEndpoint } from './ffmpegApi.ts';
 
 export const api = makeApi([
   {
@@ -326,6 +327,7 @@ export const api = makeApi([
     status: 200,
     response: z.object({ streamPath: z.string() }),
   },
+  getFfmpegInfoEndpoint,
   {
     method: 'post',
     path: '/api/upload/image',

--- a/web/src/external/ffmpegApi.ts
+++ b/web/src/external/ffmpegApi.ts
@@ -1,0 +1,9 @@
+import { FfmpegInfoResponse } from '@tunarr/types/api';
+import { makeEndpoint } from '@zodios/core';
+
+export const getFfmpegInfoEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/api/ffmpeg-info',
+  response: FfmpegInfoResponse,
+  alias: 'getFfmpegInfo',
+});


### PR DESCRIPTION
This is a first step towards simplying FFMPEG setup. Previously, users
would have to input in free text their chosen encoder. This required
FFMPEG knowledge and also knowledge of what their build supported. It
also exploded the potential for issues by allowing users to specify
_any_ format.

This includes the following changes:

* Boil down available video codecs to H264, H265, and MPEG-2 (when
  applicable)
* Allow user to specify a Hardware Accel. type (or none). This is based
  on which types are available to them
* Combine these two options to determine the video encoder. NOTE: in
  future versions, these settings will also allow us to properly confirm
hardware decoding and filtering
