### PR TITLE
Fix standalone executable files. Fixes #469

### DIFF
--- a/.github/workflows/edge-binary-build.yml
+++ b/.github/workflows/edge-binary-build.yml
@@ -71,4 +71,4 @@ jobs:
           tag_name: edge
           prerelease: true
           files: |
-            ./server/build/tunarr-${{ matrix.os.target_name }}-x64*
+            ./server/build/tunarr-${{ matrix.os.target_name }}-x64.zip*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@yao-pkg/pkg':
         specifier: ^5.11.5
         version: 5.11.5
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       copyfiles:
         specifier: ^2.2.0
         version: 2.2.0
@@ -3748,7 +3751,6 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
-    dev: false
 
   /abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -3970,6 +3972,19 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      glob: 10.3.10
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.4.2
+    dev: true
+
   /archiver@5.3.2:
     resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
     engines: {node: '>= 10'}
@@ -3981,6 +3996,19 @@ packages:
       readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.1
+    dev: true
+
+  /archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.5
+      buffer-crc32: 1.0.0
+      readable-stream: 4.4.2
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
     dev: true
 
   /archy@1.0.0:
@@ -4185,6 +4213,10 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /b4a@1.6.6:
+    resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
+    dev: true
+
   /babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -4196,6 +4228,12 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /bare-events@2.3.1:
+    resolution: {integrity: sha512-sJnSOTVESURZ61XgEleqmP255T6zTYwHPwE4r6SssIh0U9/uDvfpdoJYpVUerJJZH2fueO+CdT8ZT+OC/7aZDA==}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4444,6 +4482,11 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
 
+  /buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
   /buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
     dev: true
@@ -4474,7 +4517,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: false
 
   /builtin-status-codes@3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
@@ -4823,6 +4865,17 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.4.2
+    dev: true
+
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -4921,6 +4974,14 @@ packages:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
+    dev: true
+
+  /crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.4.2
     dev: true
 
   /create-ecdh@4.0.4:
@@ -5902,7 +5963,6 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -5992,6 +6052,10 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    dev: true
 
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -9085,6 +9149,10 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  /queue-tick@1.0.1:
+    resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
+    dev: true
+
   /quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
     dev: false
@@ -9297,7 +9365,6 @@ packages:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
-    dev: false
 
   /readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
@@ -9972,6 +10039,16 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: false
 
+  /streamx@2.18.0:
+    resolution: {integrity: sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==}
+    dependencies:
+      fast-fifo: 1.3.2
+      queue-tick: 1.0.1
+      text-decoder: 1.1.0
+    optionalDependencies:
+      bare-events: 2.3.1
+    dev: true
+
   /strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
@@ -10277,6 +10354,14 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  /tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+    dependencies:
+      b4a: 1.6.6
+      fast-fifo: 1.3.2
+      streamx: 2.18.0
+    dev: true
+
   /tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
@@ -10323,6 +10408,12 @@ packages:
       acorn: 8.11.2
       commander: 2.20.3
       source-map-support: 0.5.21
+    dev: true
+
+  /text-decoder@1.1.0:
+    resolution: {integrity: sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==}
+    dependencies:
+      b4a: 1.6.6
     dev: true
 
   /text-decoding@1.0.0:
@@ -11693,6 +11784,15 @@ packages:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+    dev: true
+
+  /zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.4.2
     dev: true
 
   /zod-to-json-schema@3.21.4(zod@3.22.4):

--- a/server/mikro-orm.base.config.ts
+++ b/server/mikro-orm.base.config.ts
@@ -15,6 +15,16 @@ import { FillerShow } from './src/dao/entities/FillerShow.js';
 import { PlexServerSettings } from './src/dao/entities/PlexServerSettings.js';
 import { Program } from './src/dao/entities/Program.js';
 import { DATABASE_LOCATION_ENV_VAR } from './src/util/constants.js';
+import { Migration20240124115044 } from './src/migrations/Migration20240124115044.js';
+import { Migration20240126165808 } from './src/migrations/Migration20240126165808.js';
+import { Migration20240221201014 } from './src/migrations/Migration20240221201014.js';
+import { Migration20240308184352 } from './src/migrations/Migration20240308184352.js';
+import { Migration20240319192121 } from './src/migrations/Migration20240319192121.js';
+import { Migration20240404182303 } from './src/migrations/Migration20240404182303.js';
+import { Migration20240411104034 } from './src/migrations/Migration20240411104034.js';
+import { Migration20240416113447 } from './src/migrations/Migration20240416113447.js';
+import { Migration20240423195250 } from './src/migrations/Migration20240423195250.js';
+import { Migration20240531155641 } from './src/migrations/Migration20240531155641.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,8 +53,50 @@ export default defineConfig({
   forceUndefined: true,
   dynamicImportProvider: (id) => import(id),
   migrations: {
-    path: './migrations',
-    pathTs: './src/migrations',
+    // Explicitly list migrations for a smoother dev experience
+    // and because we are bundling these.
+    migrationsList: [
+      {
+        name: 'Initial migration',
+        class: Migration20240124115044,
+      },
+      {
+        name: 'Add index to filler content',
+        class: Migration20240126165808,
+      },
+      {
+        name: 'Filler context index fix',
+        class: Migration20240221201014,
+      },
+      {
+        name: 'Add Plex client identifier column',
+        class: Migration20240308184352,
+      },
+      {
+        name: 'Add artist and album name fields to Program',
+        class: Migration20240319192121,
+      },
+      {
+        name: 'Implement program grouping table and hierarchy',
+        class: Migration20240404182303,
+      },
+      {
+        name: 'Deprecate plex_rating_key field on Program',
+        class: Migration20240411104034,
+      },
+      {
+        name: 'Add guide_flex_title field',
+        class: Migration20240416113447,
+      },
+      {
+        name: 'Rename season column to season_number on Program',
+        class: Migration20240423195250,
+      },
+      {
+        name: 'Add program_external_id table',
+        class: Migration20240531155641,
+      },
+    ],
   },
   extensions: [Migrator],
 });

--- a/server/package.json
+++ b/server/package.json
@@ -93,6 +93,7 @@
     "@types/uuid": "^9.0.6",
     "@types/yargs": "^17.0.29",
     "@yao-pkg/pkg": "^5.11.5",
+    "archiver": "^7.0.1",
     "copyfiles": "^2.2.0",
     "del-cli": "^3.0.0",
     "dotenv-cli": "^7.4.1",

--- a/server/scripts/bundle.ts
+++ b/server/scripts/bundle.ts
@@ -25,15 +25,11 @@ console.log('Bundling app...');
 const result = await esbuild.build({
   entryPoints: {
     bundle: 'src/index.ts',
-    basicPrettyTransport: 'src/util/logging/basicPrettyTransport.ts',
   },
   bundle: true,
   minify: false,
   outdir: 'build',
   logLevel: 'info',
-  // outExtension: {
-  //   '.js': '.mjs',
-  // },
   // We can't make this mjs yet because mikro-orm breaks
   // when using cached metadata w/ not js/ts suffixes:
   // https://github.com/mikro-orm/mikro-orm/blob/e005cc22ef4e247f9741bdcaf1af012337977b7e/packages/core/src/cache/GeneratedCacheAdapter.ts#L16

--- a/server/scripts/bundle.ts
+++ b/server/scripts/bundle.ts
@@ -1,14 +1,13 @@
 import esbuild from 'esbuild';
 import { copy } from 'esbuild-plugin-copy';
+import esbuildPluginPino from 'esbuild-plugin-pino';
 import fg from 'fast-glob';
 import fs from 'node:fs';
-import { basename, resolve } from 'node:path';
+import { basename } from 'node:path';
 import { rimraf } from 'rimraf';
 import { mikroOrmProdPlugin } from '../esbuild/mikro-orm-prod-plugin.js';
 import { nativeNodeModulesPlugin } from '../esbuild/native-node-module.js';
 import { nodeProtocolPlugin } from '../esbuild/node-protocol.js';
-import esbuildPluginPino from 'esbuild-plugin-pino';
-import basicPrettyTransport from '../src/util/logging/basicPrettyTransport.js';
 
 if (fs.existsSync('build')) {
   console.log('Deleting old build...');
@@ -21,9 +20,7 @@ console.log('Copying images...');
 fs.cpSync('src/resources/images', 'build/resources/images', {
   recursive: true,
 });
-console.log(
-  resolve(process.cwd(), './src/util/logging/basicPrettyTransport.ts'),
-);
+
 console.log('Bundling app...');
 const result = await esbuild.build({
   entryPoints: {
@@ -34,6 +31,9 @@ const result = await esbuild.build({
   minify: false,
   outdir: 'build',
   logLevel: 'info',
+  // outExtension: {
+  //   '.js': '.mjs',
+  // },
   // We can't make this mjs yet because mikro-orm breaks
   // when using cached metadata w/ not js/ts suffixes:
   // https://github.com/mikro-orm/mikro-orm/blob/e005cc22ef4e247f9741bdcaf1af012337977b7e/packages/core/src/cache/GeneratedCacheAdapter.ts#L16

--- a/server/scripts/makeExecutable.ts
+++ b/server/scripts/makeExecutable.ts
@@ -66,6 +66,7 @@ for (const target of args.target) {
     loglevel: 'verbose',
     bundle: false,
     resources: [
+      'package.json',
       './migrations/**/*',
       // NOTE: When building the executable, we need to make sure that
       // we are on the same arch type as the target so we copy in the

--- a/server/scripts/makeExecutable.ts
+++ b/server/scripts/makeExecutable.ts
@@ -1,8 +1,10 @@
 import { compile } from 'nexe';
 import fs from 'node:fs/promises';
+import { createWriteStream, existsSync } from 'node:fs';
 import path from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import archiver from 'archiver';
 
 const NODE_VERSION = '20.11.1';
 const OSX_TARGET = `macos-x64-${NODE_VERSION}`;
@@ -36,12 +38,17 @@ const args = await yargs(hideBin(process.argv))
 // Copy over the bundled webapp for packaging. We could
 // probably symlink this but the compiled webapp is so
 // lightweight that this isn't a huge deal.
+if (existsSync('./build/web')) {
+  await fs.rm('./build/web', { recursive: true });
+}
+
 await fs.cp(path.resolve(process.cwd(), '../web/dist'), './build/web', {
   recursive: true,
 });
 
 for (const target of args.target) {
   let binaryName: string;
+  let shortArch = target.split('-', 2).join('-');
   switch (target) {
     case 'macos-x64-20.11.1':
       binaryName = 'tunarr-macos-x64';
@@ -67,19 +74,35 @@ for (const target of args.target) {
     bundle: false,
     resources: [
       'package.json',
-      './migrations/**/*',
-      // NOTE: When building the executable, we need to make sure that
-      // we are on the same arch type as the target so we copy in the
-      // correct native bindings.
-      './build/better_sqlite3.node',
       './resources/**/*',
       './static/**/*', // Swagger -- TODO: Change this path
       './web/**',
     ],
     python: args.python,
     temp: args.tempdir,
-    verbose: true, //target === 'windows-x64-20.11.1',
+    verbose: true,
     remote:
       'https://github.com/chrisbenincasa/tunarr/releases/download/nexe-prebuild/',
   });
+
+  console.log(
+    `Creating Tunarr executable archive: ./build/tunarr-${shortArch}.zip`,
+  );
+
+  const outputArchive = createWriteStream(`./build/tunarr-${shortArch}.zip`);
+  const archive = archiver('zip');
+  const outStreamEnd = new Promise((resolve, reject) => {
+    outputArchive.on('close', resolve);
+    outputArchive.on('error', reject);
+  });
+
+  archive.pipe(outputArchive);
+
+  archive.file(`./build/${binaryName}`, { name: binaryName });
+  archive.directory('./build/build', 'build');
+  archive.finalize();
+
+  await outStreamEnd;
+
+  console.log('Finished writing zip.');
 }

--- a/server/scripts/package.json
+++ b/server/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/server/scripts/pkg-config.json
+++ b/server/scripts/pkg-config.json
@@ -1,5 +1,0 @@
-{
-  "scripts": "build/bundle.js",
-  "targets": ["node18-linux-arm64"],
-  "outputPath": "dist"
-}

--- a/server/scripts/sea.json
+++ b/server/scripts/sea.json
@@ -1,5 +1,0 @@
-{
-  "main": "build/bundle.js",
-  "output": "build/blob.blob",
-  "disableExperimentalSEAWarning": true
-}


### PR DESCRIPTION
A few fixes here:

* Migrations are now bundled into the main bundle file. They are listed explicitly, which should also help when generating new migrations (they won't get pulled in automatically and make dev harder)
* Include package.json into the resultant binary. This will solve the issue specific to #469 where the Windows executable was not properly running the app as an ESM module
* Change the packaging mechanism --- for now, due to limitations with Nexe (and probably Node in generaly) we'll have to distribute Tunarr standalone binaries as a ZIP that contains both the Nexe-built Node binary (node.js + our bundle + web app) and the better_sqlite3 native bindings package (which cannot be included _within_ the executable.... no matter how hard I tried. 