### PR TITLE
Generate new migrations for program_external_id

### DIFF
--- a/server/src/dao/custom_types/ProgramExternalIdType.ts
+++ b/server/src/dao/custom_types/ProgramExternalIdType.ts
@@ -3,6 +3,9 @@ import { enumKeys } from '../../util/enumUtil.js';
 export enum ProgramExternalIdType {
   PLEX = 'plex',
   PLEX_GUID = 'plex-guid',
+  TMDB = 'tmdb',
+  IMDB = 'imdb',
+  TVDB = 'tvdb',
 }
 
 export function programExternalIdTypeFromString(

--- a/server/src/dao/entities/ProgramExternalId.ts
+++ b/server/src/dao/entities/ProgramExternalId.ts
@@ -1,6 +1,7 @@
 import {
   Entity,
   Enum,
+  Index,
   ManyToOne,
   Property,
   Unique,
@@ -20,6 +21,18 @@ import { Program } from './Program.js';
  *      e.x. a program's ID on IMDB
  */
 @Entity()
+@Index({
+  name: 'unique_program_single_external_id',
+  properties: ['program', 'sourceType'],
+  expression:
+    'create unique index `unique_program_single_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NULL',
+})
+@Index({
+  name: 'unique_program_multi_external_id',
+  properties: ['program', 'sourceType', 'externalSourceId'],
+  expression:
+    'create unique index `unique_program_multiple_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NOT NULL',
+})
 @Unique({ properties: ['uuid', 'sourceType'] })
 export class ProgramExternalId extends BaseEntity {
   @Enum(() => ProgramExternalIdType)

--- a/server/src/migrations/.snapshot-db.db.json
+++ b/server/src/migrations/.snapshot-db.db.json
@@ -1299,7 +1299,10 @@
           "nullable": false,
           "enumItems": [
             "plex",
-            "plex-guid"
+            "plex-guid",
+            "tmdb",
+            "imdb",
+            "tvdb"
           ],
           "mappedType": "enum"
         },
@@ -1360,6 +1363,31 @@
           "constraint": false,
           "primary": false,
           "unique": false
+        },
+        {
+          "keyName": "unique_program_multi_external_id",
+          "columnNames": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create unique index `unique_program_multiple_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NOT NULL"
+        },
+        {
+          "keyName": "unique_program_single_external_id",
+          "columnNames": [
+            "program_uuid",
+            "source_type"
+          ],
+          "composite": true,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create unique index `unique_program_single_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NULL"
         },
         {
           "keyName": "program_external_id_uuid_source_type_unique",


### PR DESCRIPTION
These have to be done in 2 parts due to https://github.com/mikro-orm/mikro-orm/issues/5672

The first adds 2 partial indexes. One index is for single IDs (not
source ID specific) while the other is for multiple external IDs (i.e.
Plex rating key). Usage of these indexes will likely be blocked on https://github.com/mikro-orm/mikro-orm/discussions/5668

Second, we add new external IDs types in preparation for pulling/saving
these from Plex (and eventually other sources). This will set the stage
for cross-source matching.
