### PR TITLE
Improve 'first run' and 'legacy migration' handling / logic. Fixes #474

### DIFF
--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -711,7 +711,7 @@ export class ChannelDB {
             where: { content: { $in: chunk } },
           });
       },
-      2,
+      { concurrency: 2 },
     );
 
     const allCustomShowContent: CustomShowContent[] = [];
@@ -822,7 +822,7 @@ export class ChannelDB {
           return this.saveLineup(channel.uuid, { ...lineup, items: newLineup });
         }
       },
-      2,
+      { concurrency: 2 },
     );
 
     for await (const updateResult of ops) {

--- a/server/src/dao/legacy_migration/legacyDbMigration.ts
+++ b/server/src/dao/legacy_migration/legacyDbMigration.ts
@@ -138,7 +138,7 @@ export class LegacyDbMigrator {
           };
         }
       } catch (e) {
-        this.logger.error('Unable to migrate HDHR settings', e);
+        this.logger.error(e, 'Unable to migrate HDHR settings');
       }
     }
 
@@ -167,7 +167,7 @@ export class LegacyDbMigrator {
           };
         }
       } catch (e) {
-        this.logger.error('Unable to migrate XMLTV settings', e);
+        this.logger.error(e, 'Unable to migrate XMLTV settings');
       }
     }
 
@@ -270,7 +270,7 @@ export class LegacyDbMigrator {
           };
         }
       } catch (e) {
-        this.logger.error('Unable to migrate Plex settings', e);
+        this.logger.error(e, 'Unable to migrate Plex settings');
       }
     }
 
@@ -341,7 +341,7 @@ export class LegacyDbMigrator {
           await em.persistAndFlush(entities);
         }
       } catch (e) {
-        this.logger.error('Unable to migrate Plex server settings', e);
+        this.logger.error(e, 'Unable to migrate Plex server settings');
       }
     }
 
@@ -443,7 +443,7 @@ export class LegacyDbMigrator {
           };
         }
       } catch (e) {
-        this.logger.error('Unable to migrate ffmpeg settings', e);
+        this.logger.error(e, 'Unable to migrate ffmpeg settings');
       }
     }
 
@@ -455,7 +455,7 @@ export class LegacyDbMigrator {
         clientId: clientId['clientId'] as string,
       };
     } catch (e) {
-      this.logger.error('Unable to migrate client ID', e);
+      this.logger.error(e, 'Unable to migrate client ID');
     }
 
     const libraryMigrator = new LegacyLibraryMigrator();
@@ -468,7 +468,7 @@ export class LegacyDbMigrator {
           'custom-shows',
         );
       } catch (e) {
-        this.logger.error('Unable to migrate all custom shows', e);
+        this.logger.error(e, 'Unable to migrate all custom shows');
       }
     }
 
@@ -480,7 +480,7 @@ export class LegacyDbMigrator {
           'filler',
         );
       } catch (e) {
-        this.logger.error('Unable to migrate all filler shows', e);
+        this.logger.error(e, 'Unable to migrate all filler shows');
       }
     }
 
@@ -508,7 +508,7 @@ export class LegacyDbMigrator {
           }),
         );
       } catch (e) {
-        this.logger.error('Unable to migrate channels', e);
+        this.logger.error(e, 'Unable to migrate channels');
       }
     }
 
@@ -517,7 +517,7 @@ export class LegacyDbMigrator {
         this.logger.debug('Migrating cached images');
         await this.migrateCachedImages();
       } catch (e) {
-        this.logger.error('Unable to migrate cached images', e);
+        this.logger.error(e, 'Unable to migrate cached images');
       }
     }
 

--- a/server/src/dao/legacy_migration/metadataBackfill.ts
+++ b/server/src/dao/legacy_migration/metadataBackfill.ts
@@ -26,7 +26,10 @@ import {
 import { ProgramGroupingExternalId } from '../entities/ProgramGroupingExternalId';
 
 export class LegacyMetadataBackfiller {
-  private logger = LoggerFactory.child({ caller: import.meta });
+  private logger = LoggerFactory.child({
+    caller: import.meta,
+    className: LegacyMetadataBackfiller.name,
+  });
 
   // It requires valid PlexServerSettings, program metadata, etc
   async backfillParentMetadata() {
@@ -114,7 +117,7 @@ export class LegacyMetadataBackfiller {
             uuid: grandparentUUID,
           });
           if (!isNull(existingGrandparent)) {
-            this.logger.debug('Using existing grandparent grouping!');
+            this.logger.trace('Using existing grandparent grouping!');
             updatedGrandparent = true;
             if (type === ProgramType.Episode) {
               existingGrandparent.showEpisodes.add(
@@ -142,7 +145,7 @@ export class LegacyMetadataBackfiller {
           uuid: parentUUID,
         });
         if (!isNull(existingParent)) {
-          this.logger.debug('Using existing parent!');
+          this.logger.trace('Using existing parent!');
           updatedParent = true;
           if (type === ProgramType.Episode) {
             existingParent.seasonEpisodes.add(em.getReference(Program, uuid));

--- a/server/src/ffmpeg/ffmpeg.ts
+++ b/server/src/ffmpeg/ffmpeg.ts
@@ -826,6 +826,7 @@ export class FFMPEG extends (events.EventEmitter as new () => TypedEventEmitter<
       return;
     }
 
+    // TODO: Redact Plex tokens here
     this.logger.debug(`Starting ffmpeg with args: "${ffmpegArgs.join(' ')}"`);
 
     this.ffmpeg = spawn(this.ffmpegPath, ffmpegArgs, {

--- a/server/src/tasks/fixers/BackfillProgramExternalIds.ts
+++ b/server/src/tasks/fixers/BackfillProgramExternalIds.ts
@@ -16,6 +16,8 @@ import { PlexTerminalMedia } from '@tunarr/types/plex';
 export class BackfillProgramExternalIds extends Fixer {
   #logger = LoggerFactory.child({ caller: import.meta });
 
+  canRunInBackground: boolean = true;
+
   async runInternal(): Promise<void> {
     const em = getEm();
 
@@ -64,7 +66,7 @@ export class BackfillProgramExternalIds extends Fixer {
             program,
             plexConnections[program.externalSourceId],
           ),
-        2,
+        { concurrency: 1, waitAfterEachMs: 50 },
       )) {
         if (result.type === 'error') {
           this.#logger.error(

--- a/server/src/tasks/fixers/backfillProgramGroupings.ts
+++ b/server/src/tasks/fixers/backfillProgramGroupings.ts
@@ -28,7 +28,10 @@ import { LoggerFactory } from '../../util/logging/LoggerFactory';
 import Fixer from './fixer';
 
 export class BackfillProgramGroupings extends Fixer {
-  private logger = LoggerFactory.child({ caller: import.meta });
+  private logger = LoggerFactory.child({
+    caller: import.meta,
+    className: BackfillProgramGroupings.name,
+  });
 
   protected async runInternal(em: EntityManager): Promise<void> {
     const plexServers = await em.findAll(PlexServerSettings);

--- a/server/src/tasks/fixers/fixer.ts
+++ b/server/src/tasks/fixers/fixer.ts
@@ -2,6 +2,9 @@ import { EntityManager } from '@mikro-orm/better-sqlite';
 import { withDb } from '../../dao/dataSource.js';
 
 export default abstract class Fixer {
+  // False if the fixed data isn't required for proper server functioning
+  canRunInBackground: boolean = false;
+
   async run() {
     return withDb((em) => this.runInternal(em));
   }

--- a/server/src/util/logging/LoggerFactory.ts
+++ b/server/src/util/logging/LoggerFactory.ts
@@ -152,12 +152,14 @@ class LoggerFactoryImpl {
     );
   }
 
-  child(opts: { caller?: ImportMeta } & Bindings = {}) {
-    const { caller, ...rest } = opts;
-    const newChild = this.rootLogger.child({
+  child(opts: { caller?: ImportMeta; className?: string } & Bindings = {}) {
+    const { caller, className, ...rest } = opts;
+    const childOpts = {
       ...rest,
-      caller: isProduction ? undefined : caller ? getCaller(caller) : undefined,
-    });
+      caller: isProduction ? className : caller ? getCaller(caller) : undefined,
+      className: isProduction ? undefined : className, // Don't include this twice in production
+    };
+    const newChild = this.rootLogger.child(childOpts);
     this.children.push(newChild);
     return newChild;
   }


### PR DESCRIPTION
The new logic depends on a new boolean in the settings.json file. If
Tunarr detects that the settings.json file did not exist at initial
startup, it will set 'freshSettings' to true. On subsequent runs, it
will explicitly set this to 'false'. This bit is used to determine
whether a legacy migration should be attempted.

This new logic allows for the Tunarr database _directory_ to exist at
startup (a requirement for bind mounting with containers) but still be
able to determine if this is a 'first run'.

Also includes:
* Attaching className to child loggers, for additional logging context
  in production env
* Logging improvement in the legacy migrator to print actual errors
* waitAfterEachMs option in asyncPool
* support for background fixer tasks to not delay server startup too
  long
