### PR TITLE
Use Zod schemas to validate DB JSON types

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "make-exec:macos": "tsx scripts/makeExecutable.ts --target macos-x64-20.11.1",
     "make-exec:windows": "tsx scripts/makeExecutable.ts --target windows-x64-20.11.1 --python python",
     "generate-db-migration": "dotenv -e .env.development -- tsx --tsconfig ./tsconfig.build.json src/index.ts db generate-migration",
-    "generate-db-cache": "dotenv -e .env.development -- mikro-orm-esm cache:generate --combined --ts",
+    "generate-db-cache": "dotenv -e .env.development -- tsx scripts/generateDbCache.ts",
     "mikro-orm": "mikro-orm-esm",
     "preinstall": "npx only-allow pnpm",
     "run-fixer": "dotenv -e .env.development -- tsx src/index.ts fixer",

--- a/server/scripts/generateDbCache.ts
+++ b/server/scripts/generateDbCache.ts
@@ -1,0 +1,40 @@
+import {
+  FileCacheAdapter,
+  MetadataDiscovery,
+  MetadataStorage,
+  colors,
+} from '@mikro-orm/better-sqlite';
+import { CLIHelper } from '@mikro-orm/cli';
+
+// This is really hacky but I'm tired of dealing with ts-node
+
+const config = await CLIHelper.getConfiguration(true, {
+  metadataCache: {
+    enabled: true,
+    adapter: FileCacheAdapter,
+    options: {
+      combined: './metadata.json',
+    },
+  },
+});
+
+config.getMetadataCacheAdapter().clear();
+config.set('logger', CLIHelper.dump.bind(null));
+config.set('debug', true);
+const discovery = new MetadataDiscovery(
+  MetadataStorage.init(),
+  config.getDriver().getPlatform(),
+  config,
+);
+await discovery.discover(true);
+
+const combined = config.get('metadataCache').combined;
+CLIHelper.dump(
+  colors.green(
+    `${
+      combined ? 'Combined ' : ''
+    }TS metadata cache was successfully generated${
+      combined ? ' to ' + combined : ''
+    }`,
+  ),
+);

--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -90,7 +90,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
           return res.status(404).send();
         }
       } catch (err) {
-        logger.error(req.routeConfig.url, err);
+        logger.error(err, req.routeConfig.url);
         return res.status(500).send();
       }
     },
@@ -155,7 +155,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
           return res.status(404).send();
         }
       } catch (err) {
-        logger.error(req.routeConfig.url, err);
+        logger.error(err, req.routeConfig.url);
         return res.status(500).send();
       }
     },
@@ -187,9 +187,9 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
       try {
         GlobalScheduler.getScheduledJob(UpdateXmlTvTask.ID)
           .runNow()
-          .catch((err) => logger.error('Error regenerating guide: %O', err));
+          .catch((err) => logger.error(err, 'Error regenerating guide'));
       } catch (e) {
-        logger.error('Unable to update guide after lineup update %O', e);
+        logger.error(e, 'Unable to update guide after lineup update %O');
       }
 
       return res.send();
@@ -220,7 +220,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
           return res.status(404).send();
         }
       } catch (err) {
-        logger.error('%s, %s', req.routeOptions.url, err);
+        logger.error(err, req.routeOptions.url);
         return res.status(500).send();
       }
     },
@@ -299,9 +299,9 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
       try {
         GlobalScheduler.getScheduledJob(UpdateXmlTvTask.ID)
           .runNow(true)
-          .catch((err) => logger.error('Error regenerating guide: %O', err));
+          .catch((err) => logger.error(err, 'Error regenerating guide'));
       } catch (e) {
-        logger.error('Unable to update guide after lineup update %O', e);
+        logger.error(e, 'Unable to update guide after lineup update');
       }
 
       // Potentially more DB queries than just building from the result,

--- a/server/src/dao/SchemaBackedDbAdapter.ts
+++ b/server/src/dao/SchemaBackedDbAdapter.ts
@@ -40,7 +40,6 @@ export class SchemaBackedDbAdapter<T extends z.ZodTypeAny, Out = z.infer<T>>
         this.logger.debug(
           'Attempting to merge with defaults to obtain valid object',
         );
-        console.log('hey');
         needsWriteFlush = parseResult.success;
         continue;
       }

--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -205,7 +205,7 @@ export class ChannelDB {
     const update = updateRequestToChannel(updateReq);
     const loadedChannel = wrap(channel).assign(update, {
       merge: true,
-      convertCustomTypes: true,
+      // convertCustomTypes: true,
       onlyProperties: true,
     });
     await em.flush();

--- a/server/src/dao/custom_types/SchemaBackedDbType.test.ts
+++ b/server/src/dao/custom_types/SchemaBackedDbType.test.ts
@@ -1,0 +1,71 @@
+import {
+  BaseEntity,
+  Entity,
+  IType,
+  PrimaryKey,
+  Property,
+  MikroORM,
+} from '@mikro-orm/better-sqlite';
+import { z } from 'zod';
+import { SchemaBackedDbType } from './SchemaBackedDbType';
+
+const basicSchema = z.object({
+  key: z.string(),
+});
+
+class CustomType extends SchemaBackedDbType<typeof basicSchema> {
+  constructor() {
+    super(basicSchema);
+  }
+}
+
+@Entity()
+class CustomEntity extends BaseEntity {
+  @PrimaryKey({ autoincrement: true, type: 'numeric' })
+  id!: number;
+
+  @Property({ type: CustomType, columnType: 'json' })
+  jsonField!: IType<z.infer<typeof basicSchema>, string>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [CustomEntity],
+    debug: ['query', 'query-params'],
+    allowGlobalContext: true, // only for testing
+  });
+  await orm.schema.refreshDatabase();
+});
+
+describe('SchemaBackedDbType', () => {
+  test('Basic', async () => {
+    const em = orm.em.fork();
+    em.create(CustomEntity, {
+      jsonField: {
+        key: 'value',
+      },
+    });
+    await em.flush();
+
+    // Read it back
+    await em.findOneOrFail(CustomEntity, 1);
+
+    const two = new CustomEntity();
+    two.jsonField = { key: 'value' };
+    await em.persistAndFlush(two);
+
+    await em.findOneOrFail(CustomEntity, 2);
+
+    // Insert a bad value...
+    await em
+      .getConnection()
+      .execute(
+        'insert into `custom_entity` (`json_field`) values (\'{"key": 1}\') returning `id`',
+      );
+
+    await expect(em.findOneOrFail(CustomEntity, 3)).rejects.toThrow();
+  });
+});

--- a/server/src/dao/custom_types/SchemaBackedDbType.ts
+++ b/server/src/dao/custom_types/SchemaBackedDbType.ts
@@ -1,6 +1,6 @@
 import { Type } from '@mikro-orm/core';
 import { z } from 'zod';
-import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory.js';
+import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory';
 
 let _logger: Logger;
 

--- a/server/src/dao/custom_types/SchemaBackedDbType.ts
+++ b/server/src/dao/custom_types/SchemaBackedDbType.ts
@@ -1,0 +1,41 @@
+import { Type } from '@mikro-orm/core';
+import { z } from 'zod';
+import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory';
+
+let _logger: Logger;
+
+export abstract class SchemaBackedDbType<
+  T extends z.ZodTypeAny,
+  DbType = z.infer<T>,
+> extends Type<DbType, string> {
+  constructor(private schema: T) {
+    super();
+  }
+
+  convertToDatabaseValue(value: DbType): string {
+    return JSON.stringify(value);
+  }
+
+  convertToJSValue(value: string): DbType {
+    const jsonParsed: unknown = JSON.parse(value);
+    const parseResult = this.schema.safeParse(jsonParsed);
+    if (parseResult.success) {
+      return parseResult.data as DbType;
+    }
+
+    this.logger.error(
+      parseResult.error,
+      'Unable to parse schema from DB JSON value. Raw parsed JSON: %O',
+      jsonParsed,
+    );
+
+    throw parseResult.error;
+  }
+
+  protected get logger() {
+    if (!_logger) {
+      _logger = LoggerFactory.child({ className: this.constructor.name });
+    }
+    return _logger;
+  }
+}

--- a/server/src/dao/custom_types/SchemaBackedDbType.ts
+++ b/server/src/dao/custom_types/SchemaBackedDbType.ts
@@ -1,6 +1,6 @@
 import { Type } from '@mikro-orm/core';
 import { z } from 'zod';
-import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory';
+import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory.js';
 
 let _logger: Logger;
 

--- a/server/src/services/tvGuideService.ts
+++ b/server/src/services/tvGuideService.ts
@@ -691,7 +691,7 @@ export class TVGuideService {
         path: FALLBACK_ICON,
         width: 0,
         duration: 0,
-        position: 'bottom',
+        position: 'bottom-right',
       };
       channel.disableFillerOverlay = false;
       channel.number = 0;

--- a/types/src/schemas/utilSchemas.ts
+++ b/types/src/schemas/utilSchemas.ts
@@ -87,10 +87,17 @@ export const ExternalIdSchema = z.discriminatedUnion('type', [
 ]);
 
 export const ChannelIconSchema = z.object({
-  path: z.string(),
-  width: z.number(),
-  duration: z.number(),
-  position: z.string(),
+  path: z.string().catch(''),
+  width: z.number().nonnegative().catch(0),
+  duration: z.number().catch(0),
+  position: z
+    .union([
+      z.literal('top-left'),
+      z.literal('top-right'),
+      z.literal('bottom-left'),
+      z.literal('bottom-right'),
+    ])
+    .catch('bottom-right'),
 });
 
 export const TimeUnitSchema = z.union([

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -239,7 +239,10 @@ export default function ChannelTranscodingConfig() {
                     control={control}
                     name="watermark.width"
                     float
-                    rules={{ min: 0, max: 100 }}
+                    rules={{
+                      min: 0, //{ value: 0, message: 'Width must be >= 0' },
+                      max: 100,
+                    }}
                     TextFieldProps={{ label: 'Width %', fullWidth: true }}
                   />
                 </Grid2>

--- a/web/src/hooks/useUpdateChannel.ts
+++ b/web/src/hooks/useUpdateChannel.ts
@@ -33,7 +33,7 @@ export const useUpdateChannel = (isNewChannel: boolean) => {
     onError: (error) => {
       if (error instanceof ZodiosError) {
         console.error(error.data);
-        console.error(error, error.cause);
+        console.error(error, error.cause, error.message);
       }
     },
   });

--- a/web/src/preloaders/channelLoaders.ts
+++ b/web/src/preloaders/channelLoaders.ts
@@ -21,7 +21,7 @@ export const DefaultChannel = {
   icon: {
     duration: 0,
     path: '',
-    position: 'bottom',
+    position: 'bottom-right',
     width: 0,
   },
   guideMinimumDuration: 30000,


### PR DESCRIPTION
Closes #258

This implements a MikroOrm custom type that parses incoming DB JSON types using Zod schemas for extra safety. Before we were just casting the type, which was unsafe. This gives a greater degree of confidence in what we are reading/writing to these freeform fields in the DB

This also has a bunch of frontend fixes I stumbled on:
1. Fixes channel transcoding config form where bitrate/buffer size wouldn't save because they were sent to backend as strings
2. Introduces default error messages in our custom form controller components

