### PR TITLE
Improvements to default backup settings

### DIFF
--- a/server/src/dao/settings.ts
+++ b/server/src/dao/settings.ts
@@ -168,8 +168,7 @@ export class SettingsDB extends ITypedEventEmitter {
   async directUpdate(fn: (settings: SettingsFile) => SettingsFile | void) {
     return await this.db.update(fn).then(() => {
       this.logger?.debug(
-        'Detected change to settings DB file %s on disk. Reloading.',
-        path,
+        'Detected change to settings DB file on disk. Reloading.',
       );
       this.emit('change');
     });

--- a/web/src/pages/settings/GeneralSettingsPage.tsx
+++ b/web/src/pages/settings/GeneralSettingsPage.tsx
@@ -206,7 +206,7 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
                     fullWidth
                     label="Output Path"
                     {...field}
-                    helperText="By default, saves backups in the server's run directory"
+                    helperText="By default, saves backups in the server's run directory, or, if running in Docker, to /config/tunarr/backups"
                   />
                 )}
               />


### PR DESCRIPTION
Makes the following changes to backup behavior:

1. If running in a docker container, and the output path is set to the
   default empty string, we attempt to write backups to
   /config/tunarr/backups
2. Be explicit about resolving the desired output path relative to the
   process's working directory
3. Ensure that target backup output directory exists before attempting
   to write to it
4. Add more context about the new Docker defaults to the Backup config
   UI
