### PR TITLE
Force regenerate program_external_id table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log.txt
 .DS_Store
 .turbo/
 *.env*
+*.tar*

--- a/server/mikro-orm.base.config.ts
+++ b/server/mikro-orm.base.config.ts
@@ -27,6 +27,7 @@ import { Migration20240423195250 } from './src/migrations/Migration2024042319525
 import { Migration20240531155641 } from './src/migrations/Migration20240531155641.js';
 import { Migration20240603204620 } from './src/migrations/Migration20240603204620.js';
 import { Migration20240603204638 } from './src/migrations/Migration20240603204638.js';
+import { Migration20240618005544 } from './src/migrations/Migration20240618005544.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -116,6 +117,10 @@ export default defineConfig({
       {
         name: 'Program External ID partial indexes',
         class: Migration20240603204620,
+      },
+      {
+        name: 'Force regenerate program_external_id table',
+        class: Migration20240618005544,
       },
     ],
   },

--- a/server/src/dao/programExternalIdHelpers.ts
+++ b/server/src/dao/programExternalIdHelpers.ts
@@ -12,7 +12,6 @@ export const upsertProgramExternalIds = async (
   const logger = LoggerFactory.root;
   const em = getEm();
 
-  console.log(externalIds);
   if (isEmpty(externalIds)) {
     return;
   }
@@ -45,7 +44,7 @@ export const upsertProgramExternalIds = async (
       .into('program_external_id')
       .onConflict(
         knex.raw(
-          '(program_uuid, source_type) WHERE external_source_id IS NOT NULL',
+          '(program_uuid, source_type, external_source_id) WHERE external_source_id IS NOT NULL',
         ),
       )
       .merge()

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -190,13 +190,23 @@ ${chalk.blue('  |_| ')}${chalk.green(' \\___/')}${chalk.yellow(
     'db [sub]',
     'Run database commands',
     (yargs) => {
-      return yargs.positional('sub', {
-        type: 'string',
-        choices: ['generate-migration', 'init'],
-        demandOption: true,
-      });
+      return yargs
+        .positional('sub', {
+          type: 'string',
+          choices: ['generate-migration', 'init'],
+          demandOption: true,
+        })
+        .option('blank', {
+          type: 'boolean',
+          alias: 'b',
+          default: false,
+        });
     },
-    async (args: ArgumentsCamelCase<ServerOptions & { sub: string }>) => {
+    async (
+      args: ArgumentsCamelCase<
+        ServerOptions & { sub: string; blank?: boolean }
+      >,
+    ) => {
       setServerOptions(args);
       switch (args.sub) {
         case 'init': {
@@ -206,7 +216,10 @@ ${chalk.blue('  |_| ')}${chalk.green(' \\___/')}${chalk.yellow(
         case 'generate-migration': {
           const orm = await initOrm();
 
-          const result = await orm.migrator.createMigration();
+          const result = await orm.migrator.createMigration(
+            undefined,
+            args.blank,
+          );
 
           console.log(result.code);
 

--- a/server/src/migrations/.snapshot-db.db.json
+++ b/server/src/migrations/.snapshot-db.db.json
@@ -1280,14 +1280,6 @@
           "expression": "create unique index `unique_program_single_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NULL"
         },
         {
-          "keyName": "program_external_id_uuid_source_type_unique",
-          "columnNames": ["uuid", "source_type"],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": true
-        },
-        {
           "keyName": "primary",
           "columnNames": ["uuid"],
           "composite": false,
@@ -1661,7 +1653,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "enumItems": ["plex", "plex-guid", "imdb", "tmdb", "tvdb"],
+          "enumItems": ["plex", "plex-guid", "tmdb", "imdb", "tvdb"],
           "mappedType": "enum"
         },
         "external_source_id": {

--- a/server/src/migrations/Migration20240618005544.ts
+++ b/server/src/migrations/Migration20240618005544.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240618005544 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('PRAGMA foreign_keys = OFF;');
+    this.addSql(
+      "CREATE TABLE `_temp_program_external_ids` (`uuid` text NOT NULL, `created_at` datetime NULL, `updated_at` datetime NULL, `source_type` text check (`source_type` in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb')) NOT NULL, `external_source_id` text NULL, `external_key` text NOT NULL, `external_file_path` text NULL, `direct_file_path` text NULL, `program_uuid` text NOT NULL, CONSTRAINT `program_external_id_program_uuid_foreign` FOREIGN KEY (`program_uuid`) REFERENCES `program` (`uuid`) ON UPDATE CASCADE, PRIMARY KEY (`uuid`));",
+    );
+    this.addSql('DROP TABLE "program_external_id";');
+    this.addSql(
+      'ALTER TABLE "_temp_program_external_ids" RENAME TO "program_external_id";',
+    );
+    this.addSql('PRAGMA foreign_keys = ON;');
+    this.addSql(
+      'create unique index if not exists `unique_program_multiple_external_id` on `program_external_id` (`program_uuid`, `source_type`, `external_source_id`) WHERE `external_source_id` IS NOT NULL;',
+    );
+    this.addSql(
+      'create unique index if not exists `unique_program_single_external_id` on `program_external_id` (`program_uuid`, `source_type`) WHERE `external_source_id` IS NULL;',
+    );
+  }
+}

--- a/server/src/tasks/fixers/BackfillProgramExternalIds.ts
+++ b/server/src/tasks/fixers/BackfillProgramExternalIds.ts
@@ -82,7 +82,6 @@ export class BackfillProgramExternalIds extends Fixer {
           ),
         { concurrency: 1, waitAfterEachMs: 50 },
       )) {
-        console.log(result);
         if (result.type === 'error') {
           this.#logger.error(
             result.error,


### PR DESCRIPTION
Latest migration incorrectly created the conditional indexes, which
potentially allowed duplicates into the table. There was also a bug
before the latest migration that allowed dupes, which would make the
migration fail when reinserting the data into the new table. Easiest
solution here, since this data 1. still largely exists for programs in
the program table, and 2. is largely unused, is to completely drop the
table, recreate it correctly, and let the BackfillProgramExternalIds run
and fix everything up.

Some verification:

No external_key mismatches after migration

> sqlite> select eid.*, p.title from program_external_id eid join
program p on eid.program_uuid = p.uuid where p.external_key !=
eid.external_key and eid.source_type = 'plex';

There are only 3 programs that we were not able to find rating keys for
however, this means that the programs will be "broken" anyway and will
have to be readded in the UI, since their rating_keys are dangling in
Plex.

> sqlite> select count(p.uuid) from program p left join
program_external_id eid on p.uuid = eid.program_uuid where eid.uuid is
null;
count(p.uuid)
-------------
3

Fixes #537
