### PR TITLE
Plex request cache

### DIFF
--- a/server/src/api/metadataApi.ts
+++ b/server/src/api/metadataApi.ts
@@ -7,7 +7,7 @@ import {
   ProgramSourceType,
   programSourceTypeFromString,
 } from '../dao/custom_types/ProgramSourceType';
-import { PlexApiFactory } from '../external/plex';
+import { PlexApiFactory } from '../external/PlexApiFactory';
 import { RouterPluginAsyncCallback } from '../types/serverType';
 
 const externalIdSchema = z
@@ -113,7 +113,7 @@ export const metadataApiRouter: RouterPluginAsyncCallback = async (fastify) => {
   );
 
   async function handlePlexItem(query: ExternalMetadataQuery) {
-    const plexApi = await PlexApiFactory.getOrSet(query.id.externalSourceId);
+    const plexApi = await PlexApiFactory().getOrSet(query.id.externalSourceId);
 
     if (isNil(plexApi)) {
       return null;

--- a/server/src/api/plexServersApi.ts
+++ b/server/src/api/plexServersApi.ts
@@ -8,7 +8,8 @@ import { PlexServerSettingsSchema } from '@tunarr/types/schemas';
 import { isError, isNil, isObject } from 'lodash-es';
 import z from 'zod';
 import { PlexServerSettings } from '../dao/entities/PlexServerSettings.js';
-import { Plex, PlexApiFactory } from '../external/plex.js';
+import { Plex } from '../external/plex.js';
+import { PlexApiFactory } from '../external/PlexApiFactory.js';
 import { GlobalScheduler } from '../services/scheduler.js';
 import { UpdateXmlTvTask } from '../tasks/UpdateXmlTvTask.js';
 import { RouterPluginAsyncCallback } from '../types/serverType.js';
@@ -319,7 +320,7 @@ export const plexServersRouter: RouterPluginAsyncCallback = async (
           return res.status(404).send({ message: 'Plex server not found.' });
         }
 
-        const plex = PlexApiFactory.get(server);
+        const plex = PlexApiFactory().get(server);
 
         const s = await Promise.race([
           plex.checkServerStatus().then((res) => res === 1),

--- a/server/src/api/systemSettingsApi.ts
+++ b/server/src/api/systemSettingsApi.ts
@@ -14,6 +14,7 @@ import {
   getDefaultLogLevel,
   getEnvironmentLogLevel,
 } from '../util/logging/LoggerFactory';
+import { ifDefined } from '../util/index.js';
 
 export const systemSettingsRouter: RouterPluginAsyncCallback = async (
   fastify,
@@ -61,6 +62,10 @@ export const systemSettingsRouter: RouterPluginAsyncCallback = async (
           backupSettingsPotentiallyChanged = true;
           system.backup = req.body.backup;
         }
+
+        ifDefined(req.body.cache, (cache) => {
+          system.cache = cache;
+        });
 
         return file;
       });

--- a/server/src/dao/LegacyProgramGroupingCalculator.ts
+++ b/server/src/dao/LegacyProgramGroupingCalculator.ts
@@ -30,7 +30,7 @@ import {
   round,
   values,
 } from 'lodash-es';
-import { PlexApiFactory } from '../external/plex.js';
+import { PlexApiFactory } from '../external/PlexApiFactory.js';
 import {
   flipMap,
   groupByUniqFunc,
@@ -279,7 +279,7 @@ export class LegacyProgramGroupingCalculator {
       return;
     }
 
-    const plexApi = PlexApiFactory.get(plexServer);
+    const plexApi = PlexApiFactory().get(plexServer);
 
     const parentIdsByGrandparent = ld
       .chain(programs)

--- a/server/src/dao/ProgramGroupingCalculator.ts
+++ b/server/src/dao/ProgramGroupingCalculator.ts
@@ -16,7 +16,8 @@ import {
   map,
   partition,
 } from 'lodash-es';
-import { PlexApiFactory, PlexQueryResult } from '../external/plex.js';
+import { PlexQueryResult } from '../external/plex.js';
+import { PlexApiFactory } from '../external/PlexApiFactory.js';
 import { Maybe } from '../types/util.js';
 import { asyncPool } from '../util/asyncPool.js';
 import { groupByUniqAndMap, mapAsyncSeq } from '../util/index.js';
@@ -133,7 +134,7 @@ export class ProgramGroupingCalculator {
       );
     }
 
-    const plexApi = await PlexApiFactory.getOrSet(plexServerName);
+    const plexApi = await PlexApiFactory().getOrSet(plexServerName);
 
     if (!plexApi) {
       return;

--- a/server/src/dao/legacy_migration/legacyDbMigration.ts
+++ b/server/src/dao/legacy_migration/legacyDbMigration.ts
@@ -31,7 +31,7 @@ import {
   sortBy,
 } from 'lodash-es';
 import path from 'path';
-import { PlexApiFactory } from '../../external/plex.js';
+import { PlexApiFactory } from '../../external/PlexApiFactory.js';
 import { globalOptions } from '../../globals.js';
 import { serverContext } from '../../serverContext.js';
 import { GlobalScheduler } from '../../services/scheduler.js';
@@ -320,7 +320,7 @@ export class LegacyDbMigrator {
           // will take care of that -- we may want to do it here if we want
           // to remove the fixer eventually, though.
           for (const entity of entities) {
-            const plexApi = PlexApiFactory.get(entity);
+            const plexApi = PlexApiFactory().get(entity);
             const status = await plexApi.checkServerStatus();
             if (status === 1) {
               this.logger.debug(

--- a/server/src/dao/legacy_migration/metadataBackfill.ts
+++ b/server/src/dao/legacy_migration/metadataBackfill.ts
@@ -12,7 +12,8 @@ import {
   PlexTvShow,
 } from '@tunarr/types/plex';
 import { first, groupBy, isNil, isNull, isUndefined, keys } from 'lodash-es';
-import { Plex, PlexApiFactory } from '../../external/plex';
+import { Plex } from '../../external/plex';
+import { PlexApiFactory } from '../../external/PlexApiFactory';
 import { isNonEmptyString, wait } from '../../util';
 import { LoggerFactory } from '../../util/logging/LoggerFactory';
 import { ProgramSourceType } from '../custom_types/ProgramSourceType';
@@ -162,7 +163,7 @@ export class LegacyMetadataBackfiller {
       }
 
       // Otherwise, we need to go and find details...
-      const plex = PlexApiFactory.get(server);
+      const plex = PlexApiFactory().get(server);
 
       // This where the types have to diverge, because the Plex
       // API types differ.

--- a/server/src/dao/settings.ts
+++ b/server/src/dao/settings.ts
@@ -101,6 +101,9 @@ export const defaultSettings = (dbBasePath: string): SettingsFile => ({
       logsDirectory: getDefaultLogDirectory(),
       useEnvVarLevel: true,
     },
+    cache: {
+      enablePlexRequestCache: false,
+    },
   },
 });
 

--- a/server/src/external/PlexApiFactory.ts
+++ b/server/src/external/PlexApiFactory.ts
@@ -1,0 +1,79 @@
+import { forEach, isBoolean, isNull, isUndefined } from 'lodash-es';
+import NodeCache from 'node-cache';
+import { getEm } from '../dao/dataSource.js';
+import { PlexServerSettings } from '../dao/entities/PlexServerSettings.js';
+import { Plex, PlexApiOptions } from './plex.js';
+import { SettingsDB, getSettings } from '../dao/settings.js';
+import { isDefined } from '../util/index.js';
+
+let instance: PlexApiFactoryImpl;
+
+export class PlexApiFactoryImpl {
+  #cache: NodeCache;
+  #requestCacheEnabled: boolean | Record<string, boolean> = false;
+
+  constructor(private settings: SettingsDB = getSettings()) {
+    this.#cache = new NodeCache({
+      useClones: false,
+      deleteOnExpire: true,
+      checkperiod: 60,
+    });
+
+    this.#requestCacheEnabled =
+      settings.systemSettings().cache?.enablePlexRequestCache ?? false;
+
+    this.settings.addListener('change', () => {
+      this.#requestCacheEnabled =
+        settings.systemSettings().cache?.enablePlexRequestCache ?? false;
+      forEach(this.#cache.data, (data, key) => {
+        const plex = data.v as Plex;
+        if (isDefined(plex)) {
+          plex.setEnableRequestCache(this.requestCacheEnabledForServer(key));
+        }
+      });
+    });
+  }
+
+  async getOrSet(name: string) {
+    let client = this.#cache.get<Plex>(name);
+    if (isUndefined(client)) {
+      const em = getEm();
+      const server = await em.repo(PlexServerSettings).findOne({ name });
+      if (!isNull(server)) {
+        client = new Plex({
+          ...server,
+          enableRequestCache: this.requestCacheEnabledForServer(server.name),
+        });
+        this.#cache.set(server.name, client);
+      }
+    }
+    return client;
+  }
+
+  get(opts: PlexApiOptions) {
+    const key = `${opts.uri}|${opts.accessToken}`;
+    let client = this.#cache.get<Plex>(key);
+    if (!client) {
+      client = new Plex({
+        ...opts,
+        enableRequestCache: this.requestCacheEnabledForServer(opts.name),
+      });
+      this.#cache.set(key, client);
+    }
+
+    return client;
+  }
+
+  private requestCacheEnabledForServer(id: string) {
+    return isBoolean(this.#requestCacheEnabled)
+      ? this.#requestCacheEnabled
+      : this.#requestCacheEnabled[id];
+  }
+}
+
+export const PlexApiFactory = () => {
+  if (!instance) {
+    instance = new PlexApiFactoryImpl();
+  }
+  return instance;
+};

--- a/server/src/stream/plex/PlexStreamDetails.ts
+++ b/server/src/stream/plex/PlexStreamDetails.ts
@@ -10,10 +10,10 @@ import { find, first, isNull, isUndefined, replace, trimEnd } from 'lodash-es';
 import { PlexServerSettings } from '../../dao/entities/PlexServerSettings';
 import {
   Plex,
-  PlexApiFactory,
   isPlexQueryError,
   isPlexQuerySuccess,
 } from '../../external/plex';
+import { PlexApiFactory } from '../../external/PlexApiFactory';
 import { Nullable } from '../../types/util';
 import { Logger, LoggerFactory } from '../../util/logging/LoggerFactory';
 import { PlexStream, StreamDetails } from './PlexTranscoder';
@@ -63,7 +63,7 @@ export class PlexStreamDetails {
       return null;
     }
 
-    const plex = PlexApiFactory.get(this.server);
+    const plex = PlexApiFactory().get(this.server);
     const expectedItemType = item.programType;
     const itemMetadataResult = await plex.getItemMetadata(item.externalKey);
 

--- a/server/src/stream/plex/PlexTranscoder.ts
+++ b/server/src/stream/plex/PlexTranscoder.ts
@@ -9,6 +9,7 @@ import { ContentBackedStreamLineupItem } from '../../dao/derived_types/StreamLin
 import { PlexServerSettings } from '../../dao/entities/PlexServerSettings.js';
 import { serverOptions } from '../../globals.js';
 import { Plex } from '../../external/plex.js';
+import { PlexApiFactory } from '../../external/PlexApiFactory.js';
 import { StreamContextChannel } from '../types.js';
 import { Maybe } from '../../types/util.js';
 import {
@@ -108,7 +109,7 @@ export class PlexTranscoder {
       this.log('Debug logging enabled');
     }
 
-    this.plex = new Plex(server);
+    this.plex = PlexApiFactory().get(server);
     // this.metadataPath = `${lineupItem.key}?X-Plex-Token=${server.accessToken}`;
     this.plexFile = `${server.uri}${lineupItem.plexFilePath}?X-Plex-Token=${server.accessToken}`;
     if (!isUndefined(lineupItem.filePath)) {

--- a/server/src/tasks/SavePlexProgramExternalIdsTask.ts
+++ b/server/src/tasks/SavePlexProgramExternalIdsTask.ts
@@ -6,7 +6,8 @@ import { getEm } from '../dao/dataSource.js';
 import { Program } from '../dao/entities/Program.js';
 import { ProgramExternalId } from '../dao/entities/ProgramExternalId.js';
 import { upsertProgramExternalIds_deprecated } from '../dao/programExternalIdHelpers.js';
-import { Plex, PlexApiFactory, isPlexQueryError } from '../external/plex.js';
+import { Plex, isPlexQueryError } from '../external/plex.js';
+import { PlexApiFactory } from '../external/PlexApiFactory.js';
 import { Maybe } from '../types/util.js';
 import { parsePlexExternalGuid } from '../util/externalIds.js';
 import { isDefined, isNonEmptyString } from '../util/index.js';
@@ -41,7 +42,7 @@ export class SavePlexProgramExternalIdsTask extends Task {
         continue;
       }
 
-      api = await PlexApiFactory.getOrSet(id.externalSourceId);
+      api = await PlexApiFactory().getOrSet(id.externalSourceId);
 
       if (isDefined(api)) {
         chosenId = id;

--- a/server/src/tasks/TaskQueue.ts
+++ b/server/src/tasks/TaskQueue.ts
@@ -48,8 +48,8 @@ export class TaskQueue {
   }
 }
 
-// Assume each task makes one request to Plex, limit tasks to 5 QPS on Plex
 export const PlexTaskQueue = new TaskQueue('PlexTaskQueue', {
+  concurrency: 2,
   intervalCap: 5,
   interval: 2000,
 });

--- a/server/src/tasks/UpdatePlexPlayStatusTask.ts
+++ b/server/src/tasks/UpdatePlexPlayStatusTask.ts
@@ -1,6 +1,6 @@
 import { RecurrenceRule } from 'node-schedule';
 import { PlexServerSettings } from '../dao/entities/PlexServerSettings';
-import { PlexApiFactory } from '../external/plex';
+import { PlexApiFactory } from '../external/PlexApiFactory';
 import { run } from '../util';
 import { ScheduledTask } from './ScheduledTask';
 import { Task } from './Task';
@@ -103,7 +103,7 @@ class UpdatePlexPlayStatusTask extends Task {
   }
 
   protected async runInternal(): Promise<boolean> {
-    const plex = PlexApiFactory.get(this.plexServer);
+    const plex = PlexApiFactory().get(this.plexServer);
 
     const deviceName = `tunarr-channel-${this.request.channelNumber}`;
     const params = {

--- a/server/src/tasks/fixers/BackfillProgramExternalIds.ts
+++ b/server/src/tasks/fixers/BackfillProgramExternalIds.ts
@@ -13,7 +13,8 @@ import { getEm } from '../../dao/dataSource';
 import { PlexServerSettings } from '../../dao/entities/PlexServerSettings.js';
 import { Program } from '../../dao/entities/Program';
 import { ProgramExternalId } from '../../dao/entities/ProgramExternalId.js';
-import { Plex, PlexApiFactory, isPlexQueryError } from '../../external/plex.js';
+import { Plex, isPlexQueryError } from '../../external/plex.js';
+import { PlexApiFactory } from '../../external/PlexApiFactory';
 import { Maybe } from '../../types/util.js';
 import { asyncPool } from '../../util/asyncPool.js';
 import { attempt, attemptSync, groupByUniq, wait } from '../../util/index.js';
@@ -70,7 +71,7 @@ export class BackfillProgramExternalIds extends Fixer {
       });
 
       forEach(serverSettings, (server) => {
-        plexConnections[server.name] = PlexApiFactory.get(server);
+        plexConnections[server.name] = PlexApiFactory().get(server);
       });
 
       for await (const result of asyncPool(

--- a/server/src/tasks/fixers/backfillProgramGroupings.ts
+++ b/server/src/tasks/fixers/backfillProgramGroupings.ts
@@ -23,7 +23,7 @@ import {
   ProgramGroupingType,
 } from '../../dao/entities/ProgramGrouping';
 import { ProgramGroupingExternalId } from '../../dao/entities/ProgramGroupingExternalId';
-import { PlexApiFactory } from '../../external/plex';
+import { PlexApiFactory } from '../../external/PlexApiFactory';
 import { LoggerFactory } from '../../util/logging/LoggerFactory';
 import Fixer from './fixer';
 import { ProgramExternalIdType } from '../../dao/custom_types/ProgramExternalIdType';
@@ -77,7 +77,7 @@ export class BackfillProgramGroupings extends Fixer {
         continue;
       }
 
-      const plex = PlexApiFactory.get(server);
+      const plex = PlexApiFactory().get(server);
       const plexResult = await plex.doGet<PlexLibraryShows>(
         '/library/metadata/' + grandparentExternalKey,
       );
@@ -147,7 +147,7 @@ export class BackfillProgramGroupings extends Fixer {
         continue;
       }
 
-      const plex = PlexApiFactory.get(server);
+      const plex = PlexApiFactory().get(server);
       const plexResult = await plex.doGet<PlexSeasonView>(
         '/library/metadata/' + parentExternalKey,
       );
@@ -245,7 +245,7 @@ export class BackfillProgramGroupings extends Fixer {
         continue;
       }
 
-      const plex = PlexApiFactory.get(server);
+      const plex = PlexApiFactory().get(server);
       const plexResult = await plex.doGet<PlexSeasonView>(
         '/library/metadata/' + ref.externalKey,
       );

--- a/types/src/SystemSettings.ts
+++ b/types/src/SystemSettings.ts
@@ -34,9 +34,17 @@ export const LoggingSettingsSchema = z.object({
 
 export type LoggingSettings = z.infer<typeof LoggingSettingsSchema>;
 
+export const CacheSettingsSchema = z.object({
+  // Preserve previous behavior
+  enablePlexRequestCache: z.boolean().optional().default(false).catch(false),
+});
+
+export type CacheSettings = z.infer<typeof CacheSettingsSchema>;
+
 export const SystemSettingsSchema = z.object({
   backup: BackupSettingsSchema,
   logging: LoggingSettingsSchema,
+  cache: CacheSettingsSchema.optional(),
 });
 
 export type SystemSettings = z.infer<typeof SystemSettingsSchema>;

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -13,6 +13,7 @@ import {
   TimeSlotScheduleSchema,
 } from './Scheduling.js';
 import {
+  CacheSettingsSchema,
   LogLevelsSchema,
   LoggingSettingsSchema,
   SystemSettingsSchema,
@@ -192,6 +193,7 @@ export const UpdateSystemSettingsRequestSchema = z.object({
     .partial()
     .optional(),
   backup: BackupSettingsSchema.optional(),
+  cache: CacheSettingsSchema.optional(),
 });
 
 export type UpdateSystemSettingsRequest = z.infer<

--- a/web/src/pages/settings/GeneralSettingsPage.tsx
+++ b/web/src/pages/settings/GeneralSettingsPage.tsx
@@ -12,7 +12,9 @@ import {
   Select,
   SelectChangeEvent,
   TextField,
+  Tooltip,
   Typography,
+  useTheme,
 } from '@mui/material';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
@@ -79,6 +81,7 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
   const versionInfo = useVersion({
     retry: 0,
   });
+  const theme = useTheme();
 
   const { isLoading, isError } = versionInfo;
 
@@ -381,10 +384,44 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
           </FormControl>
         </Box>
         <Box>
-          <Typography variant="h5" sx={{ mb: 1 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
             Backups
           </Typography>
           {renderBackupsForm()}
+        </Box>
+        <Box>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Caching
+          </Typography>
+          <Box>
+            <FormControl sx={{ width: '50%' }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={backupsEnabled}
+                    onChange={toggleBackupEnabled}
+                  />
+                }
+                label={
+                  <span>
+                    <strong>Experimental:</strong> Enable Plex Request Cache{' '}
+                    <Tooltip
+                      title="Temporarily caches responses from Plex based by request path. Could potentially speed up channel editing."
+                      placement="top"
+                    >
+                      <sup style={{ color: theme.palette.primary.main }}>
+                        [?]
+                      </sup>
+                    </Tooltip>
+                  </span>
+                }
+              />
+              <FormHelperText>
+                This feature is currently experimental. Proceed with caution and
+                if you experience an issue, try disabling caching.
+              </FormHelperText>
+            </FormControl>
+          </Box>
         </Box>
       </Stack>
       <Stack spacing={2} direction="row" justifyContent="right" sx={{ mt: 2 }}>

--- a/web/src/pages/settings/GeneralSettingsPage.tsx
+++ b/web/src/pages/settings/GeneralSettingsPage.tsx
@@ -18,7 +18,12 @@ import {
 } from '@mui/material';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
-import { LogLevel, LogLevels, SystemSettings } from '@tunarr/types';
+import {
+  CacheSettings,
+  LogLevel,
+  LogLevels,
+  SystemSettings,
+} from '@tunarr/types';
 import {
   attempt,
   first,
@@ -53,6 +58,7 @@ type GeneralSettingsFormData = {
   backendUri: string;
   logLevel: LogLevel | 'env';
   backup: BackupSettings;
+  cache: CacheSettings;
 };
 
 type GeneralSetingsFormProps = {
@@ -95,6 +101,9 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
       ? 'env'
       : systemSettings.logging.logLevel,
     backup: systemSettings.backup,
+    cache: systemSettings.cache ?? {
+      enablePlexRequestCache: false,
+    },
   });
 
   const {
@@ -132,6 +141,7 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
         useEnvVarLevel: data.logLevel === 'env',
       },
       backup: data.backup,
+      cache: data.cache,
     };
     updateSystemSettings.mutate(updateReq, {
       onSuccess(data) {
@@ -397,9 +407,12 @@ function GeneralSettingsForm({ systemSettings }: GeneralSetingsFormProps) {
             <FormControl sx={{ width: '50%' }}>
               <FormControlLabel
                 control={
-                  <Checkbox
-                    checked={backupsEnabled}
-                    onChange={toggleBackupEnabled}
+                  <Controller
+                    control={control}
+                    name="cache.enablePlexRequestCache"
+                    render={({ field }) => (
+                      <Checkbox checked={field.value} {...field} />
+                    )}
                   />
                 }
                 label={

--- a/web/src/pages/settings/PlexSettingsPage.tsx
+++ b/web/src/pages/settings/PlexSettingsPage.tsx
@@ -613,7 +613,7 @@ export default function PlexSettingsPage() {
       {renderConfirmationDialog()}
       <Box>
         <Box mb={2}>
-          <Box sx={{ display: 'flex', mb: 2 }}>
+          <Box sx={{ display: 'flex', mb: 1 }}>
             <Typography variant="h6" sx={{ flexGrow: 1 }}>
               Plex Servers
             </Typography>
@@ -621,7 +621,7 @@ export default function PlexSettingsPage() {
           </Box>
           {renderServersTable()}
         </Box>
-        <Typography component="h6" variant="h6" sx={{ pt: 2, pb: 2 }}>
+        <Typography component="h6" variant="h6" sx={{ mb: 2 }}>
           Plex Streaming
         </Typography>
 
@@ -660,17 +660,6 @@ export default function PlexSettingsPage() {
             </FormControl>
           </Grid>
           <Grid item xs={12} sm={6}>
-            <FormControl fullWidth>
-              <FormControlLabel
-                control={
-                  <CheckboxFormController
-                    control={control}
-                    name="enableDebugLogging"
-                  />
-                }
-                label="Debug Logging"
-              />
-            </FormControl>
             <FormControl fullWidth>
               <FormControlLabel
                 control={


### PR DESCRIPTION
Introduce experimental Plex request cache. 

This can be turned on in the UI. It should improve performance in some areas, especially editing/adding large channels. However it's correctness hasn't been verified. Caching is hard and may introduce subtle bugs. As such the option defaults to false while we can dogfood it. It may be removed in a future release. 