### PR TITLE
Fixes issue with Inline Modal opening more than once

### DIFF
--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -438,9 +438,11 @@ export default function PlexProgrammingSelector() {
 
   const renderFinalRowInlineModal = (arr: PlexMedia[]) => {
     // /This Modal is for last row items because they can't be inserted using the above inline modal
-    const open = extractLastIndexes(arr, arr.length % rowSize).includes(
-      modalIndex,
-    );
+    // Check how many items are in the last row
+    const remainingItems =
+      arr.length % rowSize === 0 ? rowSize : arr.length % rowSize;
+
+    const open = extractLastIndexes(arr, remainingItems).includes(modalIndex);
 
     return (
       <InlineModal


### PR DESCRIPTION
There was an issue where Inline Modal would display more than once.  Turns out if `arr.length % rowSize === 0` it would pass 0 into `extractLastIndexes`, then slice(-0) left the entire array there, which resulted in the Inline Modal displaying more than once.  This would mainly happen when the collection filled up the last row perfectly.