### PR TITLE
Fix audio-only channel streaming initialization

### DIFF
--- a/server/src/external/plex.ts
+++ b/server/src/external/plex.ts
@@ -229,6 +229,13 @@ export class Plex {
     return this.opts.name;
   }
 
+  getFullUrl(path: string): string {
+    const sanitizedPath = path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${this.opts.uri}${sanitizedPath}`);
+    url.searchParams.set('X-Plex-Token', this.opts.accessToken);
+    return url.toString();
+  }
+
   private async doRequest<T>(req: AxiosRequestConfig): Promise<Try<T>> {
     try {
       const response = await this.axiosInstance.request<T>(req);
@@ -272,6 +279,14 @@ export class Plex {
         return new Error('Unknown error when requesting Plex');
       }
     }
+  }
+
+  async doHead(path: string, optionalHeaders: RawAxiosRequestHeaders = {}) {
+    return await this.doRequest({
+      method: 'head',
+      url: path,
+      headers: optionalHeaders,
+    });
   }
 
   // TODO: make all callers use this

--- a/types/src/plex/index.ts
+++ b/types/src/plex/index.ts
@@ -414,8 +414,8 @@ export const PlexMusicAlbumSchema = BasePlexMediaSchema.extend({
   parentTitle: z.string(), // Artist name
   summary: z.string().optional(),
   index: z.number(),
-  viewCount: z.number(),
-  skipCount: z.number(),
+  viewCount: z.number().optional(),
+  skipCount: z.number().optional(),
   lastViewedAt: z.number().optional(),
   year: z.number().optional(),
   thumb: z.string().optional(),


### PR DESCRIPTION
Issue here was that generally music tracks in Plex do not have their own thumbnails. If we're attempting to set our placeholder overlay image on an audio only stream and we're dealing with a Plex music track, look for thumbs in this order:

1. Parent thumb (album)
2. Grandparent thumb (artist)
3. Item thumb (track)

We then send a HEAD request to the URL to ensure it is reachable before starting the stream, otherwise it will fail (the original error)

An improvement here would be to sent simultaneous HEAD requests to parent/grandparent/item thumb (whichever are non-empth) and then pick the first success result in priority order described above.

