### PR TITLE
Fix jitter when loading in season episodes in inline modal

### DIFF
--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -30,8 +30,6 @@ export function getEstimatedModalHeight(
   listSize: number,
   type: PlexMedia['type'] | 'all',
 ): number {
-  console.log(type);
-
   // Episode modals have smaller height, short circuit for  now
   if (type === 'season') {
     return SeasonModalHeight;


### PR DESCRIPTION
Updated the season modal height to match the actual height of the modal after loading in 1 row of episodes.  This removes the jittering that we were seeing when switching between seasons of the same show.