### PR TITLE
Fix final row inline modal render

### DIFF
--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -517,6 +517,9 @@ export default function PlexProgrammingSelector() {
         .flatten()
         .value();
 
+      const totalSearchDataSize =
+        searchData.pages[0].totalSize || searchData.pages[0].size;
+
       elements.push(
         <CustomTabPanel value={tabValue} index={0} key="Library">
           {map(
@@ -528,7 +531,9 @@ export default function PlexProgrammingSelector() {
                 renderGridItems(item, index)
               ),
           )}
-          {renderFinalRowInlineModal(items)}
+
+          {items.length >= totalSearchDataSize &&
+            renderFinalRowInlineModal(items)}
         </CustomTabPanel>,
       );
     }


### PR DESCRIPTION
Fixes issue where InlineModal was loading as a final row after the initial fetch of data.  This fixes it so it doesn't trigger the final row inline modal until the all items are fetched