### PR TITLE
Convert 'getChannel(s)AndPrograms' queries to not use ORM

### DIFF
--- a/server/src/XmlTvWriter.ts
+++ b/server/src/XmlTvWriter.ts
@@ -11,7 +11,7 @@ import { forProgramType } from '@tunarr/shared/util';
 import { flatMap, isNil, map, round, escape } from 'lodash-es';
 import { isNonEmptyString } from './util';
 import { writeFile } from 'fs/promises';
-import { Channel } from './dao/entities/Channel.js';
+import { Channel } from './dao/direct/derivedTypes';
 import { LoggerFactory } from './util/logging/LoggerFactory';
 
 const lock = new Mutex();

--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -15,7 +15,7 @@ import {
 } from '@tunarr/types/schemas';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
-import { compact, isError, isNil, map, omit, sortBy } from 'lodash-es';
+import { compact, isError, isNil, omit, sortBy } from 'lodash-es';
 import z from 'zod';
 import { GlobalScheduler } from '../services/scheduler.js';
 import { UpdateXmlTvTask } from '../tasks/UpdateXmlTvTask.js';
@@ -150,7 +150,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
             channel.uuid,
             channelUpdate,
           );
-          await req.serverCtx.guideService.updateCachedChannel(updatedChannel);
+          await req.serverCtx.guideService.updateCachedChannel(channel.uuid);
           return res.send(omit(updatedChannel.toDTO(), 'programs'));
         } else {
           return res.status(404).send();
@@ -216,7 +216,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
         );
 
         if (!isNil(channel)) {
-          return res.send(map(channel.programs, (p) => p.toDTO()));
+          return res.send(channel.programs);
         } else {
           return res.status(404).send();
         }

--- a/server/src/api/debugApi.ts
+++ b/server/src/api/debugApi.ts
@@ -47,7 +47,7 @@ export const debugApi: RouterPluginAsyncCallback = async (fastify) => {
     async (req, res) => {
       void res.hijack();
       const t0 = new Date().getTime();
-      const channel = await req.serverCtx.channelDB.getChannelAndPrograms(
+      const channel = await req.serverCtx.channelDB.getChannelAndProgramsSLOW(
         req.query.channelId,
       );
 
@@ -94,7 +94,7 @@ export const debugApi: RouterPluginAsyncCallback = async (fastify) => {
     '/debug/plex-transcoder/video-stats',
     { schema: ChannelQuerySchema },
     async (req, res) => {
-      const channel = await req.serverCtx.channelDB.getChannelAndPrograms(
+      const channel = await req.serverCtx.channelDB.getChannelAndProgramsSLOW(
         req.query.channelId,
       );
 
@@ -303,7 +303,10 @@ export const debugApi: RouterPluginAsyncCallback = async (fastify) => {
           channel,
           await req.serverCtx.channelDB.loadLineup(channel.uuid),
         ),
-        channel,
+        // HACK until we remove much of the old DB code
+        await req.serverCtx.channelDB
+          .getChannel(req.query.channelId)
+          .then((x) => x!),
         false,
       );
 

--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -233,6 +233,7 @@ export class ChannelDB {
       )
       .select((eb) => withPrograms(eb, { joins: { customShows: true } }))
       .groupBy('channel.uuid')
+      .orderBy('channel.number asc')
       .executeTakeFirst();
     // return getEm()
     //   .repo(Channel)
@@ -363,6 +364,7 @@ export class ChannelDB {
         }),
       ])
       .groupBy('channel.uuid')
+      .orderBy('channel.number asc')
       .execute();
 
     // return getEm()

--- a/server/src/dao/converters/programConverters.ts
+++ b/server/src/dao/converters/programConverters.ts
@@ -287,15 +287,13 @@ export class ProgramConverter {
     if (program.type === ProgramType.Episode.toString()) {
       extraFields = {
         ...extraFields,
-        icon: nullToUndefined(program.episode_icon ?? program.show_icon),
-        showId: nullToUndefined(program.tv_show?.uuid ?? program.tv_show_uuid),
-        seasonId: nullToUndefined(
-          program.tv_season?.uuid ?? program.season_uuid,
-        ),
-        seasonNumber: nullToUndefined(program.tv_season?.index),
+        icon: nullToUndefined(program.episodeIcon ?? program.showIcon),
+        showId: nullToUndefined(program.tvShow?.uuid ?? program.tvShowUuid),
+        seasonId: nullToUndefined(program.tvSeason?.uuid ?? program.seasonUuid),
+        seasonNumber: nullToUndefined(program.tvSeason?.index),
         episodeNumber: nullToUndefined(program.episode),
         episodeTitle: program.title,
-        title: nullToUndefined(program.tv_show?.title ?? program.show_title),
+        title: nullToUndefined(program.tvShow?.title ?? program.showTitle),
       };
     } else if (program.type === ProgramType.Track.toString()) {
       // extraFields = {
@@ -310,7 +308,7 @@ export class ProgramConverter {
       persisted: true, // Explicit since we're dealing with db loaded entities
       uniqueId: program.uuid,
       summary: nullToUndefined(program.summary),
-      date: nullToUndefined(program.original_air_date),
+      date: nullToUndefined(program.originalAirDate),
       rating: nullToUndefined(program.rating),
       icon: nullToUndefined(program.icon),
       title: program.title,
@@ -371,23 +369,23 @@ export class ProgramConverter {
 
   private toExternalId(rawExternalId: RawProgramExternalId) {
     if (
-      isNonEmptyString(rawExternalId.external_source_id) &&
-      isValidMultiExternalIdType(rawExternalId.source_type)
+      isNonEmptyString(rawExternalId.externalSourceId) &&
+      isValidMultiExternalIdType(rawExternalId.sourceType)
     ) {
       return {
         type: 'multi' as const,
-        source: rawExternalId.source_type,
-        sourceId: rawExternalId.external_source_id,
-        id: rawExternalId.external_key,
+        source: rawExternalId.sourceType,
+        sourceId: rawExternalId.externalSourceId,
+        id: rawExternalId.externalKey,
       };
     } else if (
-      isValidSingleExternalIdType(rawExternalId.source_type) &&
-      !isNonEmptyString(rawExternalId.external_source_id)
+      isValidSingleExternalIdType(rawExternalId.sourceType) &&
+      !isNonEmptyString(rawExternalId.externalSourceId)
     ) {
       return {
         type: 'single' as const,
-        source: rawExternalId.source_type,
-        id: rawExternalId.external_key,
+        source: rawExternalId.sourceType,
+        id: rawExternalId.externalKey,
       };
     }
 

--- a/server/src/dao/converters/programConverters.ts
+++ b/server/src/dao/converters/programConverters.ts
@@ -119,7 +119,7 @@ export class ProgramConverter {
     item: LineupItem,
     channelReferences: MarkRequired<
       DeepPartial<RawChannel>,
-      'uuid' | 'number'
+      'uuid' | 'number' | 'name'
     >[], // TODO fix this up...
   ) {
     if (isOfflineItem(item)) {
@@ -411,7 +411,7 @@ export class ProgramConverter {
 
   directRedirectLineupItemToProgram(
     item: RedirectItem,
-    channel: MarkRequired<DeepPartial<RawChannel>, 'uuid' | 'number'>,
+    channel: MarkRequired<DeepPartial<RawChannel>, 'uuid' | 'number' | 'name'>,
   ): RedirectProgram {
     return {
       persisted: true,

--- a/server/src/dao/converters/programConverters.ts
+++ b/server/src/dao/converters/programConverters.ts
@@ -33,7 +33,10 @@ import {
 } from '../derived_types/Lineup.js';
 import { Channel } from '../entities/Channel.js';
 import { Program, ProgramType } from '../entities/Program.js';
-import { Program as RawProgram } from '../direct/derivedTypes.js';
+import {
+  Program as RawProgram,
+  Channel as RawChannel,
+} from '../direct/derivedTypes.js';
 import { ProgramExternalId as RawProgramExternalId } from '../direct/types.gen.js';
 import { ProgramExternalId } from '../entities/ProgramExternalId.js';
 import {
@@ -41,6 +44,7 @@ import {
   isValidSingleExternalIdType,
 } from '@tunarr/types/schemas';
 import { seq } from '@tunarr/shared/util';
+import { DeepPartial, MarkRequired } from 'ts-essentials';
 
 type ContentProgramConversionOptions = {
   skipPopulate: boolean | Partial<Record<'externalIds' | 'grouping', boolean>>;
@@ -106,6 +110,43 @@ export class ProgramConverter {
         program,
         undefined,
         opts?.contentProgramConversionOptions,
+      );
+    }
+  }
+
+  directLineupItemToChannelProgram(
+    channel: MarkRequired<RawChannel, 'programs'>,
+    item: LineupItem,
+    channelReferences: MarkRequired<
+      DeepPartial<RawChannel>,
+      'uuid' | 'number'
+    >[], // TODO fix this up...
+  ) {
+    if (isOfflineItem(item)) {
+      return this.directOfflineLineupItemToProgram(channel, item);
+    } else if (isRedirectItem(item)) {
+      const redirectChannel = find(channelReferences, { uuid: item.channel });
+      if (isNil(redirectChannel)) {
+        this.logger.warn(
+          'Dangling redirect channel reference. Source channel = %s, target channel = %s',
+          channel.uuid,
+          item.channel,
+        );
+        return this.directOfflineLineupItemToProgram(channel, {
+          type: 'offline',
+          durationMs: item.durationMs,
+        });
+      }
+      return this.directRedirectLineupItemToProgram(item, redirectChannel);
+    } else {
+      const program = channel.programs.find((p) => p.uuid === item.id);
+      if (isNil(program)) {
+        return null;
+      }
+
+      return this.directEntityToContentProgramSync(
+        program,
+        program.externalIds ?? [], // TODO fill in external IDs here
       );
     }
   }
@@ -296,12 +337,14 @@ export class ProgramConverter {
         title: nullToUndefined(program.tvShow?.title ?? program.showTitle),
       };
     } else if (program.type === ProgramType.Track.toString()) {
-      // extraFields = {
-      //   albumName: program.album?.$.title,
-      //   artistName: program.artist?.$.title,
-      //   albumId: program.album?.uuid,
-      //   artistId: program.artist?.uuid,
-      // };
+      extraFields = {
+        albumName: nullToUndefined(program.trackAlbum?.title),
+        artistName: nullToUndefined(program.trackArtist?.title),
+        albumId: nullToUndefined(program.trackAlbum?.uuid ?? program.albumUuid),
+        artistId: nullToUndefined(
+          program.trackArtist?.uuid ?? program.artistUuid,
+        ),
+      };
     }
 
     return {
@@ -335,6 +378,19 @@ export class ProgramConverter {
     };
   }
 
+  directOfflineLineupItemToProgram(
+    channel: RawChannel,
+    program: OfflineItem,
+    persisted: boolean = true,
+  ): FlexProgram {
+    return {
+      persisted,
+      type: 'flex',
+      icon: channel.icon?.path,
+      duration: program.durationMs,
+    };
+  }
+
   redirectLineupItemToProgram(
     item: RedirectItem,
     channel: Loaded<Channel, never, 'name' | 'number'>,
@@ -351,6 +407,20 @@ export class ProgramConverter {
     } else {
       return this.toRedirectChannelInternal(item, loadedChannel);
     }
+  }
+
+  directRedirectLineupItemToProgram(
+    item: RedirectItem,
+    channel: MarkRequired<DeepPartial<RawChannel>, 'uuid' | 'number'>,
+  ): RedirectProgram {
+    return {
+      persisted: true,
+      type: 'redirect',
+      channel: item.channel,
+      channelName: channel.name,
+      channelNumber: channel.number,
+      duration: item.durationMs,
+    };
   }
 
   private toRedirectChannelInternal(

--- a/server/src/dao/direct/derivedTypes.d.ts
+++ b/server/src/dao/direct/derivedTypes.d.ts
@@ -1,9 +1,24 @@
 import { DeepNullable } from 'ts-essentials';
 import * as RawType from './types.gen';
+import { Selectable } from 'kysely';
+import { ChannelIcon } from '../entities/Channel.js';
 
-export type Program = RawType.Program & {
-  tv_show: DeepNullable<Partial<RawType.ProgramGrouping>> | null;
-  tv_season: DeepNullable<Partial<RawType.ProgramGrouping>> | null;
-  track_artist: DeepNullable<Partial<RawType.ProgramGrouping>> | null;
-  track_album: DeepNullable<Partial<RawType.ProgramGrouping>> | null;
+export type Program = Selectable<RawType.Program> & {
+  tvShow?: DeepNullable<Partial<Selectable<RawType.ProgramGrouping>>> | null;
+  tvSeason?: DeepNullable<Partial<Selectable<RawType.ProgramGrouping>>> | null;
+  trackArtist?: DeepNullable<
+    Partial<Selectable<RawType.ProgramGrouping>>
+  > | null;
+  trackAlbum?: DeepNullable<
+    Partial<Selectable<RawType.ProgramGrouping>>
+  > | null;
+};
+
+export type Channel = Selectable<RawType.Channel> & {
+  icon?: ChannelIcon;
+  programs: Program[];
+};
+
+export type DB = RawType.DB & {
+  channel: Channel;
 };

--- a/server/src/dao/direct/derivedTypes.d.ts
+++ b/server/src/dao/direct/derivedTypes.d.ts
@@ -1,7 +1,7 @@
-import { DeepNullable } from 'ts-essentials';
+import { DeepNullable, MarkRequired } from 'ts-essentials';
 import * as RawType from './types.gen';
 import { Selectable } from 'kysely';
-import { ChannelIcon } from '../entities/Channel.js';
+import { ChannelIcon, ChannelOfflineSettings } from '../entities/Channel.js';
 
 export type Program = Selectable<RawType.Program> & {
   tvShow?: DeepNullable<Partial<Selectable<RawType.ProgramGrouping>>> | null;
@@ -12,13 +12,20 @@ export type Program = Selectable<RawType.Program> & {
   trackAlbum?: DeepNullable<
     Partial<Selectable<RawType.ProgramGrouping>>
   > | null;
+  externalIds?: Selectable<RawType.ProgramExternalId>[] | null; // Always require that we select the full external ID details
 };
 
-export type Channel = Selectable<RawType.Channel> & {
-  icon?: ChannelIcon;
-  programs: Program[];
+export type Channel = Selectable<
+  Omit<RawType.Channel, 'icon' | 'offline'> & {
+    icon?: ChannelIcon;
+    offline?: ChannelOfflineSettings;
+  }
+> & {
+  programs?: Program[];
 };
 
-export type DB = RawType.DB & {
+export type ChannelWithPrograms = MarkRequired<Channel, 'programs'>;
+
+export type DB = Omit<RawType.DB, 'channel'> & {
   channel: Channel;
 };

--- a/server/src/dao/direct/directDbAccess.ts
+++ b/server/src/dao/direct/directDbAccess.ts
@@ -1,9 +1,14 @@
 import { once } from 'lodash-es';
 import { GlobalOptions } from '../../globals';
-import { Kysely, ParseJSONResultsPlugin, SqliteDialect } from 'kysely';
+import {
+  CamelCasePlugin,
+  Kysely,
+  ParseJSONResultsPlugin,
+  SqliteDialect,
+} from 'kysely';
 import path from 'path';
 import Sqlite from 'better-sqlite3';
-import { DB } from './types.gen';
+import { DB } from './derivedTypes.js';
 import { LoggerFactory } from '../../util/logging/LoggerFactory';
 
 let _directDbAccess: Kysely<DB>;
@@ -30,7 +35,7 @@ export const initDirectDbAccess = once((opts: GlobalOptions) => {
           return;
       }
     },
-    plugins: [new ParseJSONResultsPlugin()],
+    plugins: [new ParseJSONResultsPlugin(), new CamelCasePlugin()],
   });
 });
 

--- a/server/src/dao/direct/programQueryHelpers.ts
+++ b/server/src/dao/direct/programQueryHelpers.ts
@@ -203,6 +203,5 @@ export function withPrograms(
           .onRef('channelPrograms.programUuid', '=', 'program.uuid')
           .onRef('channel.uuid', '=', 'channelPrograms.channelUuid'),
       ),
-    // .whereRef('program.uuid', '=', 'channelPrograms.programUuid'),
   ).as('programs');
 }

--- a/server/src/dao/direct/programQueryHelpers.ts
+++ b/server/src/dao/direct/programQueryHelpers.ts
@@ -1,47 +1,88 @@
 import { ExpressionBuilder } from 'kysely';
 import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/sqlite';
 import { ProgramType } from '../entities/Program';
-import { DB } from './types.gen';
+import {
+  Program as RawProgram,
+  ProgramGrouping as RawProgramGrouping,
+  DB,
+} from './types.gen';
+import { isBoolean, merge } from 'lodash-es';
+import { DeepRequired } from 'ts-essentials';
 
-export function withTvShow(eb: ExpressionBuilder<DB, 'program'>) {
+type ProgramGroupingFields =
+  readonly `programGrouping.${keyof RawProgramGrouping}`[];
+
+export const AllProgramGroupingFields: ProgramGroupingFields = [
+  'programGrouping.artistUuid',
+  'programGrouping.createdAt',
+  'programGrouping.icon',
+  'programGrouping.index',
+  'programGrouping.showUuid',
+  'programGrouping.summary',
+  'programGrouping.title',
+  'programGrouping.type',
+  'programGrouping.updatedAt',
+  'programGrouping.uuid',
+  'programGrouping.year',
+];
+
+export const MinimalProgramGroupingFields: ProgramGroupingFields = [
+  'programGrouping.uuid',
+  'programGrouping.title',
+  'programGrouping.year',
+];
+
+export function withTvShow(
+  eb: ExpressionBuilder<DB, 'program'>,
+  fields: ProgramGroupingFields = AllProgramGroupingFields,
+) {
   return jsonObjectFrom(
     eb
-      .selectFrom('programGrouping as pg')
-      .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.tvShowUuid')
+      .selectFrom('programGrouping')
+      .select(fields)
+      .whereRef('programGrouping.uuid', '=', 'program.tvShowUuid')
       .where('program.type', '=', ProgramType.Episode)
       .orderBy('uuid'),
   ).as('tvShow');
 }
 
-export function withTvSeason(eb: ExpressionBuilder<DB, 'program'>) {
+export function withTvSeason(
+  eb: ExpressionBuilder<DB, 'program'>,
+  fields: ProgramGroupingFields = AllProgramGroupingFields,
+) {
   return jsonObjectFrom(
     eb
-      .selectFrom('programGrouping as pg')
-      .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.seasonUuid')
+      .selectFrom('programGrouping')
+      .select(fields)
+      .whereRef('programGrouping.uuid', '=', 'program.seasonUuid')
       .where('program.type', '=', ProgramType.Episode)
       .orderBy('uuid'),
   ).as('tvSeason');
 }
 
-export function withTrackArtist(eb: ExpressionBuilder<DB, 'program'>) {
+export function withTrackArtist(
+  eb: ExpressionBuilder<DB, 'program'>,
+  fields: ProgramGroupingFields = AllProgramGroupingFields,
+) {
   return jsonObjectFrom(
     eb
-      .selectFrom('programGrouping as pg')
-      .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.artistUuid')
+      .selectFrom('programGrouping')
+      .select(fields)
+      .whereRef('programGrouping.uuid', '=', 'program.artistUuid')
       .where('program.type', '=', ProgramType.Track)
       .orderBy('uuid'),
   ).as('trackArtist');
 }
 
-export function withTrackAlbum(eb: ExpressionBuilder<DB, 'program'>) {
+export function withTrackAlbum(
+  eb: ExpressionBuilder<DB, 'program'>,
+  fields: ProgramGroupingFields = AllProgramGroupingFields,
+) {
   return jsonObjectFrom(
     eb
-      .selectFrom('programGrouping as pg')
-      .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.albumUuid')
+      .selectFrom('programGrouping')
+      .select(fields)
+      .whereRef('programGrouping.uuid', '=', 'program.albumUuid')
       .where('program.type', '=', ProgramType.Track)
       .orderBy('uuid'),
   ).as('trackAlbum');
@@ -56,11 +97,26 @@ export function withProgramExternalIds(eb: ExpressionBuilder<DB, 'program'>) {
   ).as('externalIds');
 }
 
+export function withProgramCustomShows(eb: ExpressionBuilder<DB, 'program'>) {
+  return jsonArrayFrom(
+    eb
+      .selectFrom('customShowContent')
+      .whereRef('customShowContent.contentUuid', '=', 'program.uuid')
+      .innerJoin(
+        'customShow',
+        'customShowContent.customShowUuid',
+        'customShow.uuid',
+      )
+      .select('customShow.uuid'),
+  ).as('customShows');
+}
+
 type ProgramJoins = {
-  trackAlbum: boolean;
-  trackArtist: boolean;
-  tvShow: boolean;
-  tvSeason: boolean;
+  trackAlbum: boolean | ProgramGroupingFields;
+  trackArtist: boolean | ProgramGroupingFields;
+  tvShow: boolean | ProgramGroupingFields;
+  tvSeason: boolean | ProgramGroupingFields;
+  customShows: boolean;
 };
 
 const defaultProgramJoins: ProgramJoins = {
@@ -68,52 +124,85 @@ const defaultProgramJoins: ProgramJoins = {
   trackArtist: false,
   tvShow: false,
   tvSeason: false,
+  customShows: false,
+};
+
+type ProgramFields = readonly `program.${keyof RawProgram}`[];
+
+const AllProgramFields: ProgramFields = [
+  'program.albumName',
+  'program.albumUuid',
+  'program.artistName',
+  'program.artistUuid',
+  'program.createdAt',
+  'program.duration',
+  'program.episode',
+  'program.episodeIcon',
+  'program.externalKey',
+  'program.externalSourceId',
+  'program.filePath',
+  'program.grandparentExternalKey',
+  'program.icon',
+  'program.originalAirDate',
+  'program.parentExternalKey',
+  'program.plexFilePath',
+  'program.plexRatingKey',
+  'program.rating',
+  'program.seasonIcon',
+  'program.seasonNumber',
+  'program.seasonUuid',
+  'program.showIcon',
+  'program.showTitle',
+  'program.sourceType',
+  'program.summary',
+  'program.title',
+  'program.tvShowUuid',
+  'program.type',
+  'program.updatedAt',
+  'program.uuid',
+  'program.year',
+];
+
+type WithProgramsOptions = {
+  joins?: Partial<ProgramJoins>;
+  fields?: ProgramFields;
+};
+
+const defaultWithProgramOptions: DeepRequired<WithProgramsOptions> = {
+  joins: defaultProgramJoins,
+  fields: AllProgramFields,
 };
 
 export function withPrograms(
-  eb: ExpressionBuilder<DB, 'channelPrograms'>,
-  programJoins: ProgramJoins = defaultProgramJoins,
+  eb: ExpressionBuilder<DB, 'channel' | 'channelPrograms'>,
+  options: WithProgramsOptions = defaultWithProgramOptions,
 ) {
+  const mergedOpts = merge({}, defaultWithProgramOptions, options);
   return jsonArrayFrom(
     eb
       .selectFrom('program')
-      .select([
-        'program.albumName',
-        'program.albumUuid',
-        'program.artistName',
-        'program.artistUuid',
-        'program.createdAt',
-        'program.duration',
-        'program.episode',
-        'program.episodeIcon',
-        'program.externalKey',
-        'program.externalSourceId',
-        'program.filePath',
-        'program.grandparentExternalKey',
-        'program.icon',
-        'program.originalAirDate',
-        'program.parentExternalKey',
-        'program.plexFilePath',
-        'program.plexRatingKey',
-        'program.rating',
-        'program.seasonIcon',
-        'program.seasonNumber',
-        'program.seasonUuid',
-        'program.showIcon',
-        'program.showTitle',
-        'program.sourceType',
-        'program.summary',
-        'program.title',
-        'program.tvShowUuid',
-        'program.type',
-        'program.updatedAt',
-        'program.uuid',
-        'program.year',
-      ])
-      .$if(programJoins.trackAlbum, (qb) => qb.select(withTrackAlbum))
-      .$if(programJoins.trackArtist, (qb) => qb.select(withTrackArtist))
-      .$if(programJoins.tvSeason, (qb) => qb.select(withTvSeason))
-      .$if(programJoins.tvSeason, (qb) => qb.select(withTvShow))
-      .whereRef('program.uuid', '=', 'channelPrograms.programUuid'),
+      .select(mergedOpts.fields)
+      .$if(!!mergedOpts.joins.trackAlbum, (qb) =>
+        qb.select((eb) =>
+          withTrackAlbum(
+            eb,
+            isBoolean(mergedOpts.joins.trackAlbum)
+              ? AllProgramGroupingFields
+              : mergedOpts.joins.trackAlbum,
+          ),
+        ),
+      )
+      .$if(!!mergedOpts.joins.trackArtist, (qb) => qb.select(withTrackArtist))
+      .$if(!!mergedOpts.joins.tvSeason, (qb) => qb.select(withTvSeason))
+      .$if(!!mergedOpts.joins.tvSeason, (qb) => qb.select(withTvShow))
+      .$if(!!mergedOpts.joins.customShows, (qb) =>
+        qb.select(withProgramCustomShows),
+      )
+      .innerJoin('channelPrograms', (join) =>
+        join
+          .onRef('channelPrograms.programUuid', '=', 'program.uuid')
+          .onRef('channel.uuid', '=', 'channelPrograms.channelUuid'),
+      ),
+    // .whereRef('program.uuid', '=', 'channelPrograms.programUuid'),
   ).as('programs');
 }

--- a/server/src/dao/direct/programQueryHelpers.ts
+++ b/server/src/dao/direct/programQueryHelpers.ts
@@ -6,54 +6,54 @@ import { DB } from './types.gen';
 export function withTvShow(eb: ExpressionBuilder<DB, 'program'>) {
   return jsonObjectFrom(
     eb
-      .selectFrom('program_grouping as pg')
+      .selectFrom('programGrouping as pg')
       .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.tv_show_uuid')
+      .whereRef('pg.uuid', '=', 'program.tvShowUuid')
       .where('program.type', '=', ProgramType.Episode)
       .orderBy('uuid'),
-  ).as('tv_show');
+  ).as('tvShow');
 }
 
 export function withTvSeason(eb: ExpressionBuilder<DB, 'program'>) {
   return jsonObjectFrom(
     eb
-      .selectFrom('program_grouping as pg')
+      .selectFrom('programGrouping as pg')
       .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.season_uuid')
+      .whereRef('pg.uuid', '=', 'program.seasonUuid')
       .where('program.type', '=', ProgramType.Episode)
       .orderBy('uuid'),
-  ).as('tv_season');
+  ).as('tvSeason');
 }
 
 export function withTrackArtist(eb: ExpressionBuilder<DB, 'program'>) {
   return jsonObjectFrom(
     eb
-      .selectFrom('program_grouping as pg')
+      .selectFrom('programGrouping as pg')
       .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.artist_uuid')
+      .whereRef('pg.uuid', '=', 'program.artistUuid')
       .where('program.type', '=', ProgramType.Track)
       .orderBy('uuid'),
-  ).as('track_artist');
+  ).as('trackArtist');
 }
 
 export function withTrackAlbum(eb: ExpressionBuilder<DB, 'program'>) {
   return jsonObjectFrom(
     eb
-      .selectFrom('program_grouping as pg')
+      .selectFrom('programGrouping as pg')
       .select(['pg.uuid', 'pg.title', 'pg.year'])
-      .whereRef('pg.uuid', '=', 'program.album_uuid')
+      .whereRef('pg.uuid', '=', 'program.albumUuid')
       .where('program.type', '=', ProgramType.Track)
       .orderBy('uuid'),
-  ).as('track_album');
+  ).as('trackAlbum');
 }
 
 export function withProgramExternalIds(eb: ExpressionBuilder<DB, 'program'>) {
   return jsonArrayFrom(
     eb
-      .selectFrom('program_external_id as eid')
-      .select(['eid.source_type', 'eid.external_source_id', 'eid.external_key'])
-      .whereRef('eid.program_uuid', '=', 'program.uuid'),
-  ).as('external_ids');
+      .selectFrom('programExternalId as eid')
+      .select(['eid.sourceType', 'eid.externalSourceId', 'eid.externalKey'])
+      .whereRef('eid.programUuid', '=', 'program.uuid'),
+  ).as('externalIds');
 }
 
 type ProgramJoins = {
@@ -71,42 +71,42 @@ const defaultProgramJoins: ProgramJoins = {
 };
 
 export function withPrograms(
-  eb: ExpressionBuilder<DB, 'channel_programs'>,
+  eb: ExpressionBuilder<DB, 'channelPrograms'>,
   programJoins: ProgramJoins = defaultProgramJoins,
 ) {
   return jsonArrayFrom(
     eb
       .selectFrom('program')
       .select([
-        'program.album_name',
-        'program.album_uuid',
-        'program.artist_name',
-        'program.artist_uuid',
-        'program.created_at',
+        'program.albumName',
+        'program.albumUuid',
+        'program.artistName',
+        'program.artistUuid',
+        'program.createdAt',
         'program.duration',
         'program.episode',
-        'program.episode_icon',
-        'program.external_key',
-        'program.external_source_id',
-        'program.file_path',
-        'program.grandparent_external_key',
+        'program.episodeIcon',
+        'program.externalKey',
+        'program.externalSourceId',
+        'program.filePath',
+        'program.grandparentExternalKey',
         'program.icon',
-        'program.original_air_date',
-        'program.parent_external_key',
-        'program.plex_file_path',
-        'program.plex_rating_key',
+        'program.originalAirDate',
+        'program.parentExternalKey',
+        'program.plexFilePath',
+        'program.plexRatingKey',
         'program.rating',
-        'program.season_icon',
-        'program.season_number',
-        'program.season_uuid',
-        'program.show_icon',
-        'program.show_title',
-        'program.source_type',
+        'program.seasonIcon',
+        'program.seasonNumber',
+        'program.seasonUuid',
+        'program.showIcon',
+        'program.showTitle',
+        'program.sourceType',
         'program.summary',
         'program.title',
-        'program.tv_show_uuid',
+        'program.tvShowUuid',
         'program.type',
-        'program.updated_at',
+        'program.updatedAt',
         'program.uuid',
         'program.year',
       ])
@@ -114,6 +114,6 @@ export function withPrograms(
       .$if(programJoins.trackArtist, (qb) => qb.select(withTrackArtist))
       .$if(programJoins.tvSeason, (qb) => qb.select(withTvSeason))
       .$if(programJoins.tvSeason, (qb) => qb.select(withTvShow))
-      .whereRef('program.uuid', '=', 'channel_programs.program_uuid'),
+      .whereRef('program.uuid', '=', 'channelPrograms.programUuid'),
   ).as('programs');
 }

--- a/server/src/dao/direct/types.gen.d.ts
+++ b/server/src/dao/direct/types.gen.d.ts
@@ -6,183 +6,183 @@ export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
 
 export interface CachedImage {
   hash: string;
-  mime_type: string | null;
+  mimeType: string | null;
   url: string;
 }
 
 export interface Channel {
-  created_at: string | null;
-  disable_filler_overlay: Generated<number>;
+  createdAt: string | null;
+  disableFillerOverlay: Generated<number>;
   duration: number;
-  filler_repeat_cooldown: number | null;
-  group_title: string | null;
-  guide_flex_title: string | null;
-  guide_minimum_duration: number;
+  fillerRepeatCooldown: number | null;
+  groupTitle: string | null;
+  guideFlexTitle: string | null;
+  guideMinimumDuration: number;
   icon: string | null;
   name: string;
   number: number;
   offline: Generated<string | null>;
-  start_time: number;
+  startTime: number;
   stealth: Generated<number>;
   transcoding: string | null;
-  updated_at: string | null;
+  updatedAt: string | null;
   uuid: string;
   watermark: string | null;
 }
 
 export interface ChannelCustomShows {
-  channel_uuid: string;
-  custom_show_uuid: string;
+  channelUuid: string;
+  customShowUuid: string;
 }
 
 export interface ChannelFallback {
-  channel_uuid: string;
-  program_uuid: string;
+  channelUuid: string;
+  programUuid: string;
 }
 
 export interface ChannelFillerShow {
-  channel_uuid: string;
+  channelUuid: string;
   cooldown: number;
-  filler_show_uuid: string;
+  fillerShowUuid: string;
   weight: number;
 }
 
 export interface ChannelPrograms {
-  channel_uuid: string;
-  program_uuid: string;
+  channelUuid: string;
+  programUuid: string;
 }
 
 export interface CustomShow {
-  created_at: string | null;
+  createdAt: string | null;
   name: string;
-  updated_at: string | null;
+  updatedAt: string | null;
   uuid: string;
 }
 
 export interface CustomShowContent {
-  content_uuid: string;
-  custom_show_uuid: string;
+  contentUuid: string;
+  customShowUuid: string;
   index: number;
 }
 
 export interface FillerShow {
-  created_at: string | null;
+  createdAt: string | null;
   name: string;
-  updated_at: string | null;
+  updatedAt: string | null;
   uuid: string;
 }
 
 export interface FillerShowContent {
-  filler_show_uuid: string;
+  fillerShowUuid: string;
   index: number;
-  program_uuid: string;
+  programUuid: string;
 }
 
 export interface MikroOrmMigrations {
-  executed_at: Generated<string | null>;
+  executedAt: Generated<string | null>;
   id: Generated<number>;
   name: string | null;
 }
 
 export interface PlexServerSettings {
-  access_token: string;
-  client_identifier: string | null;
-  created_at: string | null;
+  accessToken: string;
+  clientIdentifier: string | null;
+  createdAt: string | null;
   index: number;
   name: string;
-  send_channel_updates: Generated<number>;
-  send_guide_updates: Generated<number>;
-  updated_at: string | null;
+  sendChannelUpdates: Generated<number>;
+  sendGuideUpdates: Generated<number>;
+  updatedAt: string | null;
   uri: string;
   uuid: string;
 }
 
 export interface Program {
-  album_name: string | null;
-  album_uuid: string | null;
-  artist_name: string | null;
-  artist_uuid: string | null;
-  created_at: string | null;
+  albumName: string | null;
+  albumUuid: string | null;
+  artistName: string | null;
+  artistUuid: string | null;
+  createdAt: string | null;
   duration: number;
   episode: number | null;
-  episode_icon: string | null;
-  external_key: string;
-  external_source_id: string;
-  file_path: string | null;
-  grandparent_external_key: string | null;
+  episodeIcon: string | null;
+  externalKey: string;
+  externalSourceId: string;
+  filePath: string | null;
+  grandparentExternalKey: string | null;
   icon: string | null;
-  original_air_date: string | null;
-  parent_external_key: string | null;
-  plex_file_path: string | null;
-  plex_rating_key: string | null;
+  originalAirDate: string | null;
+  parentExternalKey: string | null;
+  plexFilePath: string | null;
+  plexRatingKey: string | null;
   rating: string | null;
-  season_icon: string | null;
-  season_number: number | null;
-  season_uuid: string | null;
-  show_icon: string | null;
-  show_title: string | null;
-  source_type: string;
+  seasonIcon: string | null;
+  seasonNumber: number | null;
+  seasonUuid: string | null;
+  showIcon: string | null;
+  showTitle: string | null;
+  sourceType: string;
   summary: string | null;
   title: string;
-  tv_show_uuid: string | null;
+  tvShowUuid: string | null;
   type: string;
-  updated_at: string | null;
+  updatedAt: string | null;
   uuid: string;
   year: number | null;
 }
 
 export interface ProgramExternalId {
-  created_at: string | null;
-  direct_file_path: string | null;
-  external_file_path: string | null;
-  external_key: string;
-  external_source_id: string | null;
-  program_uuid: string;
-  source_type: string;
-  updated_at: string | null;
+  createdAt: string | null;
+  directFilePath: string | null;
+  externalFilePath: string | null;
+  externalKey: string;
+  externalSourceId: string | null;
+  programUuid: string;
+  sourceType: string;
+  updatedAt: string | null;
   uuid: string;
 }
 
 export interface ProgramGrouping {
-  artist_uuid: string | null;
-  created_at: string | null;
+  artistUuid: string | null;
+  createdAt: string | null;
   icon: string | null;
   index: number | null;
-  show_uuid: string | null;
+  showUuid: string | null;
   summary: string | null;
   title: string;
   type: string;
-  updated_at: string | null;
+  updatedAt: string | null;
   uuid: string;
   year: number | null;
 }
 
 export interface ProgramGroupingExternalId {
-  created_at: string | null;
-  external_file_path: string | null;
-  external_key: string;
-  external_source_id: string;
-  group_uuid: string;
-  source_type: string;
-  updated_at: string | null;
+  createdAt: string | null;
+  externalFilePath: string | null;
+  externalKey: string;
+  externalSourceId: string | null;
+  groupUuid: string;
+  sourceType: string;
+  updatedAt: string | null;
   uuid: string;
 }
 
 export interface DB {
-  cached_image: CachedImage;
+  cachedImage: CachedImage;
   channel: Channel;
-  channel_custom_shows: ChannelCustomShows;
-  channel_fallback: ChannelFallback;
-  channel_filler_show: ChannelFillerShow;
-  channel_programs: ChannelPrograms;
-  custom_show: CustomShow;
-  custom_show_content: CustomShowContent;
-  filler_show: FillerShow;
-  filler_show_content: FillerShowContent;
-  mikro_orm_migrations: MikroOrmMigrations;
-  plex_server_settings: PlexServerSettings;
+  channelCustomShows: ChannelCustomShows;
+  channelFallback: ChannelFallback;
+  channelFillerShow: ChannelFillerShow;
+  channelPrograms: ChannelPrograms;
+  customShow: CustomShow;
+  customShowContent: CustomShowContent;
+  fillerShow: FillerShow;
+  fillerShowContent: FillerShowContent;
+  mikroOrmMigrations: MikroOrmMigrations;
+  plexServerSettings: PlexServerSettings;
   program: Program;
-  program_external_id: ProgramExternalId;
-  program_grouping: ProgramGrouping;
-  program_grouping_external_id: ProgramGroupingExternalId;
+  programExternalId: ProgramExternalId;
+  programGrouping: ProgramGrouping;
+  programGroupingExternalId: ProgramGroupingExternalId;
 }

--- a/server/src/dao/entities/Channel.ts
+++ b/server/src/dao/entities/Channel.ts
@@ -41,7 +41,7 @@ const ChannelIconSchema = z
 
 const DefaultChannelIcon = ChannelIconSchema.parse({});
 
-type ChannelIcon = z.infer<typeof ChannelIconSchema>;
+export type ChannelIcon = z.infer<typeof ChannelIconSchema>;
 
 class ChannelIconType extends SchemaBackedDbType<typeof ChannelIconSchema> {
   constructor() {
@@ -86,7 +86,7 @@ const ChannelWatermarkSchema = z.object({
   animated: z.boolean().optional().catch(undefined),
 });
 
-type ChannelWatermark = z.infer<typeof ChannelWatermarkSchema>;
+export type ChannelWatermark = z.infer<typeof ChannelWatermarkSchema>;
 
 class ChannelWatermarkType extends SchemaBackedDbType<
   typeof ChannelWatermarkSchema
@@ -106,7 +106,9 @@ const DefaultChannelOfflineSettingsSchema = ChannelOfflineSettingsSchema.parse(
   {},
 );
 
-type ChannelOfflineSettings = z.infer<typeof ChannelOfflineSettingsSchema>;
+export type ChannelOfflineSettings = z.infer<
+  typeof ChannelOfflineSettingsSchema
+>;
 
 class ChannelOfflineSettingsType extends SchemaBackedDbType<
   typeof ChannelOfflineSettingsSchema

--- a/server/src/services/dynamic_channels/ReleaseDateSortOperator.ts
+++ b/server/src/services/dynamic_channels/ReleaseDateSortOperator.ts
@@ -22,8 +22,8 @@ export class ReleaseDateSortOperator extends SchedulingOperator<ReleaseDateSortO
           return Number.MAX_SAFE_INTEGER;
         }
 
-        const date = details.original_air_date
-          ? new Date(details.original_air_date).getTime()
+        const date = details.originalAirDate
+          ? new Date(details.originalAirDate).getTime()
           : 0;
         return date;
       },
@@ -34,8 +34,8 @@ export class ReleaseDateSortOperator extends SchedulingOperator<ReleaseDateSortO
         }
 
         let n = 1;
-        if (!isNull(details.season_number)) {
-          n *= details.season_number * 1e4;
+        if (!isNull(details.seasonNumber)) {
+          n *= details.seasonNumber * 1e4;
         }
 
         if (!isNull(details.episode)) {

--- a/server/src/services/tvGuideService.ts
+++ b/server/src/services/tvGuideService.ts
@@ -1,4 +1,3 @@
-import { Loaded } from '@mikro-orm/core';
 import constants from '@tunarr/shared/constants';
 import {
   ChannelIcon,
@@ -33,7 +32,6 @@ import { XmlTvWriter } from '../XmlTvWriter.js';
 import { ChannelDB } from '../dao/channelDb.js';
 import { ProgramConverter } from '../dao/converters/programConverters.js';
 import { Lineup } from '../dao/derived_types/Lineup.js';
-import { Channel } from '../dao/entities/Channel.js';
 import { Maybe } from '../types/util.js';
 import { binarySearchRange } from '../util/binarySearch.js';
 import {
@@ -44,7 +42,7 @@ import {
 } from '../util/index.js';
 import { LoggerFactory } from '../util/logging/LoggerFactory.js';
 import { EventService } from './eventService.js';
-import { Channel as RawChannel } from '../dao/direct/derivedTypes.js';
+import { ChannelWithPrograms as RawChannel } from '../dao/direct/derivedTypes.js';
 
 dayjs.extend(duration);
 
@@ -66,7 +64,7 @@ export type TvGuideChannel = {
 };
 
 export type ChannelPrograms = {
-  channel: Channel;
+  channel: RawChannel;
   programs: TvGuideProgram[];
 };
 
@@ -220,13 +218,28 @@ export class TVGuideService {
   // If we updated channel metadata, we should push it to this cache
   // and rewrite xmltv. This should be very fast since we're not altering
   // programming details or the schedule
-  async updateCachedChannel(updatedChannel: Loaded<Channel>) {
-    const cachedLineup = this.cachedGuide[updatedChannel.uuid];
+  async updateCachedChannel(updatedChannelId: string) {
+    const channel = await this.channelDb.getChannelDirect(updatedChannelId);
+    if (isNil(channel)) {
+      this.logger.warn(
+        'Could not find channel with id %s when attempting to update cached XMLTV channels',
+        updatedChannelId,
+      );
+      return;
+    }
+
+    const cachedLineup = this.cachedGuide[channel.uuid];
     if (isUndefined(cachedLineup)) {
       return;
     }
 
-    this.cachedGuide[updatedChannel.uuid].channel = updatedChannel;
+    const existingChannel = this.cachedGuide[channel.uuid].channel;
+    // Keep the refs to the existing programs since they didn't change
+    // as part of this operation.
+    this.cachedGuide[channel.uuid].channel = {
+      ...channel,
+      programs: existingChannel.programs,
+    };
 
     return await this.refreshXML();
   }
@@ -240,10 +253,10 @@ export class TVGuideService {
     );
   }
 
-  private async getCurrentPlayingIndex(
+  private getCurrentPlayingIndex(
     { channel, lineup }: ChannelWithLineup,
     currentUpdateTimeMs: number,
-  ): Promise<CurrentPlayingProgram> {
+  ): CurrentPlayingProgram {
     const channelStartTime = new Date(channel.startTime).getTime();
     if (currentUpdateTimeMs < channelStartTime) {
       //it's flex time
@@ -291,7 +304,6 @@ export class TVGuideService {
         !inRange(targetIndex, 0, accumulate.length) ||
         !inRange(targetIndex, 0, lineup.items.length)
       ) {
-        console.log(accumulate, channelProgress);
         throw new Error(
           `General algorithm error, completely unexpected. Channel: ${channel.uuid} ${channel.name}`,
         );
@@ -299,7 +311,7 @@ export class TVGuideService {
 
       const lineupItem = lineup.items[targetIndex];
       let lineupProgram =
-        await this.programConverter.lineupItemToChannelProgram(
+        this.programConverter.directLineupItemToChannelProgram(
           channel,
           lineupItem,
           map(this.currentChannels, 'channel'),
@@ -348,7 +360,7 @@ export class TVGuideService {
       // the schedule.
       const index = (previousProgram.programIndex + 1) % lineup.items.length;
       const lineupItem = lineup.items[index];
-      const program = await this.programConverter.lineupItemToChannelProgram(
+      const program = this.programConverter.directLineupItemToChannelProgram(
         channel,
         lineupItem,
         map(this.currentChannels, 'channel'),
@@ -371,7 +383,7 @@ export class TVGuideService {
         startTimeMs: currentUpdateTimeMs,
       };
     } else {
-      playing = await this.getCurrentPlayingIndex(
+      playing = this.getCurrentPlayingIndex(
         channelWithLineup,
         currentUpdateTimeMs,
       );
@@ -685,25 +697,34 @@ export class TVGuideService {
     const result: Record<string, ChannelPrograms> = {};
     if (channels.length === 0) {
       const fakeChannelId = v4();
-      const channel = new Channel();
-      channel.uuid = fakeChannelId;
-      channel.name = 'Tunarr';
-      channel.icon = {
-        path: FALLBACK_ICON,
-        width: 0,
+      const channel: RawChannel = {
+        uuid: fakeChannelId,
+        name: 'Tunarr',
+        icon: {
+          path: FALLBACK_ICON,
+          width: 0,
+          duration: 0,
+          position: 'bottom-right',
+        },
+        disableFillerOverlay: 0, //false, cast?
+        number: 0,
+        guideMinimumDuration: 0,
         duration: 0,
-        position: 'bottom-right',
-      };
-      channel.disableFillerOverlay = false;
-      channel.number = 0;
-      channel.guideMinimumDuration = 0;
-      channel.duration = 0;
-      channel.stealth = false;
-      channel.startTime = 0;
-      channel.offline = {
-        picture: undefined,
-        soundtrack: undefined,
-        mode: 'pic',
+        stealth: 0, //false, cast?
+        startTime: 0,
+        offline: {
+          picture: undefined,
+          soundtrack: undefined,
+          mode: 'pic',
+        },
+        guideFlexTitle: null,
+        createdAt: null,
+        updatedAt: null,
+        fillerRepeatCooldown: null,
+        groupTitle: null,
+        watermark: null,
+        transcoding: null,
+        programs: [],
       };
 
       // Placeholder channel with random ID.
@@ -787,7 +808,7 @@ export class TVGuideService {
 
 function isProgramFlex(
   program: ChannelProgram | undefined,
-  channel: Loaded<Channel>,
+  channel: RawChannel,
 ): boolean {
   return (
     !isUndefined(program) &&
@@ -799,7 +820,7 @@ function isProgramFlex(
 }
 
 function programToTvGuideProgram(
-  channel: Loaded<Channel>,
+  channel: RawChannel,
   currentProgram: CurrentPlayingProgram,
 ): TvGuideProgram {
   const baseItem: Partial<TvGuideProgram> = {

--- a/server/src/services/tvGuideService.ts
+++ b/server/src/services/tvGuideService.ts
@@ -30,7 +30,7 @@ import {
 import * as syncRetry from 'retry';
 import { v4 } from 'uuid';
 import { XmlTvWriter } from '../XmlTvWriter.js';
-import { ChannelDB, LoadedChannelWithGroupRefs } from '../dao/channelDb.js';
+import { ChannelDB } from '../dao/channelDb.js';
 import { ProgramConverter } from '../dao/converters/programConverters.js';
 import { Lineup } from '../dao/derived_types/Lineup.js';
 import { Channel } from '../dao/entities/Channel.js';
@@ -44,6 +44,7 @@ import {
 } from '../util/index.js';
 import { LoggerFactory } from '../util/logging/LoggerFactory.js';
 import { EventService } from './eventService.js';
+import { Channel as RawChannel } from '../dao/direct/derivedTypes.js';
 
 dayjs.extend(duration);
 
@@ -70,7 +71,7 @@ export type ChannelPrograms = {
 };
 
 type ChannelWithLineup = {
-  channel: LoadedChannelWithGroupRefs;
+  channel: RawChannel;
   lineup: Lineup;
 };
 

--- a/server/src/stream/StreamProgramCalculator.ts
+++ b/server/src/stream/StreamProgramCalculator.ts
@@ -44,13 +44,20 @@ export function generateChannelContext(
   );
 }
 
+// Taking advantage of structural typing for transition
+// to Kysely querying...
+type MinimalChannelDetails = {
+  startTime: number;
+  duration: number;
+};
+
 export class StreamProgramCalculator {
   private logger = LoggerFactory.child({ caller: import.meta });
 
   // This code is almost identical to TvGuideService#getCurrentPlayingIndex
   async getCurrentProgramAndTimeElapsed(
     timestamp: number,
-    channel: Loaded<Channel>,
+    channel: MinimalChannelDetails,
     channelLineup: Lineup,
   ): Promise<ProgramAndTimeElapsed> {
     if (channel.startTime > timestamp) {


### PR DESCRIPTION
Huge channels were slowing the `UpdateXmlTvTask` significantly. A single channel with 4k+ items would cause the task to take upwards of 8 seconds to run. Investigation found that most of this time was spent collecting all of the channels and their programs + associated metadata. Rewriting the query to use Kysely brought my 8s UpdateXmlTvTask executions down to ~300ms.