### PR TITLE
fix: ambiguous column error when selecting all filler shows

### DIFF
--- a/server/src/dao/fillerDb.ts
+++ b/server/src/dao/fillerDb.ts
@@ -182,12 +182,17 @@ export class FillerDB {
         jsonArrayFrom(
           eb
             .selectFrom('fillerShowContent')
-            .select('programUuid as uuid')
+            .whereRef(
+              'fillerShowContent.fillerShowUuid',
+              '=',
+              'fillerShow.uuid',
+            )
             .leftJoin(
-              'fillerShowContent',
+              'fillerShow',
               'fillerShowContent.fillerShowUuid',
               'fillerShow.uuid',
-            ),
+            )
+            .select('fillerShowContent.programUuid'),
         ).as('content'),
       )
       .execute();


### PR DESCRIPTION
join statement was in the wrong order

Fixes #634
