### PR TITLE
feat!: use OS-specific, stable path for default Tunarr data directory

### DIFF
--- a/server/src/api/systemSettingsApi.ts
+++ b/server/src/api/systemSettingsApi.ts
@@ -10,10 +10,8 @@ import { isUndefined } from 'lodash-es';
 import { DeepReadonly, Writable } from 'ts-essentials';
 import { scheduleBackupJobs } from '../services/scheduler';
 import { RouterPluginAsyncCallback } from '../types/serverType';
-import {
-  getDefaultLogLevel,
-  getEnvironmentLogLevel,
-} from '../util/logging/LoggerFactory';
+import { getEnvironmentLogLevel } from '../util/logging/LoggerFactory';
+import { getDefaultLogLevel } from '../util/defaults';
 import { ifDefined } from '../util/index.js';
 
 export const systemSettingsRouter: RouterPluginAsyncCallback = async (

--- a/server/src/dao/settings.ts
+++ b/server/src/dao/settings.ts
@@ -28,13 +28,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { globalOptions } from '../globals.js';
 import { TypedEventEmitter } from '../types/eventEmitter.js';
-import { isProduction } from '../util/index.js';
 import {
-  Logger,
-  LoggerFactory,
   getDefaultLogDirectory,
   getDefaultLogLevel,
-} from '../util/logging/LoggerFactory.js';
+} from '../util/defaults.js';
+import { isProduction } from '../util/index.js';
+import { Logger, LoggerFactory } from '../util/logging/LoggerFactory.js';
 import { SchemaBackedDbAdapter } from './SchemaBackedDbAdapter.js';
 import { SyncSchemaBackedDbAdapter } from './SyncSchemaBackedDbAdapter.js';
 

--- a/server/src/util/defaults.ts
+++ b/server/src/util/defaults.ts
@@ -1,11 +1,12 @@
 import { LogConfigEnvVars } from './logging/LoggerFactory';
-import { isUndefined } from 'lodash-es';
+import { isNull, isUndefined } from 'lodash-es';
 import { Nullable } from '../types/util.js';
 import { DATABASE_LOCATION_ENV_VAR, SERVER_PORT_ENV_VAR } from './constants.js';
 import { isNonEmptyString, isProduction } from './index.js';
 import { isDocker } from './isDocker.js';
 import { LogLevels, getEnvironmentLogLevel } from './logging/LoggerFactory';
 import constants from '@tunarr/shared/constants';
+import path from 'node:path';
 
 function getRuntimeSpecificPrefix() {
   let prefix: Nullable<string> = null;
@@ -28,7 +29,7 @@ export function getDefaultLogDirectory(): string {
     return env;
   }
 
-  return `${getRuntimeSpecificPrefix() ?? ''}/tunarr/logs`;
+  return path.join(getRuntimeSpecificPrefix() ?? '', 'tunarr', 'logs');
 }
 
 export function getDefaultLogLevel(useEnvVar: boolean = true): LogLevels {
@@ -48,9 +49,13 @@ export function getDefaultDatabaseDirectory(): string {
     return env;
   }
 
-  return `${getDefaultDatabaseDirectory() ?? process.cwd()}/${
-    constants.DEFAULT_DATA_DIR
-  }`;
+  const prefix = getRuntimeSpecificPrefix();
+
+  if (!isNull(prefix)) {
+    return path.join(prefix, 'tunarr');
+  }
+
+  return path.join(process.cwd(), constants.DEFAULT_DATA_DIR);
 }
 
 export function getDefaultServerPort() {

--- a/server/src/util/fsUtil.ts
+++ b/server/src/util/fsUtil.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import { isNodeError } from './index.js';
+import path from 'node:path';
 
 export async function fileExists(path: string) {
   try {
@@ -12,5 +13,20 @@ export async function fileExists(path: string) {
 
     // Re-throw any other error type
     throw e;
+  }
+}
+
+export async function copyDirectoryContents(src: string, dest: string) {
+  await fs.mkdir(dest, { recursive: true });
+  const files = await fs.readdir(src);
+  for (const file of files) {
+    const srcPath = path.join(src, file);
+    const destPath = path.join(dest, file);
+    const stat = await fs.stat(srcPath);
+    if (stat.isDirectory()) {
+      await copyDirectoryContents(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
   }
 }

--- a/server/src/util/logging/LoggerFactory.ts
+++ b/server/src/util/logging/LoggerFactory.ts
@@ -15,7 +15,7 @@ import type ThreadStream from 'thread-stream';
 import { isNonEmptyString, isProduction } from '..';
 import { SettingsDB, getSettings } from '../../dao/settings';
 import { Maybe, TupleToUnion } from '../../types/util';
-import { isDocker } from '../isDocker';
+import { getDefaultLogLevel } from '../defaults';
 
 export const LogConfigEnvVars = {
   level: 'LOG_LEVEL',
@@ -35,40 +35,6 @@ export function getEnvironmentLogLevel(): Maybe<LogLevels> {
     }
   }
   return;
-}
-
-export function getDefaultLogLevel(useEnvVar: boolean = true): LogLevels {
-  if (useEnvVar) {
-    const level = getEnvironmentLogLevel();
-    if (!isUndefined(level)) {
-      return level;
-    }
-  }
-
-  return isProduction ? 'info' : 'debug';
-}
-
-export function getDefaultLogDirectory(): string {
-  const env = process.env[LogConfigEnvVars.directory];
-  if (isNonEmptyString(env)) {
-    return env;
-  }
-
-  // Making a lot of assumptions here...
-  if (isDocker()) {
-    return '/config/tunarr/logs';
-  }
-
-  let prefix = '';
-  if (process.env.APPDATA) {
-    prefix = `${process.env.APPDATA}`;
-  } else if (process.platform === 'darwin') {
-    prefix = `${process.env.HOME}/Library/Preferences`;
-  } else {
-    prefix = `${process.env.HOME}/.local/share`;
-  }
-
-  return `${prefix}/tunarr/logs`;
 }
 
 const ExtraLogLevels = ['http'] as const;
@@ -287,3 +253,5 @@ const getCaller = (callingModule: ImportMeta) => {
 };
 
 export const LoggerFactory = new LoggerFactoryImpl();
+
+export const RootLogger = LoggerFactory.root;


### PR DESCRIPTION
This change uses the same logic as the default log directory to determine where to create the Tunarr directory:

* if in a Docker container: /config/tunarr
* if Windows, the APPDATA env var is used
* if macOS, ~/Library/Preferences
* if *nix, ~/.local/share

The change also attempts to look for a previous Tunarr database at the "old" location and copies its contents to the new location.

Closes #620