### PR TITLE
feat: support for intermittent watermarks

### DIFF
--- a/server/src/dao/entities/Channel.ts
+++ b/server/src/dao/entities/Channel.ts
@@ -7,6 +7,7 @@ import {
   Unique,
 } from '@mikro-orm/core';
 import { Channel as ChannelDTO } from '@tunarr/types';
+import { ContentProgramTypeSchema } from '@tunarr/types/schemas';
 import { type Tag } from '@tunarr/types';
 import { BaseEntity } from './BaseEntity.js';
 import { ChannelFillerShow } from './ChannelFillerShow.js';
@@ -84,6 +85,17 @@ const ChannelWatermarkSchema = z.object({
   fixedSize: z.boolean().optional().catch(undefined),
   animated: z.boolean().optional().catch(undefined),
   opacity: z.number().min(0).max(100).int().optional().catch(100).default(100),
+  fadeConfig: z
+    .array(
+      z.object({
+        programType: ContentProgramTypeSchema.optional().catch(undefined),
+        // Encodes on/off period of displaying the watermark in mins.
+        // e.g. a 5m period fades in the watermark every 5th min and displays it
+        // for 5 mins.
+        periodMins: z.number().positive().min(1),
+      }),
+    )
+    .optional(),
 });
 
 export type ChannelWatermark = z.infer<typeof ChannelWatermarkSchema>;

--- a/server/src/stream/ProgramPlayer.ts
+++ b/server/src/stream/ProgramPlayer.ts
@@ -172,6 +172,8 @@ export class ProgramPlayer extends Player {
       return;
     }
 
+    console.log(channel, channel.watermark);
+
     if (!isUndefined(channel.watermark) && channel.watermark.enabled) {
       const watermark = { ...channel.watermark };
       let icon: string;
@@ -183,6 +185,7 @@ export class ProgramPlayer extends Player {
         icon = `http://localhost:${serverOptions().port}/images/tunarr.png`;
       }
 
+      console.log(watermark);
       return {
         ...watermark,
         enabled: true,

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -1,6 +1,9 @@
 import z, { ZodTypeAny } from 'zod';
 import { ResolutionSchema } from './miscSchemas.js';
-import { ProgramSchema } from './programmingSchema.js';
+import {
+  ContentProgramTypeSchema,
+  ProgramSchema,
+} from './programmingSchema.js';
 import { ChannelIconSchema } from './utilSchemas.js';
 
 export const WatermarkSchema = z.object({
@@ -21,6 +24,17 @@ export const WatermarkSchema = z.object({
   fixedSize: z.boolean().optional(),
   animated: z.boolean().optional(),
   opacity: z.number().min(0).max(100).int().optional().catch(100).default(100),
+  fadeConfig: z
+    .array(
+      z.object({
+        programType: ContentProgramTypeSchema.optional().catch(undefined),
+        // Encodes on/off period of displaying the watermark in mins.
+        // e.g. a 5m period fades in the watermark every 5th min and displays it
+        // for 5 mins.
+        periodMins: z.number().positive().min(1),
+      }),
+    )
+    .optional(),
 });
 
 export const FillerCollectionSchema = z.object({

--- a/types/src/schemas/programmingSchema.ts
+++ b/types/src/schemas/programmingSchema.ts
@@ -93,6 +93,12 @@ export const CondensedContentProgramSchema = BaseProgramSchema.extend({
     .optional(),
 });
 
+export const ContentProgramTypeSchema = z.union([
+  z.literal('movie'),
+  z.literal('episode'),
+  z.literal('track'),
+]);
+
 // Unfortunately we can't make this a discrim union, or even a regular union,
 // because it is used in other discriminatedUnions and zod cannot handle this
 // See:
@@ -100,11 +106,7 @@ export const CondensedContentProgramSchema = BaseProgramSchema.extend({
 // https://github.com/colinhacks/zod/issues/1884
 // This stuff makes me wanna just redefine all of this...
 export const ContentProgramSchema = CondensedContentProgramSchema.extend({
-  subtype: z.union([
-    z.literal('movie'),
-    z.literal('episode'),
-    z.literal('track'),
-  ]),
+  subtype: ContentProgramTypeSchema,
   summary: z.string().optional(),
   date: z.string().optional(),
   rating: z.string().optional(),

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -109,7 +109,6 @@ export default function ChannelTranscodingConfig() {
     return value.toString();
   });
 
-  console.log(getValues('watermark.opacity'));
   const [opacity, setOpacity] = useState(getValues('watermark.opacity'));
 
   if (ffmpegSettingsLoading) {
@@ -238,6 +237,7 @@ export default function ChannelTranscodingConfig() {
                 container
                 rowSpacing={1}
                 columnSpacing={2}
+                rowGap={1}
                 sx={{ flexGrow: 1, height: 'fit-content' }}
               >
                 <Grid2 xs={12}>
@@ -251,18 +251,18 @@ export default function ChannelTranscodingConfig() {
                         label="Watermark Picture URL"
                         onFormValueChange={(newPath) => field.onChange(newPath)}
                         onUploadError={console.error}
-                        FormControlProps={{ fullWidth: true, sx: { mb: 1 } }}
+                        FormControlProps={{ fullWidth: true }}
                         value={field.value ?? ''}
                       >
                         <FormHelperText>
-                          If blank, the channel icon will be used
+                          Leave blank to use the channel's icon.
                         </FormHelperText>
                       </ImageUploadInput>
                     )}
                   />
                 </Grid2>
                 <Grid2 xs={12}>
-                  <FormControl fullWidth sx={{ mb: 1 }}>
+                  <FormControl fullWidth>
                     <InputLabel>Position</InputLabel>
                     <Controller
                       name="watermark.position"
@@ -342,7 +342,7 @@ export default function ChannelTranscodingConfig() {
                 <Grid2 xs={12}>
                   <Divider />
                 </Grid2>
-                <Grid2>
+                <Grid2 xs={12} lg={6}>
                   <FormControl fullWidth>
                     <FormControlLabel
                       control={
@@ -354,13 +354,13 @@ export default function ChannelTranscodingConfig() {
                       label="Disable Image Scaling"
                     />
                     <FormHelperText>
-                      The image will be rendered at its actual size without
-                      applying any scaling to it.
+                      The image will be rendered at its actual size without any
+                      scaling applied.
                     </FormHelperText>
                   </FormControl>
                 </Grid2>
-                <Grid2>
-                  <FormControl fullWidth sx={{ mb: 1 }}>
+                <Grid2 xs={12} lg={6}>
+                  <FormControl fullWidth>
                     <FormControlLabel
                       control={
                         <CheckboxFormController
@@ -372,13 +372,13 @@ export default function ChannelTranscodingConfig() {
                     />
                     <FormHelperText>
                       Enable if the watermark is an animated GIF or PNG. The
-                      watermark will loop or not loop according to the image's
-                      configuration. If this option is enable and the image is
+                      watermark will loop according to the image's
+                      configuration. If this option is enabled and the image is
                       not animated, there will be playback errors.
                     </FormHelperText>
                   </FormControl>
                 </Grid2>
-                <Grid2 xs={12}>
+                <Grid2 xs={12} lg={6}>
                   <NumericFormControllerText
                     control={control}
                     name="watermark.duration"
@@ -386,7 +386,21 @@ export default function ChannelTranscodingConfig() {
                     TextFieldProps={{
                       label: 'Overlay Duration (seconds)',
                       fullWidth: true,
-                      helperText: 'Set to 0 to make the overlay permanent',
+                      helperText:
+                        "Sets the absolute duration of the watermark on the channel's stream. Set to 0 to make the overlay permantently visible.",
+                    }}
+                  />
+                </Grid2>
+                <Grid2 xs={12} lg={6}>
+                  <NumericFormControllerText
+                    control={control}
+                    name="watermark.fadeConfig.0.periodMins"
+                    rules={{ min: 0 }}
+                    TextFieldProps={{
+                      label: 'Overlay Period (mins)',
+                      fullWidth: true,
+                      helperText:
+                        'Display/hide the watermark via a fade animation every N minutes. Set to 0 to disable.',
                     }}
                   />
                 </Grid2>

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -7,7 +7,7 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import { useNavigate } from '@tanstack/react-router';
 import { Channel, SaveChannelRequest } from '@tunarr/types';
-import { keys, some } from 'lodash-es';
+import { isEmpty, keys, reject, some } from 'lodash-es';
 import { useState } from 'react';
 import {
   FormProvider,
@@ -101,6 +101,11 @@ export function EditChannelForm({
   const formIsDirty = formMethods.formState.isDirty;
 
   const onSubmit: SubmitHandler<SaveChannelRequest> = (data) => {
+    const fadeConfigs = reject(
+      data.watermark?.fadeConfig,
+      (conf) => conf.periodMins <= 0,
+    );
+
     const dataTransform: SaveChannelRequest = {
       ...data,
       // Transform this to milliseconds before we send it over
@@ -112,6 +117,12 @@ export function EditChannelForm({
         ? data.guideFlexTitle
         : undefined,
       fillerCollections: data.fillerCollections,
+      watermark: data.watermark
+        ? {
+            ...data.watermark,
+            fadeConfig: isEmpty(fadeConfigs) ? undefined : fadeConfigs,
+          }
+        : undefined,
     };
 
     updateChannelMutation.mutate(dataTransform);


### PR DESCRIPTION
This commit adds basic support for intermittent watermarks. Watermarks
for channels can be configured to fade in/out periodically.

Watermark fade configs will eventually support additional options, such
as disabling watermark for certain types of content.

Closes #492
