### PR TITLE
fix: macos entrypoint script can be executed anywhere

### DIFF
--- a/server/scripts/macos-entrypoint.sh
+++ b/server/scripts/macos-entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-exec ./bin/node ./bundle.js
+SCRIPTPATH=$(dirname "$(realpath "$0")")
+cd $SCRIPTPATH
+shift
+eval ./bin/node ./bundle.js "$@"


### PR DESCRIPTION
Also ensures that arguments passed to the script are forwarded to the Tunarr command

Fixes #668
