### PR TITLE
fix: various fixes to channel edit form

### DIFF
--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -390,7 +390,7 @@ export class ChannelDB {
     await em.flush();
 
     return {
-      channel: loadedChannel,
+      channel: await loadedChannel.populate(['fillers', 'channelFillers']),
       lineup: await this.loadLineup(id),
     };
   }

--- a/server/src/dao/converters/channelConverters.ts
+++ b/server/src/dao/converters/channelConverters.ts
@@ -12,9 +12,15 @@ export const dbChannelToApiChannel = ({
     id: channel.uuid,
     number: channel.number,
     watermark: nilToUndefined(channel.watermark),
-    // filler
-    // programs
+    fillerCollections: channel.channelFillers.isInitialized()
+      ? channel.channelFillers.map((filler) => ({
+          id: filler.fillerShow.uuid,
+          cooldownSeconds: filler.cooldown,
+          weight: filler.weight,
+        }))
+      : undefined,
     // fallback
+    guideFlexTitle: channel.guideFlexTitle,
     icon: channel.icon ?? DefaultChannelIcon,
     guideMinimumDuration: channel.guideMinimumDuration,
     groupTitle: channel.groupTitle || '',

--- a/server/src/dao/entities/Channel.ts
+++ b/server/src/dao/entities/Channel.ts
@@ -3,6 +3,7 @@ import {
   Entity,
   IType,
   ManyToMany,
+  OneToMany,
   Property,
   Unique,
 } from '@mikro-orm/core';
@@ -209,6 +210,12 @@ export class Channel extends BaseEntity {
     pivotEntity: () => ChannelFillerShow,
   })
   fillers = new Collection<FillerShow>(this);
+
+  @OneToMany({
+    entity: () => ChannelFillerShow,
+    mappedBy: 'channel',
+  })
+  channelFillers = new Collection<ChannelFillerShow>(this);
 
   @Property({ nullable: true })
   fillerRepeatCooldown?: number; // Seconds

--- a/web/src/components/channel_config/ChannelFlexConfig.tsx
+++ b/web/src/components/channel_config/ChannelFlexConfig.tsx
@@ -37,6 +37,7 @@ import { typedProperty } from '../../helpers/util.ts';
 import { useFillerLists } from '../../hooks/useFillerLists.ts';
 import useStore from '../../store/index.ts';
 import { ImageUploadInput } from '../settings/ImageUploadInput.tsx';
+import { NumericFormController } from '../util/TypedController.tsx';
 
 export function ChannelFlexConfig() {
   const channel = useStore((s) => s.channelEditor.currentEntity);
@@ -175,7 +176,7 @@ export function ChannelFlexConfig() {
 
       return (
         <Grid container key={cfl.id} sx={{ mb: 2 }} columnSpacing={2}>
-          <Grid item xs={2}>
+          <Grid item xs={3}>
             <FormControl key={cfl.id} sx={{ width: '100%' }}>
               <Select value={cfl.id} disabled={unclaimedLists.length === 0}>
                 {listOpts}
@@ -183,7 +184,7 @@ export function ChannelFlexConfig() {
             </FormControl>
           </Grid>
           <Grid item>
-            <Controller
+            <NumericFormController
               control={control}
               name={`fillerCollections.${index}.cooldownSeconds`}
               rules={{ min: 0, max: 525600 }}
@@ -341,7 +342,7 @@ export function ChannelFlexConfig() {
               render={({ field }) => (
                 <FormControl fullWidth margin="normal">
                   <FormControlLabel
-                    control={<Checkbox {...field} />}
+                    control={<Checkbox {...field} checked={field.value} />}
                     label="Hide watermark during filler"
                   />
                 </FormControl>

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -142,12 +142,13 @@ export default function ChannelTranscodingConfig() {
   ) => {
     if (e.target.value === 'global') {
       setTargetResString('global');
-      setValue('transcoding.targetResolution', 'global');
+      setValue('transcoding.targetResolution', 'global', { shouldDirty: true });
     } else if (resolutionValues.has(e.target.value)) {
       setTargetResString(e.target.value as ResolutionOptionValues);
       setValue(
         'transcoding.targetResolution',
         resolutionFromAnyString(e.target.value),
+        { shouldDirty: true },
       );
     }
   };

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -119,6 +119,8 @@ export function EditChannelForm({
       (conf) => conf.periodMins <= 0,
     );
 
+    console.log(data.fillerCollections);
+
     const dataTransform: SaveChannelRequest = {
       ...data,
       // Transform this to milliseconds before we send it over

--- a/web/src/hooks/useUpdateChannel.ts
+++ b/web/src/hooks/useUpdateChannel.ts
@@ -6,6 +6,7 @@ import {
 import { Channel, SaveChannelRequest } from '@tunarr/types';
 import { ZodiosError } from '@zodios/core';
 import { useTunarrApi } from './useTunarrApi';
+import { z } from 'zod';
 
 export const useUpdateChannel = (
   isNewChannel: boolean,
@@ -41,8 +42,11 @@ export const useUpdateChannel = (
     },
     onError: (error, vars, ctx) => {
       if (error instanceof ZodiosError) {
-        console.error(error.data);
-        console.error(error, error.cause, error.message);
+        console.error(error.message, error.data, error.cause);
+        if (error.cause instanceof z.ZodError) {
+          console.error(error.cause.message);
+        }
+        console.error(error.cause);
       } else {
         console.error(error);
       }


### PR DESCRIPTION
1. Fix saving filler collections. These had issues where the values
   weren't re-populated into the form after the save because they were
   excluded from the API response
2. Fix setting Channel-specific resolution requirements
3. Channel filler collection cooldown was not working properly
4. Channel 'disable filler watermark' checkbox was not updating it's UI
   value properly
5. Will show full Zod error on failure to save Channel which should help
   any future issues
