### PR TITLE
fix: use Jellyfin authorization scheme over X-Emby-Token header

### DIFF
--- a/server/src/api/jellyfinApi.ts
+++ b/server/src/api/jellyfinApi.ts
@@ -89,7 +89,6 @@ export const jellyfinApiRouter: RouterPluginCallback = (fastify, _, done) => {
     },
     (req, res) =>
       withJellyfinMediaSource(req, res, async (mediaSource) => {
-        console.log(req.query.itemTypes);
         const api = MediaSourceApiFactory().getJellyfinClient({
           ...mediaSource,
           url: mediaSource.uri,

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -47,7 +47,9 @@ export class JellyfinApiClient extends BaseApiClient<
       extraHeaders: {
         ...options.extraHeaders,
         Accept: 'application/json',
-        'X-Emby-Token': options.apiKey,
+        Authorization: `MediaBrowser Token="${
+          options.apiKey
+        }", Client="Tunarr", Device="Web Browser", Version=${getTunarrVersion()}`,
       },
     });
   }


### PR DESCRIPTION
This is the most future-proof way to authorize against Jellyfin servers
per
https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f
