### PR TITLE
XMLTV setting improvements - redo to make the release pick up the changes

### DIFF
--- a/server/src/api/xmltvSettingsApi.ts
+++ b/server/src/api/xmltvSettingsApi.ts
@@ -1,4 +1,5 @@
 import { XmlTvSettings } from '@tunarr/types';
+import { BaseErrorSchema } from '@tunarr/types/api';
 import { XmlTvSettingsSchema } from '@tunarr/types/schemas';
 import { isError } from 'lodash-es';
 import { z } from 'zod';
@@ -9,7 +10,6 @@ import { UpdateXmlTvTask } from '../tasks/UpdateXmlTvTask.js';
 import { RouterPluginCallback } from '../types/serverType.js';
 import { firstDefined } from '../util/index.js';
 import { LoggerFactory } from '../util/logging/LoggerFactory.js';
-import { BaseErrorSchema } from '@tunarr/types/api';
 
 export const xmlTvSettingsRouter: RouterPluginCallback = (
   fastify,
@@ -60,6 +60,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
           enableImageCache: settings.enableImageCache === true,
           outputPath: xmltv.outputPath,
           programmingHours: settings.programmingHours ?? 12,
+          useShowPoster: settings.useShowPoster ?? false,
         });
         xmltv = req.serverCtx.settings.xmlTvSettings();
         req.serverCtx.eventService.push({

--- a/server/src/dao/legacy_migration/legacyDbMigration.ts
+++ b/server/src/dao/legacy_migration/legacyDbMigration.ts
@@ -153,23 +153,26 @@ export class LegacyDbMigrator {
         const xmltvSettings = await attempt(() =>
           this.readOldDbFile('xmltv-settings'),
         );
+
+        const defaultSettings = defaultXmlTvSettings(
+          globalOptions().databaseDirectory,
+        );
+
         if (isError(xmltvSettings)) {
           settings = {
             ...settings,
-            xmltv: {
-              ...defaultXmlTvSettings(globalOptions().databaseDirectory),
-            },
+            xmltv: defaultSettings,
           };
         } else {
           this.logger.debug('Migrating XMLTV settings', xmltvSettings);
           settings = {
             ...settings,
-            xmltv: {
+            xmltv: merge({}, defaultSettings, {
               enableImageCache: xmltvSettings['enableImageCache'] as boolean,
               outputPath: xmltvSettings['file'] as string,
               programmingHours: xmltvSettings['cache'] as number,
               refreshHours: xmltvSettings['refresh'] as number,
-            },
+            }),
           };
         }
       } catch (e) {

--- a/server/src/dao/settings.ts
+++ b/server/src/dao/settings.ts
@@ -233,6 +233,7 @@ export const getSettings = once((dbPath?: string) => {
   const freshSettings = !existsSync(actualPath);
 
   const defaultValue = defaultSettings(globalOptions().databaseDirectory);
+  console.log(defaultValue);
   // Load this synchronously, but then give the DB instance an async version
   const db = new LowSync<SettingsFile>(
     new SyncSchemaBackedDbAdapter(SettingsFileSchema, actualPath, defaultValue),

--- a/types/package.json
+++ b/types/package.json
@@ -7,7 +7,7 @@
     "bundle": "tsc --emitDeclarationOnly --declaration",
     "build": "tsc",
     "clean": "rimraf ./build/",
-    "dev": "tsc --emitDeclarationOnly --declaration --watch",
+    "dev": "tsc --watch",
     "build-dev": "tsc --emitDeclarationOnly --declaration --watch"
   },
   "main": "./build/src/index.js",

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
-import { ResolutionSchema } from './miscSchemas.js';
 import { Tag, TupleToUnion } from '../util.js';
+import { ResolutionSchema } from './miscSchemas.js';
 import { ScheduleSchema } from './utilSchemas.js';
 
 export const XmlTvSettingsSchema = z.object({
@@ -8,6 +8,9 @@ export const XmlTvSettingsSchema = z.object({
   refreshHours: z.number().default(4),
   outputPath: z.string().default(''),
   enableImageCache: z.boolean().default(false),
+  // If true, episodes will use the poster for their show in
+  // the XMLTV file
+  useShowPoster: z.boolean().default(false).catch(false),
 });
 
 export const SupportedVideoFormats = ['h264', 'hevc', 'mpeg2'] as const;

--- a/web/src/pages/settings/XmlTvSettingsPage.tsx
+++ b/web/src/pages/settings/XmlTvSettingsPage.tsx
@@ -1,25 +1,14 @@
-import {
-  Box,
-  Button,
-  FormControl,
-  FormControlLabel,
-  FormHelperText,
-  Stack,
-  TextField,
-} from '@mui/material';
+import { Box, Button, FormControl, Stack, TextField } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { XmlTvSettings, defaultXmlTvSettings } from '@tunarr/types';
 import _ from 'lodash-es';
+import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import UnsavedNavigationAlert from '../../components/settings/UnsavedNavigationAlert.tsx';
-import {
-  CheckboxFormController,
-  NumericFormControllerText,
-} from '../../components/util/TypedController.tsx';
+import { NumericFormControllerText } from '../../components/util/TypedController.tsx';
 import { useXmlTvSettings } from '../../hooks/settingsHooks.ts';
 import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
-import { useSnackbar } from 'notistack';
 
 export default function XmlTvSettingsPage() {
   const apiClient = useTunarrApi();
@@ -117,7 +106,7 @@ export default function XmlTvSettingsPage() {
           }}
         />
       </Stack>
-      <FormControl>
+      {/* <FormControl>
         <FormControlLabel
           control={
             <CheckboxFormController control={control} name="enableImageCache" />
@@ -131,7 +120,7 @@ export default function XmlTvSettingsPage() {
           location in Plex (as opposed to url) will not work correctly in this
           case.
         </FormHelperText>
-      </FormControl>
+      </FormControl> */}
       <UnsavedNavigationAlert isDirty={isDirty} />
       <Stack spacing={2} direction="row" sx={{ mt: 2 }}>
         <Stack


### PR DESCRIPTION
- **fix: hide image cache settings in xmltv as the feature is currently disabled**
- **feat: add option to use show's poster instead of episode poster**
