### PR TITLE
Fix external watermarks + cache them locally for faster streaming

### DIFF
--- a/server/src/api/sessionApi.ts
+++ b/server/src/api/sessionApi.ts
@@ -129,7 +129,7 @@ export const sessionApiRouter: RouterPluginAsyncCallback = async (fastify) => {
       }
 
       const sessions =
-        req.serverCtx.sessionManager.getAllConcatSessions(channelId);
+        req.serverCtx.sessionManager.getAllSessionsForChannel(channelId);
 
       if (isEmpty(sessions)) {
         return res.status(404).send('No session found for channel ID');

--- a/server/src/ffmpeg/ffmpeg.ts
+++ b/server/src/ffmpeg/ffmpeg.ts
@@ -682,9 +682,8 @@ export class FFMPEG {
 
     if (doOverlay && !isNil(watermark?.url)) {
       if (watermark.animated) {
-        ffmpegArgs.push('-ignore_loop', '0');
+        ffmpegArgs.push('-ignore_loop', '0', '-stream_loop', '-1');
       }
-      ffmpegArgs.push('-loop', '1');
       ffmpegArgs.push(`-i`, `${watermark.url}`);
       overlayFile = inputFiles++;
       this.ensureResolution = true;

--- a/server/src/stream/jellyfin/JellyfinProgramStream.ts
+++ b/server/src/stream/jellyfin/JellyfinProgramStream.ts
@@ -70,7 +70,7 @@ export class JellyfinProgramStream extends ProgramStream {
       new ProgramDB(),
     );
 
-    const watermark = this.getWatermark();
+    const watermark = await this.getWatermark();
     this.ffmpeg = new FFMPEG(ffmpegSettings, channel, this.context.audioOnly); // Set the transcoder options
 
     const stream = await jellyfinStreamDetails.getStream(lineupItem);

--- a/server/src/stream/plex/PlexProgramStream.ts
+++ b/server/src/stream/plex/PlexProgramStream.ts
@@ -71,7 +71,7 @@ export class PlexProgramStream extends ProgramStream {
     const plexSettings = this.settingsDB.plexSettings();
     const plexStreamDetails = new PlexStreamDetails(server);
 
-    const watermark = this.getWatermark();
+    const watermark = await this.getWatermark();
     const ffmpeg = new FFMPEG(ffmpegSettings, channel, this.context.audioOnly); // Set the transcoder options
 
     const stream = await plexStreamDetails.getStream(lineupItem);


### PR DESCRIPTION
- **fix: terminate all sessions associated with channel on DELETE /api/sessions/:channel**
- **fix: download external watermarks locally + fix some watermark streaming issues**
