### PR TITLE
fix: reimplement BackfillProgramGroupings fixer

### DIFF
--- a/server/mikro-orm.base.config.ts
+++ b/server/mikro-orm.base.config.ts
@@ -32,7 +32,6 @@ import { Migration20240805185042 } from './src/migrations/Migration2024080518504
 import { Migration20240917191535 } from './src/migrations/Migration20240917191535.js';
 import { DATABASE_LOCATION_ENV_VAR } from './src/util/constants.js';
 import { getDefaultDatabaseDirectory } from './src/util/defaults.js';
-import { LoggerFactory } from './src/util/logging/LoggerFactory.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -62,7 +61,8 @@ export default defineConfig({
   forceUndefined: true,
   dynamicImportProvider: (id) => import(id),
   logger(message) {
-    LoggerFactory.root.debug(message);
+    // LoggerFactory.root.debug(message);
+    console.debug(message);
   },
   migrations: {
     // Explicitly list migrations for a smoother dev experience

--- a/server/src/dao/SchemaBackedDbAdapter.ts
+++ b/server/src/dao/SchemaBackedDbAdapter.ts
@@ -32,11 +32,12 @@ export class SchemaBackedDbAdapter<T extends z.ZodTypeAny, Out = z.infer<T>>
       this.logger.error(e);
       return null;
     });
-    if (data === null) {
+    if (data === null && this.defaultValue === null) {
       this.logger.debug('Unexpected null data at %s; %O', this.path, data);
       return null;
     }
-    const parsed: unknown = JSON.parse(data);
+
+    const parsed: unknown = data ? JSON.parse(data) : {};
     let parseResult: z.SafeParseReturnType<unknown, Out> =
       await this.schema.safeParseAsync(parsed);
     let needsWriteFlush = false;

--- a/server/src/dao/channelDb.ts
+++ b/server/src/dao/channelDb.ts
@@ -1042,6 +1042,12 @@ export class ChannelDB {
           return existing;
         }
 
+        const defaultValue = {
+          items: [],
+          startTimeOffsets: [],
+          lastUpdated: dayjs().valueOf(),
+          version: CurrentLineupSchemaVersion,
+        };
         const db = new Low<Lineup>(
           new SchemaBackedDbAdapter(
             LineupSchema,
@@ -1049,13 +1055,9 @@ export class ChannelDB {
               globalOptions().databaseDirectory,
               `channel-lineups/${channelId}.json`,
             ),
+            defaultValue,
           ),
-          {
-            items: [],
-            startTimeOffsets: [],
-            lastUpdated: dayjs().valueOf(),
-            version: CurrentLineupSchemaVersion,
-          },
+          defaultValue,
         );
         await db.read();
         fileDbCache[channelId] = db;

--- a/server/src/dao/direct/directDbAccess.ts
+++ b/server/src/dao/direct/directDbAccess.ts
@@ -27,7 +27,7 @@ export const initDirectDbAccess = once((opts: GlobalOptions) => {
             process.env['DATABASE_DEBUG_LOGGING'] ||
             process.env['DIRECT_DATABASE_DEBUG_LOGGING']
           ) {
-            logger().debug(
+            console.debug(
               'Query: %O (%d ms)',
               event.query.sql,
               event.queryDurationMillis,

--- a/server/src/external/BaseApiClient.ts
+++ b/server/src/external/BaseApiClient.ts
@@ -181,7 +181,7 @@ export abstract class BaseApiClient<
           // The request was made and the server responded with a status code
           // that falls out of the range of 2xx
           this.logger.warn(
-            'API client esponse error: path: %O, status %d, params: %O, data: %O, headers: %O',
+            'API client response error: path: %O, status %d, params: %O, data: %O, headers: %O',
             error.config?.url ?? '',
             status,
             error.config?.params,

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -304,7 +304,7 @@ export class JellyfinApiClient extends BaseApiClient<JellyfinApiClientOptions> {
     return super.preRequestValidate(req);
   }
 
-  protected static override redactRequestInfo(
+  protected override redactRequestInfo(
     conf: InternalAxiosRequestConfig<unknown>,
   ): void {
     super.redactRequestInfo(conf);

--- a/server/src/external/plex/PlexApiClient.ts
+++ b/server/src/external/plex/PlexApiClient.ts
@@ -275,7 +275,7 @@ export class PlexApiClient extends BaseApiClient {
     return super.preRequestValidate(req);
   }
 
-  protected static override redactRequestInfo(
+  protected override redactRequestInfo(
     conf: InternalAxiosRequestConfig<unknown>,
   ): void {
     super.redactRequestInfo(conf);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -116,6 +116,7 @@ async function legacyDizquetvDirectoryPath() {
 }
 
 export async function initServer(opts: ServerOptions) {
+  const start = performance.now();
   await initDbDirectories();
   const settingsDb = getSettings();
   LoggerFactory.initialize(settingsDb);
@@ -461,9 +462,14 @@ export async function initServer(opts: ServerOptions) {
     port: opts.port,
   });
 
+  logger.debug(
+    'Took %d ms for the server to start',
+    round(performance.now() - start, 2),
+  );
   logger.info(
     `HTTP server listening on host:port: http://${host}:${opts.port}`,
   );
+
   const hdhrSettings = ctx.settings.hdhrSettings();
   if (hdhrSettings.autoDiscoveryEnabled) {
     await ctx.hdhrService.ssdp.start();

--- a/server/src/tasks/fixers/BackfillProgramExternalIds.ts
+++ b/server/src/tasks/fixers/BackfillProgramExternalIds.ts
@@ -35,7 +35,7 @@ export class BackfillProgramExternalIds extends Fixer {
     className: this.constructor.name,
   });
 
-  canRunInBackground: boolean = true;
+  canRunInBackground: boolean = false;
 
   async runInternal(): Promise<void> {
     const em = getEm();

--- a/server/src/tasks/fixers/backfillProgramGroupings.ts
+++ b/server/src/tasks/fixers/backfillProgramGroupings.ts
@@ -1,36 +1,11 @@
-import { Loaded, ref } from '@mikro-orm/better-sqlite';
-import { PlexLibraryShows, PlexSeasonView } from '@tunarr/types/plex';
 import { NotNull } from 'kysely';
-import ld, {
-  chunk,
-  concat,
-  filter,
-  find,
-  first,
-  forEach,
-  head,
-  isEmpty,
-  isNil,
-  isUndefined,
-  map,
-  reduce,
-  some,
-  tail,
-  uniq,
-} from 'lodash-es';
-import { ProgramExternalIdType } from '../../dao/custom_types/ProgramExternalIdType';
+import { chunk, head, reduce, tail } from 'lodash-es';
 import { ProgramSourceType } from '../../dao/custom_types/ProgramSourceType';
-import { getEm } from '../../dao/dataSource';
 import { directDbAccess } from '../../dao/direct/directDbAccess.js';
-import { MediaSource } from '../../dao/entities/MediaSource';
-import { Program, ProgramType } from '../../dao/entities/Program';
-import {
-  ProgramGrouping,
-  ProgramGroupingType,
-} from '../../dao/entities/ProgramGrouping';
-import { ProgramGroupingExternalId } from '../../dao/entities/ProgramGroupingExternalId';
-import { MediaSourceApiFactory } from '../../external/MediaSourceApiFactory';
+import { ProgramType } from '../../dao/entities/Program';
+import { ProgramGroupingType } from '../../dao/entities/ProgramGrouping';
 import { LoggerFactory } from '../../util/logging/LoggerFactory';
+import { Timer } from '../../util/perf';
 import Fixer from './fixer';
 
 // TODO: Handle Jellyfin items
@@ -40,397 +15,211 @@ export class BackfillProgramGroupings extends Fixer {
     caller: import.meta,
     className: BackfillProgramGroupings.name,
   });
+  private timer = new Timer(this.logger);
 
   protected async runInternal(): Promise<void> {
-    const em = getEm();
-    const plexServers = await getEm().findAll(MediaSource);
-
     // We'll try filling using the data we have first...
-    const results = await directDbAccess()
-      .selectFrom('program')
-      .select(['program.uuid', 'program.tvShowUuid'])
-      .where('program.seasonUuid', 'is not', null)
-      .where('program.tvShowUuid', 'is not', null)
-      .innerJoin('programGrouping', (join) =>
-        join
-          .onRef('programGrouping.uuid', '=', 'program.seasonUuid')
-          .on('programGrouping.showUuid', 'is', null),
-      )
-      .select('programGrouping.uuid as seasonId')
-      .groupBy(['program.seasonUuid', 'program.tvShowUuid'])
-      .$narrowType<{ tvShowUuid: NotNull }>()
-      .execute();
-
-    for (const result of chunk(results, 50)) {
-      const first = head(result)!;
-      const rest = tail(result);
-      await directDbAccess()
-        .transaction()
-        .execute((tx) =>
-          tx
-            .updateTable('programGrouping')
-            .set(({ eb }) => {
-              return {
-                showUuid: reduce(
-                  rest,
-                  (ebb, r) =>
-                    ebb
-                      .when('programGrouping.uuid', '=', r.seasonId)
-                      .then(r.tvShowUuid),
-                  eb
-                    .case()
-                    .when('programGrouping.uuid', '=', first.seasonId)
-                    .then(first.tvShowUuid),
-                ).end(),
-              };
-            })
-            .execute(),
-        );
-    }
-
-    // Update shows first, then seasons, so we can relate them
-    const serversAndShows = await em
-      .createQueryBuilder(Program)
-      .select(['externalSourceId', 'grandparentExternalKey'], true)
-      .where({
-        type: ProgramType.Episode,
-        grandparentExternalKey: { $ne: null },
-        tvShow: null,
-        // At the time this was written, this was the only source type
-        sourceType: ProgramSourceType.PLEX,
-      })
-      .execute();
-
-    for (const {
-      externalSourceId,
-      grandparentExternalKey,
-    } of serversAndShows) {
-      const existing = await em.findOne(ProgramGrouping, {
-        type: ProgramGroupingType.TvShow,
-        externalRefs: {
-          sourceType: ProgramExternalIdType.PLEX,
-          externalKey: grandparentExternalKey,
-          externalSourceId,
-        },
-      });
-
-      if (!isNil(existing)) {
-        this.logger.trace('Skipping existing TV show: %s', existing.uuid);
-        continue;
-      }
-
-      const server = find(plexServers, (ps) => ps.name === externalSourceId);
-      if (isNil(server)) {
-        this.logger.warn(
-          'Could not find server with name %s',
-          externalSourceId,
-        );
-        continue;
-      }
-
-      const plex = MediaSourceApiFactory().get(server);
-      const plexResult = await plex.doGetPath<PlexLibraryShows>(
-        '/library/metadata/' + grandparentExternalKey,
-      );
-
-      if (isNil(plexResult) || plexResult.Metadata.length < 1) {
-        this.logger.warn(
-          'Found no result for key %s in plex server %s',
-          grandparentExternalKey,
-          externalSourceId,
-        );
-        continue;
-      }
-
-      const show = first(plexResult.Metadata)!;
-
-      const grouping = em.create(ProgramGrouping, {
-        title: show.title,
-        type: ProgramGroupingType.TvShow,
-        icon: show.thumb,
-        summary: show.summary,
-        year: show.year,
-      });
-
-      const refs = em.create(ProgramGroupingExternalId, {
-        sourceType: ProgramExternalIdType.PLEX,
-        externalSourceId: server.name, // clientIdentifier would be better
-        externalKey: show.ratingKey,
-        group: grouping,
-      });
-
-      em.persist([grouping, refs]);
-    }
-
-    const serversAndSeasons = await em
-      .createQueryBuilder(Program)
-      .select(['externalSourceId', 'parentExternalKey'], true)
-      .where({
-        type: ProgramType.Episode,
-        parentExternalKey: { $ne: null },
-        season: null,
-        // At the time this was written, this was the only source type
-        sourceType: ProgramExternalIdType.PLEX,
-      })
-      .execute();
-
-    for (const { externalSourceId, parentExternalKey } of serversAndSeasons) {
-      const existing = await em.findOne(ProgramGrouping, {
-        type: ProgramGroupingType.TvShowSeason,
-        externalRefs: {
-          sourceType: ProgramExternalIdType.PLEX,
-          externalKey: parentExternalKey,
-          externalSourceId,
-        },
-      });
-
-      if (!isNil(existing)) {
-        this.logger.trace('Skipping existing season: %s', existing.uuid);
-        continue;
-      }
-
-      const server = find(plexServers, (ps) => ps.name === externalSourceId);
-      if (isNil(server)) {
-        this.logger.warn(
-          'Could not find server with name %s',
-          externalSourceId,
-        );
-        continue;
-      }
-
-      const plex = MediaSourceApiFactory().get(server);
-      const plexResult = await plex.doGetPath<PlexSeasonView>(
-        '/library/metadata/' + parentExternalKey,
-      );
-
-      if (isNil(plexResult) || plexResult.Metadata.length < 1) {
-        this.logger.warn(
-          'Found no result for key %s in plex server %s',
-          parentExternalKey,
-          externalSourceId,
-        );
-        continue;
-      }
-
-      const season = first(plexResult.Metadata)!;
-
-      const grouping = em.create(ProgramGrouping, {
-        title: season.title,
-        type: ProgramGroupingType.TvShowSeason,
-        icon: season.thumb,
-        summary: season.summary,
-      });
-
-      const refs = em.create(ProgramGroupingExternalId, {
-        sourceType: ProgramExternalIdType.PLEX,
-        externalSourceId: server.name, // clientIdentifier would be better
-        externalKey: season.ratingKey,
-        group: grouping,
-      });
-
-      em.persist([grouping, refs]);
-    }
-
-    await em.flush();
-
-    // Now let's do all of the relations...
-    // First associate shows and seasons
-
-    const episodes = await em.find(
-      Program,
-      {
-        type: ProgramType.Episode,
-        parentExternalKey: { $ne: null },
-        grandparentExternalKey: { $ne: null },
-        $or: [
-          {
-            season: null,
-          },
-          {
-            tvShow: null,
-          },
-        ],
-      },
-      {
-        orderBy: { uuid: 'desc' },
-      },
-    );
-
-    this.logger.debug('Updating %d episodes', episodes.length);
-
-    if (!isEmpty(episodes)) {
-      await this.updateEpisodes(episodes);
-    }
-
-    const seasonsMissingIndexes = await em.find(
-      ProgramGrouping,
-      { type: ProgramGroupingType.TvShowSeason, index: null },
-      {
-        populateWhere: {
-          externalRefs: {
-            sourceType: ProgramExternalIdType.PLEX,
-          },
-        },
-        populate: ['externalRefs'],
-      },
-    );
-
-    // Backfill missing season numbers
-    for (const season of seasonsMissingIndexes) {
-      const ref = season.externalRefs.$.find(
-        (ref) => ref.sourceType === ProgramExternalIdType.PLEX,
-      );
-      if (isUndefined(ref)) {
-        continue;
-      }
-
-      const server = find(
-        plexServers,
-        (ps) => ps.name === ref.externalSourceId,
-      );
-      if (isNil(server)) {
-        this.logger.warn(
-          'Could not find server with name %s',
-          ref.externalSourceId,
-        );
-        continue;
-      }
-
-      const plex = MediaSourceApiFactory().get(server);
-      const plexResult = await plex.doGetPath<PlexSeasonView>(
-        '/library/metadata/' + ref.externalKey,
-      );
-
-      if (isNil(plexResult) || plexResult.Metadata.length < 1) {
-        this.logger.warn(
-          'Found no result for key %s in plex server %s',
-          ref.externalKey,
-          ref.externalSourceId,
-        );
-        continue;
-      }
-
-      const plexSeason = first(plexResult.Metadata)!;
-      season.index = plexSeason.index;
-      em.persist(season);
-    }
-
-    await em.flush();
-  }
-
-  private async updateEpisodes(episodes: Loaded<Program>[]) {
-    const em = getEm();
-    const seasonIds = ld
-      .chain(episodes)
-      .map((p) => ({ sourceId: p.externalSourceId, id: p.parentExternalKey }))
-      .uniqBy('id')
-      .value();
-
-    const showIds = ld
-      .chain(episodes)
-      .map((p) => ({
-        sourceId: p.externalSourceId,
-        id: p.grandparentExternalKey,
-      }))
-      .uniqBy('id')
-      .value();
-
-    const showAndSeasonGroupings: Loaded<ProgramGrouping, 'externalRefs'>[] =
-      [];
-
-    for (const idChunk of chunk(concat(seasonIds, showIds), 50)) {
-      // TODO:: Replace with direct query
-      showAndSeasonGroupings.push(
-        ...(await em.find(
-          ProgramGrouping,
-          {
-            $or: reduce(
-              idChunk,
-              (prev, { sourceId, id }) => [
-                ...prev,
-                {
-                  externalRefs: { externalKey: id, externalSourceId: sourceId },
-                },
-              ],
-              [],
-            ),
-          },
-          {
-            populate: ['uuid', 'externalRefs'],
-          },
-        )),
-      );
-    }
-
-    const showsToSeasons = ld
-      .chain(episodes)
-      .map((e) => ({
-        show: e.grandparentExternalKey!,
-        season: e.parentExternalKey!,
-      }))
-      .groupBy('show')
-      .mapValues((objs) => map(objs, 'season'))
-      .mapValues(uniq)
-      .value();
-
-    ld.chain(showAndSeasonGroupings)
-      .filter({ type: ProgramGroupingType.TvShowSeason })
-      .forEach((season) => {
-        const matchingEps = ld
-          .chain(episodes)
-          .filter((e) =>
-            some(season.externalRefs.$, {
-              externalSourceId: e.externalSourceId,
-              externalKey: e.parentExternalKey,
-            }),
+    const results = await this.timer.timeAsync(
+      'missing groupiings db query',
+      () =>
+        directDbAccess()
+          .selectFrom('program')
+          .select(['program.uuid', 'program.tvShowUuid'])
+          .where('program.seasonUuid', 'is not', null)
+          .where('program.tvShowUuid', 'is not', null)
+          .innerJoin('programGrouping', (join) =>
+            join
+              .onRef('programGrouping.uuid', '=', 'program.seasonUuid')
+              .on('programGrouping.showUuid', 'is', null),
           )
-          .value();
+          .select('programGrouping.uuid as seasonId')
+          .groupBy(['program.seasonUuid', 'program.tvShowUuid'])
+          .$narrowType<{ tvShowUuid: NotNull }>()
+          .execute(),
+    );
 
-        forEach(matchingEps, (ep) => {
-          ep.season = ref(season);
-        });
-      })
-      .value();
-
-    ld.chain(showAndSeasonGroupings)
-      .filter({ type: ProgramGroupingType.TvShow })
-      .forEach((show) => {
-        const matchingEps = filter(episodes, (e) =>
-          some(show.externalRefs.$, {
-            externalSourceId: e.externalSourceId,
-            externalKey: e.grandparentExternalKey,
-          }),
-        );
-
-        const plexInfo = find(show.externalRefs.$, {
-          sourceType: ProgramExternalIdType.PLEX,
-        });
-
-        if (plexInfo) {
-          const seasonIds = showsToSeasons[plexInfo.externalKey];
-          const matchingSeasons = filter(
-            showAndSeasonGroupings,
-            (g) =>
-              g.type === ProgramGroupingType.TvShowSeason &&
-              some(
-                g.externalRefs.$,
-                (ref) =>
-                  ref.externalSourceId === plexInfo.externalSourceId &&
-                  seasonIds.includes(ref.externalKey),
-              ),
+    await this.timer.timeAsync('update program groupings 1', async () => {
+      for (const result of chunk(results, 50)) {
+        const first = head(result)!;
+        const rest = tail(result);
+        await directDbAccess()
+          .transaction()
+          .execute((tx) =>
+            tx
+              .updateTable('programGrouping')
+              .set(({ eb }) => {
+                return {
+                  showUuid: reduce(
+                    rest,
+                    (ebb, r) =>
+                      ebb
+                        .when('programGrouping.uuid', '=', r.seasonId)
+                        .then(r.tvShowUuid),
+                    eb
+                      .case()
+                      .when('programGrouping.uuid', '=', first.seasonId)
+                      .then(first.tvShowUuid),
+                  ).end(),
+                };
+              })
+              .executeTakeFirst(),
           );
+      }
+    });
 
-          forEach(matchingSeasons, (season) => {
-            season.show = ref(show);
-          });
-        }
+    // Update program -> show mappings with existing information
+    const updatedShows = await directDbAccess()
+      .transaction()
+      .execute((tx) =>
+        tx
+          .updateTable('program')
+          .set(({ selectFrom }) => ({
+            tvShowUuid: selectFrom('programGroupingExternalId')
+              .whereRef(
+                'programGroupingExternalId.externalSourceId',
+                '=',
+                'program.externalSourceId',
+              )
+              .whereRef(
+                'programGroupingExternalId.externalKey',
+                '=',
+                'program.grandparentExternalKey',
+              )
+              .leftJoin(
+                'programGrouping',
+                'programGroupingExternalId.groupUuid',
+                'programGrouping.uuid',
+              )
+              .select('programGrouping.uuid')
+              .limit(1),
+          }))
+          .where((eb) =>
+            eb.and([
+              eb('program.type', '=', ProgramType.Episode),
+              eb('program.grandparentExternalKey', 'is not', null),
+              eb('program.tvShowUuid', 'is', null),
+              eb('program.sourceType', '=', ProgramSourceType.PLEX),
+            ]),
+          )
+          .execute(),
+      );
 
-        forEach(matchingEps, (e) => {
-          e.tvShow = ref(show);
-        });
+    this.logger.debug(
+      'Fixed %s program->show mappings',
+      reduce(updatedShows, (n, { numUpdatedRows }) => n + numUpdatedRows, 0n),
+    );
+
+    // Update show -> season mappings with existing information
+    // Do this in the background since it is less important.
+    directDbAccess()
+      .transaction()
+      .execute((tx) =>
+        tx
+          .updateTable('program')
+          .set(({ selectFrom }) => ({
+            seasonUuid: selectFrom('programGroupingExternalId')
+              .whereRef(
+                'programGroupingExternalId.externalSourceId',
+                '=',
+                'program.externalSourceId',
+              )
+              .whereRef(
+                'programGroupingExternalId.externalKey',
+                '=',
+                'program.grandparentExternalKey',
+              )
+              .leftJoin(
+                'programGrouping',
+                'programGroupingExternalId.groupUuid',
+                'programGrouping.uuid',
+              )
+              .select('programGrouping.uuid')
+              .limit(1),
+          }))
+          .where((eb) =>
+            eb.and([
+              eb('program.type', '=', ProgramType.Episode),
+              eb('program.parentExternalKey', 'is not', null),
+              eb('program.seasonUuid', 'is', null),
+              eb('program.sourceType', '=', ProgramSourceType.PLEX),
+            ]),
+          )
+          .execute(),
+      )
+      .then((updatedSeasons) => {
+        this.logger.debug(
+          'Fixed %s program->season mappings',
+          reduce(
+            updatedSeasons,
+            (n, { numUpdatedRows }) => n + numUpdatedRows,
+            0n,
+          ),
+        );
       })
-      .value();
+      .catch((e) => {
+        this.logger.error(
+          e,
+          'Error while updating season associations. Will try again on restart',
+        );
+      });
 
-    await em.flush();
+    directDbAccess()
+      .transaction()
+      .execute((tx) =>
+        tx
+          .updateTable('programGrouping')
+          .set(({ selectFrom }) => ({
+            showUuid: selectFrom('program')
+              .where('program.type', '=', 'episode')
+              .where('program.grandparentExternalKey', 'is not', null)
+              .innerJoin('programGroupingExternalId', (join) =>
+                join
+                  .onRef(
+                    'programGroupingExternalId.externalSourceId',
+                    '=',
+                    'program.externalSourceId',
+                  )
+                  .onRef(
+                    'programGroupingExternalId.externalKey',
+                    '=',
+                    'program.grandparentExternalKey',
+                  ),
+              )
+              .innerJoin(
+                'programGrouping',
+                'programGrouping.uuid',
+                'programGroupingExternalId.groupUuid',
+              )
+              .where('programGrouping.uuid', 'is not', null)
+              .select('programGrouping.uuid')
+              .limit(1),
+          }))
+          .where('programGrouping.type', '=', ProgramGroupingType.TvShowSeason)
+          .where('programGrouping.showUuid', 'is', null)
+          .executeTakeFirst(),
+      )
+      .then((res) => {
+        this.logger.debug(
+          'Fixed %s show->season associations',
+          res.numUpdatedRows,
+        );
+      })
+      .catch((e) => {
+        this.logger.error(e, 'Error while updating show->season associations');
+      });
+
+    const stillMissing = await directDbAccess()
+      .selectFrom('program')
+      .select(({ fn }) => fn.count<number>('program.uuid').as('count'))
+      .where((eb) =>
+        eb.or([eb('tvShowUuid', 'is', null), eb('seasonUuid', 'is', null)]),
+      )
+      .where('type', '=', ProgramType.Episode)
+      .executeTakeFirst();
+
+    this.logger.debug(
+      'There are still %d episode programs with missing associations',
+      stillMissing?.count,
+    );
   }
 }


### PR DESCRIPTION
This fixer ran extremely slow for large DBs due to mikro-orm having to
handle many thousands of entities, which it is not primed to do.
Instead, we can generate the updates using existing DB data with direct
updates. However, we will still have to implement a background updater
if we need to pull information from the media source (i.e. it is missing
from the DB)
