### PR TITLE
Cleanup results messaging when filtering

### DIFF
--- a/web/src/components/channel_config/MediaItemGrid.tsx
+++ b/web/src/components/channel_config/MediaItemGrid.tsx
@@ -407,13 +407,22 @@ export function MediaItemGrid<PageDataType, ItemType>({
           sx={{ display: 'block', margin: '2em auto' }}
         />
       )}
-      {data && !hasNextPage && (
+      {data && scrollParams.max === 0 && !hasNextPage && (
         <Typography
           variant="h6"
           fontStyle={'italic'}
           sx={{ textAlign: 'center', mt: 2 }}
         >
-          fin.
+          No results
+        </Typography>
+      )}
+      {data && scrollParams.max !== 0 && !hasNextPage && (
+        <Typography
+          variant="h6"
+          fontStyle={'italic'}
+          sx={{ textAlign: 'center', mt: 2 }}
+        >
+          The End.
         </Typography>
       )}
     </Box>


### PR DESCRIPTION
Minor tweak to change "fin." to "The End." and also replaces that with "No Results" when filtering and 0 items are returned

No results:
<img width="1543" alt="image" src="https://github.com/user-attachments/assets/5eb98506-4026-4be4-a05a-c561ba968e13">

End of Results:
<img width="1537" alt="image" src="https://github.com/user-attachments/assets/8dba6aaa-3818-44c6-943d-edb6d335464c">

Fixes: https://github.com/chrisbenincasa/tunarr/issues/860
