### PR TITLE
fix: use window location for base URL in m3u clipboard copy when backend url is empty

### DIFF
--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -77,7 +77,6 @@ export const useCopyToClipboard = () => {
       // This is only supported by chromium: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard#using_the_clipboard_api
       try {
         if (browser.getEngineName() === 'Blink') {
-          console.log('here');
           const result = await navigator.permissions.query({
             // @ts-expect-error -- clipboard-write not included in PermissionName enum
             name: 'clipboard-write',

--- a/web/src/pages/channels/ChannelsPage.tsx
+++ b/web/src/pages/channels/ChannelsPage.tsx
@@ -40,7 +40,7 @@ import { VisibilityState } from '@tanstack/react-table';
 import { Channel, ChannelIcon } from '@tunarr/types';
 import { ChannelSessionsResponse } from '@tunarr/types/api';
 import dayjs from 'dayjs';
-import { isEmpty, map } from 'lodash-es';
+import { isEmpty, map, trimEnd } from 'lodash-es';
 import {
   MRT_Row,
   MaterialReactTable,
@@ -239,9 +239,13 @@ export default function ChannelsPage() {
         <MenuItem
           onClick={(e) => {
             e.stopPropagation();
-            const url = `${
-              isNonEmptyString(backendUri) ? `${backendUri}/` : ''
-            }stream/channels/${channelId}.m3u8`;
+            const base = isNonEmptyString(backendUri)
+              ? backendUri
+              : window.location.origin;
+            const url = `${trimEnd(
+              base,
+              '/',
+            )}/stream/channels/${channelId}.m3u8`;
             copyToClipboard(
               url,
               `Copied channel "${channelName}" m3u link to clipboard`,


### PR DESCRIPTION
Fixes: #878
