### PR TITLE
fix: mitigate RCE vulneratbility

### DIFF
--- a/server/src/api/systemApi.ts
+++ b/server/src/api/systemApi.ts
@@ -9,6 +9,7 @@ import { BackupSettings, BackupSettingsSchema } from '@tunarr/types/schemas';
 import { isUndefined } from 'lodash-es';
 import { DeepReadonly, Writable } from 'ts-essentials';
 import { z } from 'zod';
+import { serverOptions } from '../globals.js';
 import { scheduleBackupJobs } from '../services/scheduler.js';
 import { FixersByName } from '../tasks/fixers/index.js';
 import { RouterPluginAsyncCallback } from '../types/serverType.js';
@@ -149,6 +150,7 @@ export const systemApiRouter: RouterPluginAsyncCallback = async (
         ...(settings.logging as Writable<LoggingSettings>),
         environmentLogLevel: envLogLevel,
       },
+      adminMode: serverOptions().admin,
     };
   }
 };

--- a/server/src/cli/index.ts
+++ b/server/src/cli/index.ts
@@ -1,0 +1,3 @@
+import { settingsCommands } from './settings/settingsCommands';
+
+export const commands = [settingsCommands];

--- a/server/src/cli/settings/settingsCommands.ts
+++ b/server/src/cli/settings/settingsCommands.ts
@@ -1,0 +1,11 @@
+import { CommandModule } from 'yargs';
+import { SettingsUpdateCommand } from './settingsUpdateCommand';
+import { SettingsViewCommand } from './settingsViewCommand';
+
+export const settingsCommands: CommandModule = {
+  command: 'settings <command>',
+  describe: 'View/Update settings',
+  builder: (yargs) =>
+    yargs.command(SettingsViewCommand).command(SettingsUpdateCommand),
+  handler: () => {},
+};

--- a/server/src/cli/settings/settingsUpdateCommand.ts
+++ b/server/src/cli/settings/settingsUpdateCommand.ts
@@ -1,0 +1,50 @@
+import { merge } from 'lodash-es';
+import { CommandModule } from 'yargs';
+import { SettingsSchema, getSettings } from '../../dao/settings';
+
+type SettingsUpdateCommandArgs = {
+  pretty: boolean;
+  settings: unknown;
+};
+
+export const SettingsUpdateCommand: CommandModule<
+  SettingsUpdateCommandArgs,
+  SettingsUpdateCommandArgs
+> = {
+  command: 'update',
+  describe: 'Update Tunarr settings directly.',
+  builder: (yargs) =>
+    yargs
+      .usage('$0 settings update ')
+      .option('pretty', {
+        type: 'boolean',
+        default: false,
+        desc: 'Print settings JSON with spacing',
+      })
+      .option('settings', {
+        type: 'string',
+      })
+      .example([
+        [
+          '$0 settings update --settings.ffmpeg.ffmpegExecutablePath="/usr/bin/ffmpeg"',
+          'Update FFmpeg executable path',
+        ],
+      ]),
+  handler: async (args) => {
+    const settings = getSettings().getAll();
+    const newSettings = merge({}, settings.settings, args.settings);
+
+    try {
+      const validSettings = SettingsSchema.parse(newSettings);
+      await getSettings().directUpdate((prev) => {
+        prev.settings = validSettings;
+      });
+
+      console.log(
+        JSON.stringify(validSettings, undefined, args.pretty ? 4 : undefined),
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  },
+};

--- a/server/src/cli/settings/settingsViewCommand.ts
+++ b/server/src/cli/settings/settingsViewCommand.ts
@@ -1,0 +1,45 @@
+import { at, isArray, isEmpty } from 'lodash-es';
+import { CommandModule } from 'yargs';
+import { getSettings } from '../../dao/settings';
+
+type SettingsViewCommandArgs = {
+  pretty: boolean;
+  path?: string[];
+};
+
+export const SettingsViewCommand: CommandModule<
+  SettingsViewCommandArgs,
+  SettingsViewCommandArgs
+> = {
+  command: 'view',
+  builder: (yargs) =>
+    yargs
+      .option('pretty', {
+        type: 'boolean',
+        default: false,
+        desc: 'Print settings JSON with spacing',
+      })
+      .option('path', {
+        type: 'string',
+        array: true,
+        desc: 'Filter settings JSON down to one or more paths in JSON path syntax (e.g. settings.ffmpeg.ffmpegExecutablePath)',
+      }),
+  // eslint-disable-next-line @typescript-eslint/require-await
+  handler: async (args) => {
+    const settings = getSettings();
+    let viewSettings: unknown;
+    if (!isEmpty(args.path)) {
+      viewSettings = at(settings.getAll(), args.path ?? []);
+    } else {
+      viewSettings = settings.getAll();
+    }
+
+    if (isArray(viewSettings) && !isEmpty(viewSettings)) {
+      viewSettings = viewSettings[0];
+    }
+
+    console.log(
+      JSON.stringify(viewSettings, null, args.pretty ? 4 : undefined),
+    );
+  },
+};

--- a/server/src/globals.ts
+++ b/server/src/globals.ts
@@ -8,6 +8,7 @@ import dbConfig from '../mikro-orm.config.js';
 export type ServerOptions = GlobalOptions & {
   port: number;
   printRoutes: boolean;
+  admin: boolean;
 };
 
 export type GlobalOptions = {

--- a/server/src/types/schemas.ts
+++ b/server/src/types/schemas.ts
@@ -7,4 +7,4 @@ export const TruthyQueryParam = z
     z.literal('false'),
     z.coerce.number(),
   ])
-  .transform((value) => value === true || value === 'true');
+  .transform((value) => value === 1 || value === true || value === 'true');

--- a/server/src/util/strings.ts
+++ b/server/src/util/strings.ts
@@ -1,0 +1,13 @@
+/**
+ * Performs a naive sanitization for passing user-inputted text to
+ * child_process exec:
+ *  1. Removes shell metacharacters
+ *  2. Removes extra whitespace
+ *  3. Trims repeating whitespace in between args
+ */
+export function sanitizeForExec(executable: string): string {
+  return executable
+    .replace(/[|;<>"'`$()&\\\n]/gm, '')
+    .trim()
+    .replace(/\s+/g, ' ');
+}

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -202,6 +202,7 @@ export const SystemSettingsResponseSchema = SystemSettingsSchema.extend({
   logging: LoggingSettingsSchema.extend({
     environmentLogLevel: LogLevelsSchema.optional(),
   }),
+  adminMode: z.boolean(),
 });
 
 export type SystemSettingsResponse = z.infer<

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -96,7 +96,7 @@ export const FfmpegSettingsSchema = z.object({
   normalizeAudioCodec: z.boolean().default(true),
   normalizeResolution: z.boolean().default(true),
   normalizeAudio: z.boolean().default(true),
-  maxFPS: z.number().default(60),
+  maxFPS: z.coerce.number().min(1).max(240).default(60),
   scalingAlgorithm: z
     .union([
       z.literal('bicubic'),

--- a/web/src/external/settingsApi.ts
+++ b/web/src/external/settingsApi.ts
@@ -2,6 +2,7 @@ import { SystemSettingsSchema } from '@tunarr/types';
 import {
   InsertMediaSourceRequestSchema,
   JellyfinLoginRequest,
+  SystemSettingsResponseSchema,
   UpdateMediaSourceRequestSchema,
   UpdateSystemSettingsRequestSchema,
 } from '@tunarr/types/api';
@@ -118,7 +119,7 @@ const updatePlexStreamSettings = makeEndpoint({
 const getSystemSettings = makeEndpoint({
   method: 'get',
   path: '/api/system/settings',
-  response: SystemSettingsSchema,
+  response: SystemSettingsResponseSchema,
   alias: 'getSystemSettings',
 });
 

--- a/web/src/hooks/useSystemSettings.ts
+++ b/web/src/hooks/useSystemSettings.ts
@@ -1,10 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { UpdateSystemSettingsRequest } from '@tunarr/types/api';
-import { useApiQuery } from './useApiQuery.ts';
+import { useApiQuery, useApiSuspenseQuery } from './useApiQuery.ts';
 import { useTunarrApi } from './useTunarrApi.ts';
 
 export const useSystemSettings = () =>
   useApiQuery({
+    queryFn(api) {
+      return api.getSystemSettings();
+    },
+    queryKey: ['system', 'settings'],
+  });
+
+export const useSystemSettingsSuspense = () =>
+  useApiSuspenseQuery({
     queryFn(api) {
       return api.getSystemSettings();
     },

--- a/web/src/pages/settings/FfmpegSettingsPage.tsx
+++ b/web/src/pages/settings/FfmpegSettingsPage.tsx
@@ -1,6 +1,8 @@
 import { TranscodeResolutionOptions } from '@/helpers/constants.ts';
+import { useSystemSettingsSuspense } from '@/hooks/useSystemSettings.ts';
 import { HelpOutline } from '@mui/icons-material';
 import {
+  Alert,
   Box,
   Button,
   Checkbox,
@@ -174,6 +176,7 @@ export default function FfmpegSettingsPage() {
     queryKey: ['ffmpeg-info'],
     queryFn: (apiClient) => apiClient.getFfmpegInfo(),
   });
+  const systemSettings = useSystemSettingsSuspense();
 
   const {
     reset,
@@ -656,10 +659,18 @@ export default function FfmpegSettingsPage() {
   return (
     <Box component="form" onSubmit={handleSubmit(updateFfmpegSettings)}>
       <Stack spacing={2} useFlexGap>
+        {!systemSettings.data.adminMode && (
+          <Alert severity="info">
+            Tunarr must be run in admin mode in order to update the FFmpeg and
+            FFprobe executable paths. The paths can also be updated from the
+            command line.
+          </Alert>
+        )}
         <FormControl fullWidth>
           <Controller
             control={control}
             name="ffmpegExecutablePath"
+            disabled={!systemSettings.data.adminMode}
             render={({ field }) => (
               <TextField
                 id="ffmpeg-executable-path"
@@ -676,6 +687,7 @@ export default function FfmpegSettingsPage() {
           <Controller
             control={control}
             name="ffprobeExecutablePath"
+            disabled={!systemSettings.data.adminMode}
             render={({ field }) => (
               <TextField
                 id="ffprobe-executable-path"


### PR DESCRIPTION
Recently a RCE vulnerability was reported on dizqueTV relating to ffmpeg
executable settings: https://www.exploit-db.com/exploits/52079. Tunarr
still used a version of this code, namely Node's child_process.exec()
function to extract information from the configured ffmpeg executable
path. It did not perform the necessary sanitation on user input which
allowed bad actors to potentially expose sensitive information in the
Tunarr UI, **IFF** Tunarr was exposed to the open internet.

This change adds a few mechanisms to help mitigate this vulnerability:

1. All shell metacharacters are removed before passing user input to
   child_process.exec()
2. The configured executable setting is run through fs.stat before
   execution (this _mostly_ protects against non-executable file
settings, but would not protect against arbitrarily executing a file on
the host system)
3. Adds "admin mode" -- this mode is disabled by default. ffmpeg/ffprobe
   settings can only be configured via the UI/API when Tunarr server is
run in admin mode.
4. Exposes a CLI for updating Tunarr settings arbitrarily. This allows
   settings updates on a live, non-admin mode Tunarr instance. Requires
host machine access, naturally
