### PR TITLE
fix: resolve Jellyfin items when underlying file changes

### DIFF
--- a/server/src/api/debug/debugJellyfinApi.ts
+++ b/server/src/api/debug/debugJellyfinApi.ts
@@ -1,6 +1,7 @@
 import { isNil } from 'lodash-es';
 import { z } from 'zod';
 import { JellyfinApiClient } from '../../external/jellyfin/JellyfinApiClient.ts';
+import { JellyfinItemFinder } from '../../external/jellyfin/JellyfinItemFinder.ts';
 import { RouterPluginAsyncCallback } from '../../types/serverType.ts';
 import { Nilable } from '../../types/util.ts';
 
@@ -60,6 +61,22 @@ export const DebugJellyfinApiRouter: RouterPluginAsyncCallback = async (
       await res.send(
         await client.getItems(null, req.query.parentId, [], [], pageParams),
       );
+    },
+  );
+
+  fastify.get(
+    '/jellyfin/match_program/:id',
+    {
+      schema: {
+        params: z.object({
+          id: z.string(),
+        }),
+      },
+    },
+    async (req, res) => {
+      const finder = new JellyfinItemFinder(req.serverCtx.programDB);
+      const match = await finder.findForProgramId(req.params.id);
+      return res.status(match ? 200 : 404).send(match);
     },
   );
 };

--- a/server/src/api/jellyfinApi.ts
+++ b/server/src/api/jellyfinApi.ts
@@ -172,8 +172,8 @@ export const jellyfinApiRouter: RouterPluginCallback = (fastify, _, done) => {
             nameStartsWithOrGreater: req.query.nameStartsWithOrGreater,
             nameStartsWith: req.query.nameStartsWith,
             nameLessThan: req.query.nameLessThan,
-            genres: req.query.genres?.join('|'),
-            recursive: req.query.recursive?.toString(),
+            genres: req.query.genres,
+            recursive: req.query.recursive,
           },
           isNonEmptyTyped(req.query.sortBy)
             ? req.query.sortBy

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -60,7 +60,7 @@ export async function initDbDirectories() {
 
 export async function bootstrapTunarr() {
   await initDbDirectories();
-  initDirectDbAccess(globalOptions());
+  initDirectDbAccess(path.join(globalOptions().databaseDirectory, 'db.db'));
   await syncMigrationTablesIfNecessary();
   const settingsDb = getSettings();
   LoggerFactory.initialize(settingsDb);

--- a/server/src/dao/converters/ProgramMinter.ts
+++ b/server/src/dao/converters/ProgramMinter.ts
@@ -198,26 +198,22 @@ class ProgramDaoMinter {
     };
   }
 
-  mintRawExternalIds(
+  mintExternalIds(
     serverName: string,
     programId: string,
     originalProgram: ContentProgramOriginalProgram,
   ) {
     return match(originalProgram)
       .with({ sourceType: 'plex' }, ({ program: originalProgram }) =>
-        this.mintRawExternalIdsForPlex(serverName, programId, originalProgram),
+        this.mintExternalIdsForPlex(serverName, programId, originalProgram),
       )
       .with({ sourceType: 'jellyfin' }, ({ program: originalProgram }) =>
-        this.mintRawExternalIdsForJellyfin(
-          serverName,
-          programId,
-          originalProgram,
-        ),
+        this.mintExternalIdsForJellyfin(serverName, programId, originalProgram),
       )
       .exhaustive();
   }
 
-  mintRawExternalIdsForPlex(
+  mintExternalIdsForPlex(
     serverName: string,
     programId: string,
     media: PlexTerminalMedia,
@@ -266,12 +262,12 @@ class ProgramDaoMinter {
     return [ratingId, guidId, ...externalGuids];
   }
 
-  mintRawExternalIdsForJellyfin(
+  mintJellyfinExternalId(
     serverName: string,
     programId: string,
     media: JellyfinItem,
   ) {
-    const ratingId = {
+    return {
       uuid: v4(),
       createdAt: +dayjs(),
       updatedAt: +dayjs(),
@@ -280,6 +276,14 @@ class ProgramDaoMinter {
       programUuid: programId,
       externalSourceId: serverName,
     } satisfies NewProgramExternalId;
+  }
+
+  mintExternalIdsForJellyfin(
+    serverName: string,
+    programId: string,
+    media: JellyfinItem,
+  ) {
+    const ratingId = this.mintJellyfinExternalId(serverName, programId, media);
 
     const externalGuids = compact(
       map(media.ProviderIds, (externalGuid, guidType) => {

--- a/server/src/dao/direct/derivedTypes.d.ts
+++ b/server/src/dao/direct/derivedTypes.d.ts
@@ -6,6 +6,7 @@ import { FillerShow } from './schema/FillerShow.js';
 import { Program } from './schema/Program.ts';
 import { MinimalProgramExternalId } from './schema/ProgramExternalId.ts';
 import { ProgramGrouping } from './schema/ProgramGrouping.ts';
+import { ProgramGroupingExternalId } from './schema/ProgramGroupingExternalId.ts';
 
 export type ProgramWithRelations = Program & {
   tvShow?: DeepNullable<Partial<ProgramGrouping>> | null;
@@ -55,6 +56,10 @@ export type ChannelFillerShowWithContent = MarkRequired<
 
 export type ProgramWithExternalIds = Program & {
   externalIds: MinimalProgramExternalId[];
+};
+
+export type ProgramGroupingWithExternalIds = ProgramGrouping & {
+  externalIds: ProgramGroupingExternalId[];
 };
 
 // export type DB = Omit<RawType.DB, 'channel' | 'mediaSource'> & {

--- a/server/src/dao/direct/directDbAccess.ts
+++ b/server/src/dao/direct/directDbAccess.ts
@@ -8,8 +8,6 @@ import {
   SqliteDialect,
 } from 'kysely';
 import { findIndex, isError, last, map, once, slice } from 'lodash-es';
-import path from 'path';
-import { GlobalOptions } from '../../globals.ts';
 import { attempt } from '../../util/index.ts';
 import { LoggerFactory } from '../../util/logging/LoggerFactory.ts';
 import {
@@ -25,10 +23,10 @@ let _directDbAccess: Kysely<DB>;
 
 const logger = once(() => LoggerFactory.child({ className: 'DirectDBAccess' }));
 
-export const initDirectDbAccess = once((opts: GlobalOptions) => {
+export const initDirectDbAccess = once((dbName: string) => {
   _directDbAccess = new Kysely<DB>({
     dialect: new SqliteDialect({
-      database: new Sqlite(path.join(opts.databaseDirectory, 'db.db'), {
+      database: new Sqlite(dbName, {
         timeout: 5000,
       }),
     }),

--- a/server/src/dao/direct/schema/Program.ts
+++ b/server/src/dao/direct/schema/Program.ts
@@ -5,7 +5,7 @@ import { MediaSourceType } from './MediaSource.ts';
 import { WithCreatedAt, WithUpdatedAt, WithUuid } from './base.ts';
 
 export const ProgramTypes = ['movie', 'episode', 'track'] as const;
-export const ProgramType: Record<string, ProgramType> = {
+export const ProgramType = {
   Movie: 'movie',
   Episode: 'episode',
   Track: 'track',

--- a/server/src/external/jellyfin/JellyfinItemFinder.test.ts
+++ b/server/src/external/jellyfin/JellyfinItemFinder.test.ts
@@ -1,0 +1,25 @@
+import {
+  initDirectDbAccess,
+  syncMigrationTablesIfNecessary,
+} from '../../dao/direct/directDbAccess.ts';
+import { ProgramDB } from '../../dao/programDB.ts';
+import { JellyfinItemFinder } from './JellyfinItemFinder.ts';
+
+beforeAll(async () => {
+  initDirectDbAccess(':memory:');
+  await syncMigrationTablesIfNecessary();
+});
+
+vi.mock(import('./JellyfinApiClient.ts'), () => {
+  const JellyfinApiClient = vi.fn();
+  JellyfinApiClient.prototype;
+  return { JellyfinApiClient };
+});
+
+describe('JellyfinItemFinder', () => {
+  test('finds item', async () => {
+    const programDB = new ProgramDB();
+    const finder = new JellyfinItemFinder(programDB);
+    console.log(await programDB.getProgramById('Hello'));
+  });
+});

--- a/server/src/external/jellyfin/JellyfinItemFinder.ts
+++ b/server/src/external/jellyfin/JellyfinItemFinder.ts
@@ -1,0 +1,204 @@
+import { JellyfinItem, JellyfinItemKind } from '@tunarr/types/jellyfin';
+import dayjs from 'dayjs';
+import { find, isUndefined, some } from 'lodash-es';
+import { match } from 'ts-pattern';
+import { ProgramMinterFactory } from '../../dao/converters/ProgramMinter.ts';
+import {
+  ProgramExternalIdType,
+  programExternalIdTypeFromJellyfinProvider,
+} from '../../dao/custom_types/ProgramExternalIdType.ts';
+import { ProgramWithExternalIds } from '../../dao/direct/derivedTypes.js';
+import { ProgramType } from '../../dao/direct/schema/Program.ts';
+import { ProgramDB } from '../../dao/programDB.ts';
+import { GlobalScheduler } from '../../services/scheduler.ts';
+import { ReconcileProgramDurationsTask } from '../../tasks/ReconcileProgramDurationsTask.ts';
+import { Maybe } from '../../types/util.ts';
+import { groupByUniq, isDefined } from '../../util/index.ts';
+import { LoggerFactory } from '../../util/logging/LoggerFactory.ts';
+import { isQueryError } from '../BaseApiClient.ts';
+import { MediaSourceApiFactory } from '../MediaSourceApiFactory.ts';
+import { JellyfinGetItemsQuery } from './JellyfinApiClient.ts';
+
+export class JellyfinItemFinder {
+  #logger = LoggerFactory.child({ className: this.constructor.name });
+
+  constructor(private programDB: ProgramDB) {}
+
+  async findForProgramAndUpdate(programId: string) {
+    const program = await this.programDB.getProgramById(programId);
+
+    if (!program) {
+      this.#logger.warn('No program found with ID: %s', programId);
+      return;
+    }
+
+    const potentialApiMatch = await this.findForProgram(program);
+
+    if (!potentialApiMatch) {
+      return;
+    }
+
+    const oldExternalId = find(
+      program.externalIds,
+      (eid) => eid.sourceType === ProgramExternalIdType.JELLYFIN,
+    );
+
+    const minter = ProgramMinterFactory.create();
+    const newExternalId = minter.mintJellyfinExternalId(
+      program.externalSourceId,
+      program.uuid,
+      potentialApiMatch,
+    );
+
+    await this.programDB.replaceProgramExternalId(
+      program.uuid,
+      newExternalId,
+      oldExternalId,
+    );
+
+    // Right now just check if the durations are different.
+    // otherwise we might blow away details we already have, since
+    // Jellyfin collects metadata asynchronously (sometimes)
+    const updatedProgram = minter.mint(program.externalSourceId, {
+      sourceType: 'jellyfin',
+      program: potentialApiMatch,
+    });
+
+    if (updatedProgram.duration !== program.duration) {
+      await this.programDB.updateProgramDuration(
+        program.uuid,
+        updatedProgram.duration,
+      );
+      GlobalScheduler.scheduleOneOffTask(
+        ReconcileProgramDurationsTask.name,
+        dayjs().add(500, 'ms'),
+        new ReconcileProgramDurationsTask(),
+      );
+    }
+
+    return newExternalId;
+  }
+
+  async findForProgramId(programId: string) {
+    const program = await this.programDB.getProgramById(programId);
+    if (!program) {
+      this.#logger.warn('No program found with ID: %s', programId);
+      return;
+    }
+    return this.findForProgram(program);
+  }
+
+  async findForProgram(program: ProgramWithExternalIds) {
+    if (program.sourceType !== 'jellyfin') {
+      this.#logger.warn('Program does not have source type "jellyfin"');
+      return;
+    }
+
+    const jfClient = await MediaSourceApiFactory().getJellyfinByName(
+      program.externalSourceId,
+    );
+
+    if (!jfClient) {
+      this.#logger.error(
+        "Couldn't get jellyfin api client for id: %s",
+        program.externalSourceId,
+      );
+      return;
+    }
+
+    // If we can locate the item on JF, there is no problem.
+    const existingItem = await jfClient.getItem(program.externalKey);
+    if (!isQueryError(existingItem) && isDefined(existingItem.data)) {
+      this.#logger.error(
+        existingItem,
+        'Item exists on Jellyfin - no need to find a new match',
+      );
+      return;
+    }
+
+    // If we find a match we have to:
+    // 1. Update the program
+    // 2. Update its external IDs
+    // 3. Reconcile durations in both the lineup and the guide
+    const getPotentialMatchByType = async (type: ProgramExternalIdType) => {
+      if (idsBySourceType[type]) {
+        const opts: JellyfinGetItemsQuery = {
+          nameStartsWithOrGreater: program.title,
+          recursive: true,
+        };
+
+        switch (type) {
+          case ProgramExternalIdType.TMDB: {
+            opts.hasTmdbId = true;
+            break;
+          }
+          case ProgramExternalIdType.IMDB: {
+            opts.hasImdbId = true;
+            break;
+          }
+          case ProgramExternalIdType.TVDB: {
+            opts.hasTvdbId = true;
+            break;
+          }
+          default:
+            break;
+        }
+
+        const jellyfinItemType: JellyfinItemKind = match(program.type)
+          .returnType<JellyfinItemKind>()
+          .with(ProgramType.Movie, () => 'Movie')
+          .with(ProgramType.Episode, () => 'Episode')
+          .with(ProgramType.Track, () => 'Audio')
+          .exhaustive();
+
+        const queryResult = await jfClient.getItems(
+          null,
+          null,
+          [jellyfinItemType],
+          [],
+          null,
+          opts,
+        );
+
+        if (queryResult.type === 'success') {
+          return find(queryResult.data.Items, (match) =>
+            some(
+              match.ProviderIds,
+              (val, key) =>
+                programExternalIdTypeFromJellyfinProvider(key) === type &&
+                val === idsBySourceType[type].externalKey,
+            ),
+          );
+        } else {
+          this.#logger.error(
+            { error: queryResult },
+            'Error while querying items on Jellyfin',
+          );
+        }
+      }
+      return;
+    };
+
+    // Match on:
+    // 1. Title
+    // 2. external ID type
+    const idsBySourceType = groupByUniq(
+      program.externalIds,
+      (p) => p.sourceType,
+    );
+
+    let possibleMatch: Maybe<JellyfinItem> = await getPotentialMatchByType(
+      ProgramExternalIdType.IMDB,
+    );
+
+    if (isUndefined(possibleMatch)) {
+      possibleMatch = await getPotentialMatchByType(ProgramExternalIdType.TMDB);
+    }
+
+    if (isUndefined(possibleMatch)) {
+      possibleMatch = await getPotentialMatchByType(ProgramExternalIdType.TVDB);
+    }
+
+    return possibleMatch;
+  }
+}

--- a/server/src/stream/jellyfin/JellyfinProgramStream.ts
+++ b/server/src/stream/jellyfin/JellyfinProgramStream.ts
@@ -47,7 +47,8 @@ export class JellyfinProgramStream extends ProgramStream {
     if (!isContentBackedLineupIteam(lineupItem)) {
       return Result.failure(
         new Error(
-          'Lineup item is not backed by Plex: ' + JSON.stringify(lineupItem),
+          'Lineup item is not backed by a media source: ' +
+            JSON.stringify(lineupItem),
         ),
       );
     }
@@ -71,7 +72,6 @@ export class JellyfinProgramStream extends ProgramStream {
     const jellyfinStreamDetails = new JellyfinStreamDetails(
       server,
       this.settingsDB,
-      // new ProgramDB(),
     );
 
     const watermark = await this.getWatermark();

--- a/server/src/testing/getFakeSettingsDb.ts
+++ b/server/src/testing/getFakeSettingsDb.ts
@@ -22,9 +22,10 @@ export async function setTestGlobalOptions(
 ) {
   const tmpName = await createTmpDir({ unsafeCleanup: true });
   setGlobalOptions({
-    databaseDirectory: tmpName,
+    database: tmpName,
     force_migration: false,
     log_level: 'debug',
+    verbose: 0,
     ...(opts ?? {}),
   });
   return globalOptions();


### PR DESCRIPTION
Jellyfin item IDs are not stable. When the underlying file changes in
Jellyfin, apparently even if this file has the same path, Jellyfin will
regenerate the ID. An example of this is when an upgrade occurs to a
file from an *arr suite program. We can use existing IMDB/TMDB/TVDB IDs
we found when initially saving the item to search Jellyfin and find its
replacement. This is done on-the-fly when attempting to stream an item
that is subsequently not found.