### PR TITLE
Fetch Complete Rows in Grid

### DIFF
--- a/web/src/helpers/inlineModalUtil.ts
+++ b/web/src/helpers/inlineModalUtil.ts
@@ -1,4 +1,5 @@
 import { range } from 'lodash-es';
+import { estimateNumberOfColumns } from './util';
 
 // Magic Numbers
 // TODO: eventually grab this data via refs just in case it changes in the future
@@ -13,7 +14,7 @@ export function getImagesPerRow(
   imageWidth: number,
 ): number {
   if (imageWidth <= 0 || containerWidth <= 0) {
-    return 9; // some default value
+    return containerWidth > 0 ? estimateNumberOfColumns(containerWidth) : 8; // some default value
   }
 
   const roundedImageWidth = Math.round(imageWidth * 100) / 100;

--- a/web/src/helpers/util.ts
+++ b/web/src/helpers/util.ts
@@ -497,3 +497,25 @@ export const ifProd = <T>(f: () => T): T | null => {
   }
   return null;
 };
+
+// Hardcoded values for our grid
+// This allows us to calculate estimated columns before images load
+export function estimateNumberOfColumns(containerWidth: number) {
+  if (containerWidth <= 319) {
+    return 1;
+  } else if (containerWidth <= 479) {
+    return 2;
+  } else if (containerWidth <= 639) {
+    return 3;
+  } else if (containerWidth <= 799) {
+    return 4;
+  } else if (containerWidth <= 959) {
+    return 5;
+  } else if (containerWidth <= 1119) {
+    return 6;
+  } else if (containerWidth <= 1279) {
+    return 7;
+  } else {
+    return 8;
+  }
+}


### PR DESCRIPTION
We now estimate the number of columns based on the screen size and fetch a value divisible by that so that we always have a nice clean grid.

I also added in logic so that if a user resizes their screen and breaks that clean grid, their next fetch of items will grab additional items to accommodate the blank spaces and make the grid perfect again.


Fixes: https://github.com/chrisbenincasa/tunarr/issues/858