### PR TITLE
Fetch Complete Rows in Grid for Jellyfin

### DIFF
--- a/web/src/components/channel_config/SelectedProgrammingActions.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingActions.tsx
@@ -86,7 +86,7 @@ export default function SelectedProgrammingActions({
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const snackbar = useSnackbar();
-  const { addSelectedItems, isLoading } = useAddSelectedItems(
+  const { addSelectedItems } = useAddSelectedItems(
     onAddSelectedMedia,
     onAddMediaSuccess,
   );
@@ -177,7 +177,6 @@ export default function SelectedProgrammingActions({
             key={'add-selected-media'}
             icon={smallViewport ? null : <AddCircle />}
             tooltipTitle={<Typography noWrap>Add Media</Typography>}
-            disableInteractive={isLoading}
             tooltipOpen
             delay={250}
             onClick={(e) => addSelectedItems(e)}
@@ -208,7 +207,6 @@ export default function SelectedProgrammingActions({
             tooltipTitle={<Typography noWrap>Select All</Typography>}
             tooltipOpen
             delay={500}
-            disableInteractive={selectAllLoading}
             onClick={() => selectAllItems()}
           />
         )}
@@ -220,7 +218,6 @@ export default function SelectedProgrammingActions({
             tooltipTitle={<Typography noWrap>Unselect All</Typography>}
             tooltipOpen
             delay={1000}
-            arrow={true}
             onClick={() => removeAllItems()}
           />
         )}

--- a/web/src/store/channelEditor/actions.ts
+++ b/web/src/store/channelEditor/actions.ts
@@ -98,7 +98,6 @@ export const safeSetCurrentChannel = (
   programming?: CondensedChannelProgramming,
 ) =>
   useStore.setState(({ channelEditor }) => {
-    console.log('here', { ...channelEditor });
     if (channelEditor.currentEntity?.id !== channel.id) {
       channelEditor.currentEntity = channel;
       channelEditor.originalEntity = channel;


### PR DESCRIPTION
- Adds support for perfect grid fetches in Jellyfin, even when the browser is resized.
- getChunkSize now uses a multiplier (we may need to adjust this to make it more useful) and also takes in the bufferSize to ensure all values can calculate out a perfect grid row.
- Removes some props from `SpeedDialAction` that did nothing and caused noisy console errors
- Removes channelEditor console log to make the console a little less noisy for easier debugging

See similar Plex work here: https://github.com/chrisbenincasa/tunarr/pull/948