### PR TITLE
Disable speed-dial when selecting all media items or adding media

### DIFF
--- a/web/src/components/channel_config/SelectedProgrammingActions.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingActions.tsx
@@ -86,7 +86,7 @@ export default function SelectedProgrammingActions({
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const snackbar = useSnackbar();
-  const { addSelectedItems } = useAddSelectedItems(
+  const { addSelectedItems, isLoading } = useAddSelectedItems(
     onAddSelectedMedia,
     onAddMediaSuccess,
   );
@@ -171,6 +171,7 @@ export default function SelectedProgrammingActions({
         onClose={handleClose}
         onOpen={handleOpen}
         open={open}
+        FabProps={{ disabled: isLoading || selectAllLoading }}
       >
         {selectedMedia.length > 0 && (
           <SpeedDialAction


### PR DESCRIPTION
Temporarily disables Speed Dial when Selecting All OR Adding Media Items

Fixes: https://github.com/chrisbenincasa/tunarr/issues/809