### PR TITLE
Update language to make Name required when adding jellyfin server

### DIFF
--- a/web/src/components/settings/media_source/JelllyfinServerEditDialog.tsx
+++ b/web/src/components/settings/media_source/JelllyfinServerEditDialog.tsx
@@ -324,7 +324,7 @@ export function JellyfinServerEditDialog({ open, onClose, server }: Props) {
                   helperText={
                     error && isNonEmptyString(error.message)
                       ? error.message
-                      : 'Optional. If left blank, the name will be derived from the server'
+                      : 'Enter a name for your Jellyfin Server'
                   }
                 />
               )}


### PR DESCRIPTION
Original goal was to make the name Optional but it turns out there is nothing that currently handles generating that name.  Easier to just make this a required field.

Fixes: https://github.com/chrisbenincasa/tunarr/issues/959