### PR TITLE
Prevent multiple 'select alls' from duplicating selections and inflating counts beyond library size

### DIFF
--- a/web/src/components/channel_config/SelectedProgrammingActions.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingActions.tsx
@@ -103,6 +103,7 @@ export default function SelectedProgrammingActions({
 
   const selectAllItems = () => {
     if (!isNil(selectedServer) && !isNil(selectedLibrary)) {
+      removeAllItems();
       setSelectAllLoading(true);
       let prom: Promise<void>;
       switch (selectedServer.type) {


### PR DESCRIPTION
Every time we click 'select all' I now first unselect everything.  Previously, we were re-selecting everything, causing the selection numbers to inflate exponentially.

Fixes: https://github.com/chrisbenincasa/tunarr/issues/742