### PR TITLE
fix: use stable ID when reporting Plex playback session status

### DIFF
--- a/server/src/external/MediaSourceApiFactory.ts
+++ b/server/src/external/MediaSourceApiFactory.ts
@@ -1,7 +1,7 @@
-import { ChannelDB } from '@/db/ChannelDB.ts';
 import { SettingsDB, getSettings } from '@/db/SettingsDB.ts';
 import { MediaSourceDB } from '@/db/mediaSourceDB.ts';
 import { MediaSourceType } from '@/db/schema/MediaSource.ts';
+import { registerSingletonInitializer } from '@/globals.ts';
 import { Maybe } from '@/types/util.js';
 import { isDefined } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
@@ -165,11 +165,11 @@ export class MediaSourceApiFactoryImpl {
   }
 }
 
-export const MediaSourceApiFactory = (
-  mediaSourceDB: MediaSourceDB = new MediaSourceDB(new ChannelDB()),
-) => {
+registerSingletonInitializer((ctx) => {
   if (!instance) {
-    instance = new MediaSourceApiFactoryImpl(mediaSourceDB);
+    instance = new MediaSourceApiFactoryImpl(ctx.mediaSourceDB);
   }
   return instance;
-};
+});
+
+export const MediaSourceApiFactory = () => instance;

--- a/server/src/external/plex/PlexApiClient.ts
+++ b/server/src/external/plex/PlexApiClient.ts
@@ -1,6 +1,8 @@
 import { Maybe, Nilable } from '@/types/util.js';
 import { getChannelId } from '@/util/channels.js';
 import { isSuccess } from '@/util/index.js';
+import { getTunarrVersion } from '@/util/version.ts';
+import { PlexClientIdentifier } from '@tunarr/shared/constants';
 import {
   PlexDvr,
   PlexDvrsResponse,
@@ -50,6 +52,11 @@ export type PlexApiOptions = {
 
 const PlexCache = new PlexQueryCache();
 
+const PlexHeaders = {
+  'X-Plex-Product': 'Tunarr',
+  'X-Plex-Client-Identifier': PlexClientIdentifier,
+};
+
 export class PlexApiClient extends BaseApiClient {
   private opts: PlexApiOptions;
   private accessToken: string;
@@ -59,6 +66,8 @@ export class PlexApiClient extends BaseApiClient {
       url: opts.uri,
       name: opts.name,
       extraHeaders: {
+        ...PlexHeaders,
+        'X-Plex-Version': getTunarrVersion(),
         'X-Plex-Token': opts.accessToken,
       },
     });

--- a/server/src/globals.ts
+++ b/server/src/globals.ts
@@ -4,6 +4,7 @@ import once from 'lodash-es/once.js';
 import path, { resolve } from 'node:path';
 import { ServerArgsType } from './cli/RunServerCommand.ts';
 import { GlobalArgsType } from './cli/types.ts';
+import { ServerContext } from './serverContext.ts';
 import { LogLevels } from './util/logging/LoggerFactory.ts';
 
 export type GlobalOptions = GlobalArgsType & {
@@ -81,11 +82,11 @@ export const dbOptions = () => {
   };
 };
 
-type Initializer = () => unknown;
+type Initializer<T> = (ctx: ServerContext) => T;
 let initalized = false;
-const initializers: Initializer[] = [];
+const initializers: Initializer<unknown>[] = [];
 
-export const registerSingletonInitializer = <T>(f: () => T) => {
+export const registerSingletonInitializer = <T>(f: Initializer<T>) => {
   if (initalized) {
     throw new Error(
       'Attempted to register singleton after intialization. This singleton will never be initialized!!',
@@ -95,7 +96,7 @@ export const registerSingletonInitializer = <T>(f: () => T) => {
   initializers.push(f);
 };
 
-export const initializeSingletons = once(() => {
-  forEach(initializers, (f) => f());
+export const initializeSingletons = once((ctx: ServerContext) => {
+  forEach(initializers, (f) => f(ctx));
   initalized = true;
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -97,9 +97,8 @@ export async function initServer(opts: ServerOptions) {
 
   logger.info('Using Tunarr database directory: %s', opts.databaseDirectory);
 
-  initializeSingletons();
-
   const ctx = serverContext();
+  initializeSingletons(ctx);
   registerHealthChecks(ctx);
   await ctx.m3uService.clearCache();
   await new ChannelLineupMigrator(ctx.channelDB).run();

--- a/server/src/services/dynamic_channels/PlexContentSourceUpdater.ts
+++ b/server/src/services/dynamic_channels/PlexContentSourceUpdater.ts
@@ -3,6 +3,7 @@ import { ProgramDB } from '@/db/ProgramDB.ts';
 import { PendingProgram } from '@/db/derived_types/Lineup.ts';
 import { MediaSourceDB } from '@/db/mediaSourceDB.ts';
 import { Channel } from '@/db/schema/Channel.ts';
+import { MediaSourceApiFactory } from '@/external/MediaSourceApiFactory.ts';
 import { PlexApiClient } from '@/external/plex/PlexApiClient.js';
 import { Logger, LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { Timer } from '@/util/perf.js';
@@ -44,7 +45,7 @@ export class PlexContentSourceUpdater extends ContentSourceUpdater<DynamicConten
       throw new Error('media source not found');
     }
 
-    this.#plex = new PlexApiClient(server);
+    this.#plex = MediaSourceApiFactory().get(server);
   }
 
   protected async run() {

--- a/server/src/tasks/UpdateXmlTvTask.ts
+++ b/server/src/tasks/UpdateXmlTvTask.ts
@@ -1,7 +1,7 @@
 import { ChannelDB } from '@/db/ChannelDB.ts';
 import { SettingsDB, defaultXmlTvSettings } from '@/db/SettingsDB.ts';
 import { MediaSourceDB } from '@/db/mediaSourceDB.ts';
-import { PlexApiClient } from '@/external/plex/PlexApiClient.js';
+import { MediaSourceApiFactory } from '@/external/MediaSourceApiFactory.ts';
 import { globalOptions } from '@/globals.js';
 import { ServerContext } from '@/serverContext.js';
 import { TVGuideService } from '@/services/TvGuideService.ts';
@@ -92,7 +92,7 @@ export class UpdateXmlTvTask extends Task<void> {
     const allMediaSources = await this.mediaSourceDB.findByType('plex');
 
     await mapAsyncSeq(allMediaSources, async (plexServer) => {
-      const plex = new PlexApiClient(plexServer);
+      const plex = MediaSourceApiFactory().get(plexServer);
       let dvrs: PlexDvr[] = [];
 
       if (!plexServer.sendGuideUpdates && !plexServer.sendChannelUpdates) {

--- a/server/src/tasks/fixers/addPlexServerIds.ts
+++ b/server/src/tasks/fixers/addPlexServerIds.ts
@@ -1,6 +1,6 @@
 import { getDatabase } from '@/db/DBAccess.ts';
 import { MediaSourceType } from '@/db/schema/MediaSource.ts';
-import { PlexApiClient } from '@/external/plex/PlexApiClient.js';
+import { MediaSourceApiFactory } from '@/external/MediaSourceApiFactory.ts';
 import { find, isNil } from 'lodash-es';
 import Fixer from './fixer.js';
 
@@ -13,7 +13,7 @@ export class AddPlexServerIdsFixer extends Fixer {
       .where('type', '=', MediaSourceType.Plex)
       .execute();
     for (const server of plexServers) {
-      const api = new PlexApiClient(server);
+      const api = MediaSourceApiFactory().get(server);
       const devices = await api.getDevices();
       if (!isNil(devices) && devices.MediaContainer.Device) {
         const matchingServer = find(

--- a/server/src/tasks/fixers/missingSeasonNumbersFixer.ts
+++ b/server/src/tasks/fixers/missingSeasonNumbersFixer.ts
@@ -52,10 +52,8 @@ export class MissingSeasonNumbersFixer extends Fixer {
       return;
     }
 
-    const plexByName = groupByUniqPropAndMap(
-      allPlexServers,
-      'name',
-      (server) => new PlexApiClient(server),
+    const plexByName = groupByUniqPropAndMap(allPlexServers, 'name', (server) =>
+      MediaSourceApiFactory().get(server),
     );
 
     const updatedPrograms: RawProgram[] = [];

--- a/shared/src/util/constants.ts
+++ b/shared/src/util/constants.ts
@@ -7,7 +7,7 @@ const constants = {
   DEFAULT_DATA_DIR: '.tunarr',
 };
 
-const PlexClientIdentifier = 'p86cy1w47clco3ro8t92nfy1';
+export const PlexClientIdentifier = 'p86cy1w47clco3ro8t92nfy1';
 
 export const DefaultPlexHeaders = {
   Accept: 'application/json',
@@ -17,7 +17,7 @@ export const DefaultPlexHeaders = {
   'X-Plex-Version': '0.1',
   'X-Plex-Client-Identifier': PlexClientIdentifier,
   'X-Plex-Platform': 'Chrome',
-  'X-Plex-Platform-Version': '80.0',
+  'X-Plex-Platform-Version': '130.0',
 };
 
 export default constants;

--- a/web/src/helpers/plexLogin.ts
+++ b/web/src/helpers/plexLogin.ts
@@ -4,7 +4,10 @@ import { ApiClient } from '../external/api.ts';
 import { AsyncInterval } from './AsyncInterval.ts';
 import { sequentialPromises } from './util.ts';
 
-// From Plex: The Client Identifier identifies the specific instance of your app. A random string or UUID is sufficient here. There are no hard requirements for Client Identifier length or format, but once one is generated the client should store and re-use this identifier for subsequent requests.
+// From Plex: The Client Identifier identifies the specific instance of your app.
+// A random string or UUID is sufficient here. There are no hard requirements for
+// Client Identifier length or format, but once one is generated the client should store
+// and re-use this identifier for subsequent requests.
 const ClientIdentifier = 'p86cy1w47clco3ro8t92nfy1';
 
 const PlexLoginHeaders = {


### PR DESCRIPTION
Fixes #960
