### PR TITLE
Fix infinite scroll on list view

### DIFF
--- a/web/src/components/channel_config/MediaItemGrid.tsx
+++ b/web/src/components/channel_config/MediaItemGrid.tsx
@@ -425,7 +425,10 @@ export function MediaItemGrid<PageDataType, ItemType>({
   return (
     <Box
       ref={containerRef}
-      sx={{ position: 'relative', minHeight: containerMinHeight }}
+      sx={{
+        position: 'relative',
+        minHeight: viewType === 'grid' ? containerMinHeight : 'auto',
+      }}
     >
       {showAlphabetFilter && handleAlphaNumFilter && (
         <Box
@@ -524,7 +527,7 @@ export function MediaItemGrid<PageDataType, ItemType>({
           No results
         </Typography>
       )}
-      {data && scrollParams.max !== 0 && !hasNextPage && (
+      {data && scrollParams.max !== 0 && viewType != 'list' && !hasNextPage && (
         <Typography
           variant="h6"
           fontStyle={'italic'}


### PR DESCRIPTION
2 things, this should fix the infinite scroll issue when switching to list view.  It also fixes an issue where we display "The End" for a list view all the time.  This is confusing for users of the List View so I opted to hide that messaging for them.  We would need to bind that message to the end of the virtualized list but I don't think the message is that much of a value add at the moment.  We would probably want to rethink how we display # of returned items, end of lists, etc all together.

Fixes: https://github.com/chrisbenincasa/tunarr/issues/830