### PR TITLE
fix: implement "slot pad" mode in random slots

### DIFF
--- a/server/src/util/dayjs.ts
+++ b/server/src/util/dayjs.ts
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
+import timezone from 'dayjs/plugin/timezone.js';
+import utc from 'dayjs/plugin/utc.js';
 
 dayjs.extend(duration);
+dayjs.extend(timezone);
+dayjs.extend(utc);
 
 export default dayjs;

--- a/shared/package.json
+++ b/shared/package.json
@@ -29,7 +29,7 @@
     "bundle": "tsup",
     "build": "tsup --dts",
     "clean": "rimraf ./build/",
-    "dev": "tsup --watch",
+    "dev": "tsup --watch --dts",
     "test": "vitest"
   },
   "dependencies": {

--- a/shared/src/services/slotSchedulerUtil.ts
+++ b/shared/src/services/slotSchedulerUtil.ts
@@ -135,6 +135,15 @@ export function createProgramIterators(
           const program = first(programBySlotType.redirect[slotId] ?? []);
           if (program) {
             acc[id] = new StaticProgramIterator(program);
+          } else {
+            acc[id] = new StaticProgramIterator({
+              type: 'redirect',
+              channel: slot.programming.channelId,
+              channelName: slot.programming.channelName ?? '',
+              channelNumber: -1,
+              duration: 1,
+              persisted: false,
+            });
           }
         } else if (slot.programming.type === 'custom-show') {
           acc[id] =

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -1,12 +1,12 @@
+export { mod as dayjsMod } from './dayjsExtensions.js';
 export * from './plexSearchUtil.js';
+export * as seq from './seq.js';
 import { ChannelProgram } from '@tunarr/types';
 import { PlexMedia } from '@tunarr/types/plex';
+import { isNull } from 'lodash-es';
 import isFunction from 'lodash-es/isFunction.js';
 import { MarkRequired } from 'ts-essentials';
 import type { PerTypeCallback } from '../types/index.js';
-import { isNull } from 'lodash-es';
-export { mod as dayjsMod } from './dayjsExtensions.js';
-export * as seq from './seq.js';
 
 export function applyOrValueNoRest<Super, X extends Super, T>(
   f: ((m: X) => T) | T,
@@ -119,3 +119,9 @@ export function nullToUndefined<T>(x: T | null | undefined): T | undefined {
   }
   return x;
 }
+
+export const flushEventLoop = async () => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};

--- a/types/src/api/Scheduling.ts
+++ b/types/src/api/Scheduling.ts
@@ -20,6 +20,7 @@ const FlexProgrammingSlotSchema = z.object({
 const RedirectProgrammingSlotSchema = z.object({
   type: z.literal('redirect'),
   channelId: z.string(),
+  channelName: z.string().optional(),
 });
 
 const CustomShowProgrammingSlotSchema = z.object({

--- a/web/src/components/channel_config/ChannelProgrammingList.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingList.tsx
@@ -22,8 +22,8 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import { ChannelProgram } from '@tunarr/types';
 import dayjs, { Dayjs } from 'dayjs';
-import { findIndex, isUndefined, map, sumBy } from 'lodash-es';
-import { CSSProperties, useCallback, useState } from 'react';
+import { findIndex, isString, isUndefined, map, sumBy } from 'lodash-es';
+import React, { CSSProperties, useCallback, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import {
   FixedSizeList,
@@ -63,6 +63,7 @@ type CommonProps = {
   enableRowEdit?: boolean;
   enableRowDelete?: boolean;
   showProgramCount?: boolean;
+  listEmptyMessage?: React.ReactNode;
 };
 
 type DirectPassedProgramProps = {
@@ -90,6 +91,7 @@ const defaultProps: MarkRequired<
   deleteProgram: deleteProgram,
   enableDnd: true,
   showProgramCount: true,
+  listEmptyMessage: 'No ',
 };
 
 type ListItemProps = {
@@ -430,11 +432,20 @@ export default function ChannelProgrammingList(props: Props) {
     }
 
     if (programList.length === 0) {
+      const msg = isString(props.listEmptyMessage) ? (
+        <Typography align="center" sx={{ my: 4, fontStyle: 'italic' }}>
+          {props.listEmptyMessage}
+        </Typography>
+      ) : (
+        props.listEmptyMessage
+      );
       return (
         <Box width={'100%'}>
-          <Typography align="center" sx={{ my: 4, fontStyle: 'italic' }}>
-            No programming added yet
-          </Typography>
+          {msg ?? (
+            <Typography align="center" sx={{ my: 4, fontStyle: 'italic' }}>
+              No programming added yet
+            </Typography>
+          )}
         </Box>
       );
     }

--- a/web/src/components/slot_scheduler/RandomSlotRow.tsx
+++ b/web/src/components/slot_scheduler/RandomSlotRow.tsx
@@ -8,11 +8,19 @@ import {
   Select,
   Tooltip,
 } from '@mui/material';
-import { RandomSlot, RandomSlotProgramming } from '@tunarr/types/api';
+import {
+  RandomSlot,
+  RandomSlotProgramming,
+  RedirectProgrammingRandomSlot,
+} from '@tunarr/types/api';
 import { map, range } from 'lodash-es';
 import React, { useCallback } from 'react';
 import { Control, UseFormSetValue, useWatch } from 'react-hook-form';
-import { DropdownOption, ProgramOption } from '../../helpers/slotSchedulerUtil';
+import {
+  DropdownOption,
+  ProgramOption,
+  RedirectProgramOption,
+} from '../../helpers/slotSchedulerUtil';
 import { handleNumericFormValue } from '../../helpers/util';
 import { RandomSlotForm } from '../../pages/channels/RandomSlotEditorPage';
 
@@ -80,10 +88,15 @@ export const RandomSlotRow = React.memo(
             type: 'flex',
           };
         } else if (slotId.startsWith('redirect')) {
+          const channelId = slotId.split('.')[1];
           slotProgram = {
             type: 'redirect',
-            channelId: slotId.split('.')[1],
-          };
+            channelId,
+            channelName: programOptions.find(
+              (opt): opt is RedirectProgramOption =>
+                opt.type === 'redirect' && opt.channelId === channelId,
+            )?.channelName,
+          } satisfies RedirectProgrammingRandomSlot;
         } else if (slotId.startsWith('custom-show')) {
           slotProgram = {
             type: 'custom-show',

--- a/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
+++ b/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
@@ -1,0 +1,273 @@
+import {
+  DropdownOption,
+  flexOptions,
+  padOptions,
+} from '@/helpers/slotSchedulerUtil';
+import { RandomSlotForm } from '@/pages/channels/RandomSlotEditorPage';
+import {
+  appendToCurrentLineup,
+  setChannelStartTime,
+  setCurrentLineup,
+} from '@/store/channelEditor/actions';
+import { useChannelEditorLazy } from '@/store/selectors';
+import { UIChannelProgram } from '@/types';
+import { Autorenew } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  FormGroup,
+  FormHelperText,
+  Grid2 as Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+import { scheduleRandomSlots } from '@tunarr/shared';
+import { RandomSlotSchedule } from '@tunarr/types/api';
+import { useToggle } from '@uidotdev/usehooks';
+import dayjs from 'dayjs';
+import { useSnackbar } from 'notistack';
+import pluralize from 'pluralize';
+import { Controller, useFormContext } from 'react-hook-form';
+import { RotatingLoopIcon } from '../base/LoadingIcon';
+import { NumericFormControllerText } from '../util/TypedController';
+
+const distributionOptions: DropdownOption<string>[] = [
+  { value: 'uniform', description: 'Uniform' },
+  { value: 'weighted', description: 'Weighted' },
+];
+
+const padStyleOptions: DropdownOption<RandomSlotSchedule['padStyle']>[] = [
+  { value: 'episode', description: 'Pad Episodes' },
+  { value: 'slot', description: 'Pad Slot' },
+];
+
+type Props = {
+  onCalculateStart?: () => void;
+  onCalculateEnd?: () => void;
+};
+
+export const RandomSlotSettingsForm = ({
+  onCalculateStart,
+  onCalculateEnd,
+}: Props) => {
+  const { control, getValues, watch } = useFormContext<RandomSlotForm>();
+  const padTime = watch('padMs');
+
+  const { materializeNewProgramList: getMaterializedProgramList } =
+    useChannelEditorLazy();
+  const snackbar = useSnackbar();
+  const [isCalculatingSlots, toggleIsCalculatingSlots] = useToggle(false);
+
+  const showPerfSnackbar = (duration: number, numShows: number) => {
+    const message = `Calculated ${dayjs
+      .duration(getValues('maxDays'), 'days')
+      .humanize()} (${numShows} ${pluralize(
+      'program',
+      numShows,
+    )}) of programming in ${duration}ms`;
+    snackbar.enqueueSnackbar(message, {
+      variant: 'info',
+    });
+  };
+
+  const calculateSlots = async () => {
+    performance.mark('guide-start');
+    const now = dayjs.tz();
+    setChannelStartTime(+now);
+    setCurrentLineup([], true);
+    onCalculateStart?.();
+    toggleIsCalculatingSlots(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const it = scheduleRandomSlots(
+      {
+        ...getValues(),
+        timeZoneOffset: new Date().getTimezoneOffset(),
+        type: 'random',
+      },
+      getMaterializedProgramList(),
+      now,
+    );
+
+    let buf: UIChannelProgram[] = [];
+    let offset = 0,
+      index = 0;
+
+    try {
+      for await (const x of it) {
+        buf.push({
+          ...x,
+          originalIndex: index,
+          startTimeOffset: offset,
+        });
+        offset += x.duration;
+        index++;
+
+        // TODO: Look into if we really want this...
+        if (buf.length % 10000 === 0) {
+          appendToCurrentLineup(buf);
+          buf = [];
+        }
+      }
+      appendToCurrentLineup(buf);
+      performance.mark('guide-end');
+      const { duration: ms } = performance.measure(
+        'guide',
+        'guide-start',
+        'guide-end',
+      );
+      showPerfSnackbar(Math.round(ms), buf.length);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      toggleIsCalculatingSlots(false);
+      onCalculateEnd?.();
+    }
+  };
+
+  return (
+    <Box>
+      <Typography sx={{ flexGrow: 1, fontWeight: 600 }}>Settings</Typography>
+      <Grid container columnSpacing={2} justifyContent={'flex-start'}>
+        <Grid size={{ sm: 12, md: 6 }}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel>Pad Times</InputLabel>
+            <Controller
+              control={control}
+              name="padMs"
+              render={({ field }) => (
+                <Select label="Pad Times" {...field}>
+                  {padOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.description}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+
+            <FormHelperText>
+              Ensures programs have a nice-looking start time, it will add Flex
+              time to fill the gaps.
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+        {padTime > 1 && (
+          <Grid size={{ sm: 12, md: 6 }}>
+            <FormControl fullWidth margin="normal">
+              <InputLabel>Pad Style</InputLabel>
+              <Controller
+                control={control}
+                name="padStyle"
+                render={({ field }) => (
+                  <Select label="Pad Style" {...field}>
+                    {padStyleOptions.map((opt) => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.description}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                )}
+              />
+
+              <FormHelperText>
+                <strong>Pad Slot:</strong> Align slot start times to the
+                specified pad time.
+                <br />
+                <strong>Pad Episode:</strong> Align episode start times (within
+                a slot) to the specified pad time. <strong>NOTE:</strong>{' '}
+                Depending on slot length and the chosen pad time, this could
+                potentially create a lot of flex.
+              </FormHelperText>
+            </FormControl>
+          </Grid>
+        )}
+
+        <Grid size={{ sm: 12, md: 6 }}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel>Flex Style</InputLabel>
+            <Controller
+              control={control}
+              name="flexPreference"
+              render={({ field }) => (
+                <Select label="Flex Style" {...field}>
+                  {flexOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.description}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+            <FormHelperText>
+              Usually slots need to add flex time to ensure that the next slot
+              starts at the correct time. When there are multiple videos in the
+              slot, you might prefer to distribute the flex time between the
+              videos or to place most of the flex time at the end of the slot.
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+        <Grid size={{ sm: 12, md: 6 }}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel>Distribution</InputLabel>
+            <Controller
+              control={control}
+              name="randomDistribution"
+              render={({ field }) => (
+                <Select label="Distribution" {...field}>
+                  {distributionOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.description}
+                    </MenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+            <FormHelperText>
+              Uniform means that all slots have an equal chancel to be picked.
+              Weighted makes the configuration of the slots more complicated but
+              allows to tweak the weight for each slot so you can make some
+              slots more likely to be picked than others.
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+        <Grid size={{ sm: 12, md: 6 }}>
+          <FormGroup row>
+            <NumericFormControllerText
+              control={control}
+              prettyFieldName="Days to Precalculate"
+              TextFieldProps={{
+                label: 'Days to Precalculate',
+                fullWidth: true,
+                margin: 'normal',
+              }}
+              name="maxDays"
+            />
+
+            <FormHelperText sx={{ ml: 1 }}>
+              Maximum number of days to precalculate the schedule. Note that the
+              length of the schedule is also bounded by the maximum number of
+              programs allowed in a channel.
+            </FormHelperText>
+          </FormGroup>
+        </Grid>
+      </Grid>
+      <Divider sx={{ my: 4 }} />
+      <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+        <Button
+          variant="contained"
+          onClick={() => calculateSlots().catch(console.error)}
+          disabled={isCalculatingSlots}
+          startIcon={isCalculatingSlots ? <RotatingLoopIcon /> : <Autorenew />}
+        >
+          Refresh Preview
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/web/src/pages/channels/RandomSlotEditorPage.tsx
+++ b/web/src/pages/channels/RandomSlotEditorPage.tsx
@@ -1,52 +1,33 @@
+import { RandomSlotSettingsForm } from '@/components/slot_scheduler/RandomSlotSettingsForm';
 import { useSlotProgramOptions } from '@/hooks/programming_controls/useSlotProgramOptions';
 import { useChannelEditor } from '@/store/selectors';
-import { ArrowBack, Autorenew } from '@mui/icons-material';
+import { ArrowBack } from '@mui/icons-material';
 import {
   Alert,
   Box,
   Button,
   Divider,
-  FormControl,
-  FormGroup,
-  FormHelperText,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
   Stack,
-  TextField,
   Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
 import { Link as RouterLink } from '@tanstack/react-router';
-import { scheduleRandomSlots } from '@tunarr/shared';
 import { RandomSlotSchedule } from '@tunarr/types/api';
+import { useToggle } from '@uidotdev/usehooks';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import { filter, isNil, isUndefined, map } from 'lodash-es';
-import { useSnackbar } from 'notistack';
-import pluralize from 'pluralize';
-import { useCallback, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { filter, isNil, isUndefined } from 'lodash-es';
+import { useCallback } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import PaddedPaper from '../../components/base/PaddedPaper';
 import ChannelProgrammingList from '../../components/channel_config/ChannelProgrammingList';
 import UnsavedNavigationAlert from '../../components/settings/UnsavedNavigationAlert';
 import { RandomSlots } from '../../components/slot_scheduler/RandomSlots';
-import {
-  DropdownOption,
-  flexOptions,
-  lineupItemAppearsInSchedule,
-  padOptions,
-} from '../../helpers/slotSchedulerUtil';
-import { zipWithIndex } from '../../helpers/util';
+import { lineupItemAppearsInSchedule } from '../../helpers/slotSchedulerUtil';
 import { useUpdateLineup } from '../../hooks/useUpdateLineup';
-import {
-  resetLineup,
-  updateCurrentChannel,
-} from '../../store/channelEditor/actions';
-import { UIChannelProgram } from '../../types';
+import { resetLineup } from '../../store/channelEditor/actions';
 
 dayjs.extend(duration);
 
@@ -55,14 +36,9 @@ export type RandomSlotForm = Omit<
   'timeZoneOffset' | 'type'
 >;
 
-const distributionOptions: DropdownOption<string>[] = [
-  { value: 'uniform', description: 'Uniform' },
-  { value: 'weighted', description: 'Weighted' },
-];
-
 const defaultRandomSlotSchedule: RandomSlotSchedule = {
   type: 'random',
-  padStyle: 'episode',
+  padStyle: 'slot',
   randomDistribution: 'uniform',
   flexPreference: 'distribute',
   maxDays: 365,
@@ -78,16 +54,29 @@ export default function RandomSlotEditorPage() {
     schedule: loadedSchedule,
   } = useChannelEditor();
 
-  const updateLineupMutation = useUpdateLineup();
-  const snackbar = useSnackbar();
+  const updateLineupMutation = useUpdateLineup({
+    onSuccess(data) {
+      reset(data.schedule ?? defaultRandomSlotSchedule, {
+        keepDefaultValues: false,
+        keepDirty: false,
+      });
+    },
+  });
+
   const theme = useTheme();
   const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
   const programOptions = useSlotProgramOptions();
+  const [isCalculatingSlots, toggleIsCalculatingSlots] = useToggle(false);
 
   const hasExistingTimeSlotSchedule =
     !isNil(loadedSchedule) && loadedSchedule.type === 'time';
 
-  const [, setStartTime] = useState(channel?.startTime ?? +dayjs());
+  const randomSlotForm = useForm<RandomSlotForm>({
+    defaultValues:
+      !isUndefined(loadedSchedule) && loadedSchedule.type === 'random'
+        ? loadedSchedule
+        : defaultRandomSlotSchedule,
+  });
 
   const {
     control,
@@ -96,31 +85,9 @@ export default function RandomSlotEditorPage() {
     watch,
     formState: { isValid, isDirty },
     reset,
-  } = useForm<RandomSlotForm>({
-    defaultValues:
-      !isUndefined(loadedSchedule) && loadedSchedule.type === 'random'
-        ? loadedSchedule
-        : defaultRandomSlotSchedule,
-  });
-
-  const [generatedList, setGeneratedList] = useState<
-    UIChannelProgram[] | undefined
-  >(undefined);
-
-  const showPerfSnackbar = (duration: number, numShows: number) => {
-    const message = `Calculated ${dayjs
-      .duration(getValues('maxDays'), 'days')
-      .humanize()} (${numShows} ${pluralize(
-      'program',
-      numShows,
-    )}) of programming in ${duration}ms`;
-    snackbar.enqueueSnackbar(message, {
-      variant: 'info',
-    });
-  };
+  } = randomSlotForm;
 
   const resetLineupToSaved = useCallback(() => {
-    setGeneratedList(undefined);
     resetLineup();
     reset();
   }, [reset]);
@@ -145,45 +112,6 @@ export default function RandomSlotEditorPage() {
         programs: filteredLineup,
       },
     });
-  };
-
-  const calculateSlots = () => {
-    performance.mark('guide-start');
-    scheduleRandomSlots(
-      {
-        ...getValues(),
-        timeZoneOffset: new Date().getTimezoneOffset(),
-        type: 'random',
-      },
-      newLineup,
-    )
-      .then((res) => {
-        performance.mark('guide-end');
-        const { duration: ms } = performance.measure(
-          'guide',
-          'guide-start',
-          'guide-end',
-        );
-        showPerfSnackbar(Math.round(ms), res.programs.length);
-        // TODO Adjust for timezone
-        setStartTime(res.startTime);
-        updateCurrentChannel({ startTime: res.startTime });
-        let offset = 0;
-        const uiPrograms: UIChannelProgram[] = map(
-          res.programs,
-          (program, index) => {
-            const newProgram = {
-              ...program,
-              originalIndex: index,
-              startTimeOffset: offset,
-            };
-            offset += program.duration;
-            return newProgram;
-          },
-        );
-        setGeneratedList(uiPrograms);
-      })
-      .catch(console.error);
   };
 
   if (isUndefined(channel)) {
@@ -222,146 +150,26 @@ export default function RandomSlotEditorPage() {
             programOptions={programOptions}
           />
           <Divider sx={{ my: 2 }} />
-          <Box>
-            <Typography sx={{ flexGrow: 1, fontWeight: 600 }}>
-              Settings
-            </Typography>
-            <Grid
-              container
-              spacing={2}
-              columns={16}
-              justifyContent={'flex-start'}
-            >
-              <Grid item sm={16} md={8}>
-                <FormControl fullWidth margin="normal">
-                  <InputLabel>Pad Times</InputLabel>
-                  <Controller
-                    control={control}
-                    name="padMs"
-                    render={({ field }) => (
-                      <Select label="Pad Times" {...field}>
-                        {padOptions.map((opt) => (
-                          <MenuItem key={opt.value} value={opt.value}>
-                            {opt.description}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    )}
-                  />
-
-                  <FormHelperText>
-                    Ensures programs have a nice-looking start time, it will add
-                    Flex time to fill the gaps.
-                  </FormHelperText>
-                </FormControl>
-              </Grid>
-              <Grid item sm={16} md={8}>
-                <FormControl fullWidth margin="normal">
-                  <InputLabel>Flex Style</InputLabel>
-                  <Controller
-                    control={control}
-                    name="flexPreference"
-                    render={({ field }) => (
-                      <Select label="Flex Style" {...field}>
-                        {flexOptions.map((opt) => (
-                          <MenuItem key={opt.value} value={opt.value}>
-                            {opt.description}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    )}
-                  />
-                  <FormHelperText>
-                    Usually slots need to add flex time to ensure that the next
-                    slot starts at the correct time. When there are multiple
-                    videos in the slot, you might prefer to distribute the flex
-                    time between the videos or to place most of the flex time at
-                    the end of the slot.
-                  </FormHelperText>
-                </FormControl>
-              </Grid>
-              <Grid item sm={16} md={8}>
-                <FormControl fullWidth margin="normal">
-                  <InputLabel>Distribution</InputLabel>
-                  <Controller
-                    control={control}
-                    name="randomDistribution"
-                    render={({ field }) => (
-                      <Select label="Distribution" {...field}>
-                        {distributionOptions.map((opt) => (
-                          <MenuItem key={opt.value} value={opt.value}>
-                            {opt.description}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    )}
-                  />
-                  <FormHelperText>
-                    Uniform means that all slots have an equal chancel to be
-                    picked. Weighted makes the configuration of the slots more
-                    complicated but allows to tweak the weight for each slot so
-                    you can make some slots more likely to be picked than
-                    others.
-                  </FormHelperText>
-                </FormControl>
-              </Grid>
-              <Grid item sm={16} md={8}>
-                <FormGroup row>
-                  <Controller
-                    control={control}
-                    name="maxDays"
-                    render={({ field }) => (
-                      <TextField
-                        fullWidth
-                        margin="normal"
-                        label="Days to Precalculate"
-                        // error={!precalcDaysValid}
-                        {...field}
-                      />
-                    )}
-                  />
-
-                  <FormHelperText sx={{ ml: 1 }}>
-                    Maximum number of days to precalculate the schedule. Note
-                    that the length of the schedule is also bounded by the
-                    maximum number of programs allowed in a channel.
-                  </FormHelperText>
-                </FormGroup>
-              </Grid>
-            </Grid>
-            <Divider sx={{ my: 4 }} />
-            <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
-              <Button
-                variant="contained"
-                onClick={() => calculateSlots()}
-                disabled={!isValid || !isDirty}
-                startIcon={<Autorenew />}
-              >
-                Refresh Preview
-              </Button>
-            </Box>
-          </Box>
+          <FormProvider {...randomSlotForm}>
+            <RandomSlotSettingsForm
+              onCalculateStart={() => toggleIsCalculatingSlots(true)}
+              onCalculateEnd={() => toggleIsCalculatingSlots(false)}
+            />
+          </FormProvider>
         </PaddedPaper>
         <PaddedPaper>
           <Typography sx={{ pb: 1 }}>Programming Preview</Typography>
 
           <Divider />
-          {generatedList ? (
-            <ChannelProgrammingList
-              type={'direct'}
-              programList={zipWithIndex(generatedList)}
-              enableDnd={false}
-              virtualListProps={{
-                width: '100%',
-                height: 400,
-                itemSize: smallViewport ? 70 : 35,
-                overscanCount: 5,
-              }}
-            />
-          ) : (
+          <Box sx={{ minHeight: 400 }}>
             <ChannelProgrammingList
               type="selector"
               enableDnd={false}
+              enableRowDelete={false}
+              enableRowEdit={false}
+              listEmptyMessage={
+                isCalculatingSlots ? 'Calculating Slots...' : null
+              }
               virtualListProps={{
                 width: '100%',
                 height: 400,
@@ -369,7 +177,7 @@ export default function RandomSlotEditorPage() {
                 overscanCount: 5,
               }}
             />
-          )}
+          </Box>
         </PaddedPaper>
       </Stack>
       <UnsavedNavigationAlert isDirty={isDirty} />
@@ -392,7 +200,7 @@ export default function RandomSlotEditorPage() {
         )}
         <Button
           variant="contained"
-          disabled={!isValid || !isDirty}
+          disabled={!isValid}
           onClick={() => onSave()}
         >
           Save

--- a/web/src/pages/channels/TimeSlotEditorPage.tsx
+++ b/web/src/pages/channels/TimeSlotEditorPage.tsx
@@ -109,7 +109,7 @@ function sanitizeStartTimes(schedule: TimeSlotSchedule) {
 export default function TimeSlotEditorPage() {
   const {
     channelEditor: { currentEntity: channel, schedule: loadedSchedule },
-    getMaterializedProgramList,
+    materializeNewProgramList: getMaterializedProgramList,
   } = useChannelEditorLazy();
 
   const [startTime, setStartTime] = useState(

--- a/web/src/store/channelEditor/actions.ts
+++ b/web/src/store/channelEditor/actions.ts
@@ -132,6 +132,30 @@ export const setCurrentLineup = (
     }
   });
 
+export const appendToCurrentLineup = (
+  newItems: CondensedChannelProgram[],
+  dirty?: boolean,
+) =>
+  useStore.setState((state) => {
+    if (state.channelEditor.programList.length === 0) {
+      state.channelEditor.programList = addIndexesAndCalculateOffsets(newItems);
+    } else {
+      const lastItem = last(state.channelEditor.programList)!;
+      const nextOffset = lastItem.startTimeOffset + lastItem.duration;
+      state.channelEditor.programList.push(
+        ...addIndexesAndCalculateOffsets(
+          newItems,
+          nextOffset,
+          state.channelEditor.programList.length,
+        ),
+      );
+    }
+    state.channelEditor.programsLoaded = true;
+    if (!isUndefined(dirty)) {
+      state.channelEditor.dirty.programs = dirty;
+    }
+  });
+
 export const resetCurrentLineup = (programming: CondensedChannelProgramming) =>
   useStore.setState((state) => {
     const zippedLineup = addIndexesAndCalculateOffsets(programming.lineup);

--- a/web/src/store/selectors.ts
+++ b/web/src/store/selectors.ts
@@ -90,9 +90,23 @@ export const useChannelEditorLazy = () => {
     [channelEditor.programList, channelEditor.programLookup, materializeLineup],
   );
 
+  const materializeOriginalLineup = useCallback(
+    () =>
+      materializeLineup(
+        channelEditor.originalProgramList,
+        channelEditor.programLookup,
+      ),
+    [
+      channelEditor.originalProgramList,
+      channelEditor.programLookup,
+      materializeLineup,
+    ],
+  );
+
   return {
     channelEditor,
-    getMaterializedProgramList: materializeNewLineup,
+    materializeNewProgramList: materializeNewLineup,
+    materializeOriginalProgramList: materializeOriginalLineup,
   };
 };
 


### PR DESCRIPTION
This enables more tight packing of random slots (i.e. moderate length
slots w/ short shows) by aligngin slots to pad times, instead of
individual episodes within a schedule

This also includes a host of other fixes and improvements for the random
slot algorithm, UI, and slots in general. It also changes the
implementation of random slots to use a generator function - this is a
trial usage
