### PR TITLE
feat(ffmpeg): add audio language preferences

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
 
   web:
     dependencies:
+      '@cospired/i18n-iso-languages':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@emotion/react':
         specifier: ^11.11.1
         version: 11.11.1(@types/react@18.2.15)(react@18.2.0)
@@ -1019,6 +1022,10 @@ packages:
   '@commitlint/types@19.0.3':
     resolution: {integrity: sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==}
     engines: {node: '>=v18'}
+
+  '@cospired/i18n-iso-languages@4.2.0':
+    resolution: {integrity: sha512-vy8cq1176MTxVwB1X9niQjcIYOH29F8Huxtx8hLmT5Uz3l1ztGDGri8KN/4zE7LV2mCT7JrcAoNV/I9yb+lNUw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7921,6 +7928,8 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.0
       chalk: 5.3.0
+
+  '@cospired/i18n-iso-languages@4.2.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/server/src/db/SettingsDB.ts
+++ b/server/src/db/SettingsDB.ts
@@ -161,7 +161,7 @@ export class SettingsDB extends ITypedEventEmitter {
     return this.db.data.settings.plexStream;
   }
 
-  ffmpegSettings(): DeepReadonly<FfmpegSettings> {
+  ffmpegSettings(): FfmpegSettings {
     return this.db.data.settings.ffmpeg;
   }
 

--- a/server/src/migration/db/Migration1735923656.ts
+++ b/server/src/migration/db/Migration1735923656.ts
@@ -1,0 +1,27 @@
+import { CompiledQuery, Kysely, Migration } from 'kysely';
+
+export default {
+  async up(db: Kysely<unknown>): Promise<void> {
+    // Add language preferences to ffmpeg_settings
+    await db.executeQuery(
+      CompiledQuery.raw(`
+        UPDATE settings 
+        SET ffmpeg = json_set(
+          ffmpeg, 
+          '$.languagePreferences', 
+          '{"preferences":[{"iso6391":"en","iso6392":"eng","displayName":"English"}]}'
+        )
+        WHERE json_extract(ffmpeg, '$.languagePreferences') IS NULL;
+      `),
+    );
+  },
+
+  async down(db: Kysely<unknown>): Promise<void> {
+    await db.executeQuery(
+      CompiledQuery.raw(`
+        UPDATE settings 
+        SET ffmpeg = json_remove(ffmpeg, '$.languagePreferences');
+      `),
+    );
+  },
+} satisfies Migration;

--- a/server/src/stream/plex/PlexStreamDetails.ts
+++ b/server/src/stream/plex/PlexStreamDetails.ts
@@ -339,7 +339,9 @@ export class PlexStreamDetails {
           // to pick these streams.
           selected: audioStream.selected,
           default: audioStream.default,
-          language: audioStream.languageCode,
+          language: audioStream.language,
+          languageTag: audioStream.languageTag,
+          languageCode: audioStream.languageCode,
           title: audioStream.displayTitle,
         } satisfies AudioStreamDetails;
       },

--- a/server/src/stream/types.ts
+++ b/server/src/stream/types.ts
@@ -53,6 +53,8 @@ export type AudioStreamDetails = {
   selected?: boolean;
   title?: string;
   language?: string;
+  languageTag?: string;
+  languageCode?: string;
   forced?: boolean;
 };
 

--- a/types/src/LanguagePreferences.ts
+++ b/types/src/LanguagePreferences.ts
@@ -1,0 +1,12 @@
+import z from 'zod';
+import {
+  LanguagePreferenceSchema,
+  LanguagePreferencesSchema,
+} from './schemas/settingsSchemas.js';
+
+export type LanguagePreference = z.infer<typeof LanguagePreferenceSchema>;
+export type LanguagePreferences = z.infer<typeof LanguagePreferencesSchema>;
+
+export const defaultLanguagePreferences = LanguagePreferencesSchema.parse({
+  preferences: [{ iso6391: 'en', displayName: 'English' }],
+});

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -14,3 +14,4 @@ export * from './TranscodeConfig.js';
 export * from './XmlTvSettings.js';
 export * from './misc.js';
 export * from './util.js';
+export * from './LanguagePreferences.js';

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -73,6 +73,16 @@ export const FfmpegNumericLogLevels: Record<
   trace: 56,
 };
 
+export const LanguagePreferenceSchema = z.object({
+  // ISO 639-1 (2-letter)
+  iso6391: z.string().length(2),
+  displayName: z.string(),
+});
+
+export const LanguagePreferencesSchema = z.object({
+  preferences: z.array(LanguagePreferenceSchema).min(1),
+});
+
 export const FfmpegSettingsSchema = z.object({
   configVersion: z.number().default(5),
   ffmpegExecutablePath: z.string().default('/usr/bin/ffmpeg'),
@@ -82,6 +92,9 @@ export const FfmpegSettingsSchema = z.object({
   enableLogging: z.boolean().default(false),
   enableFileLogging: z.boolean().default(false),
   logLevel: z.enum(FfmpegLogLevels).optional().default('warning'),
+  languagePreferences: LanguagePreferencesSchema.default({
+    preferences: [{ iso6391: 'en', displayName: 'English' }],
+  }),
   // DEPRECATED
   enableTranscoding: z.boolean().default(true).describe('DEPRECATED'),
   audioVolumePercent: z.number().default(100),

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
+    "@cospired/i18n-iso-languages": "^4.2.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/web/src/components/LanguagePreferencesList.tsx
+++ b/web/src/components/LanguagePreferencesList.tsx
@@ -1,0 +1,91 @@
+import languages from '@cospired/i18n-iso-languages';
+import en from '@cospired/i18n-iso-languages/langs/en.json';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { Autocomplete, Box, Button, IconButton, Stack, TextField, Typography } from '@mui/material';
+
+// Initialize the languages database with English names
+languages.registerLocale(en);
+
+export interface LanguagePreference {
+    iso6391: string;
+    displayName: string;
+}
+
+interface LanguagePreferencesListProps {
+    preferences: LanguagePreference[];
+    onChange: (preferences: LanguagePreference[]) => void;
+}
+
+// Get all available languages as a map of ISO 639-1 codes to display names
+const languageOptions = Object.entries(languages.getNames('en')).map(([code, name]) => ({
+    iso6391: code,
+    displayName: name
+}));
+
+export function LanguagePreferencesList({ preferences, onChange }: LanguagePreferencesListProps) {
+    const handleAdd = () => {
+        onChange([...preferences, { iso6391: 'en', displayName: 'English' }]);
+    };
+
+    const handleDelete = (index: number) => {
+        if (preferences.length > 1) {
+            onChange(preferences.filter((_, i) => i !== index));
+        }
+    };
+
+    const handleChange = (index: number, value: LanguagePreference | null) => {
+        if (!value) return;
+        const newPreferences = [...preferences];
+        newPreferences[index] = value;
+        onChange(newPreferences);
+    };
+
+    return (
+        <Box>
+            <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>Audio Language Preferences</Typography>
+
+            <Typography variant="subtitle2" sx={{ mb: 1, fontStyle: 'italic' }}>
+                In order of priority
+            </Typography>
+            <Stack spacing={2}>
+                {preferences.map((pref, index) => (
+                    <Stack key={index} direction="row" spacing={2} alignItems="center">
+                        <Autocomplete
+                            fullWidth
+                            value={pref}
+                            onChange={(_, newValue) => handleChange(index, newValue)}
+                            options={languageOptions}
+                            getOptionLabel={(option) => option.displayName}
+                            isOptionEqualToValue={(option, value) => option.iso6391 === value.iso6391}
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    label="Language"
+                                    variant="outlined"
+                                />
+                            )}
+                        />
+                        {preferences.length > 1 && (
+                            <IconButton
+                                onClick={() => handleDelete(index)}
+                                size="small"
+                                aria-label="Delete language preference"
+                            >
+                                <DeleteIcon />
+                            </IconButton>
+                        )}
+                    </Stack>
+                ))}
+
+            </Stack>
+            <Button
+                startIcon={<AddIcon />}
+                variant='outlined'
+                onClick={handleAdd}
+                sx={{ width: 'fit-content', my: 1 }}
+            >
+                Add Language
+            </Button>
+        </Box>
+    );
+} 

--- a/web/src/pages/settings/FfmpegSettingsPage.tsx
+++ b/web/src/pages/settings/FfmpegSettingsPage.tsx
@@ -42,6 +42,7 @@ import UnsavedNavigationAlert from '../../components/settings/UnsavedNavigationA
 import { CheckboxFormController } from '../../components/util/TypedController.tsx';
 
 import { DeleteConfirmationDialog } from '@/components/DeleteConfirmationDialog.tsx';
+import { LanguagePreferencesList } from '@/components/LanguagePreferencesList';
 import {
   useFfmpegSettings,
   useTranscodeConfigs,
@@ -95,7 +96,12 @@ export default function FfmpegSettingsPage() {
     handleSubmit,
     watch,
   } = useForm<Omit<FfmpegSettings, 'configVersion'>>({
-    defaultValues: defaultFfmpegSettings,
+    defaultValues: {
+      ...defaultFfmpegSettings,
+      languagePreferences: {
+        preferences: [{ iso6391: 'en', displayName: 'English' }]
+      }
+    },
     mode: 'onBlur',
   });
 
@@ -265,6 +271,7 @@ export default function FfmpegSettingsPage() {
             command line.
           </Alert>
         )}
+
         <FormControl fullWidth>
           <Controller
             control={control}
@@ -414,6 +421,19 @@ export default function FfmpegSettingsPage() {
         </Button>
       </Stack>
       <Divider sx={{ mt: 2 }} />
+      <FormControl fullWidth>
+        <Controller
+          control={control}
+          name="languagePreferences"
+          render={({ field }) => (
+            <LanguagePreferencesList
+              preferences={field.value?.preferences || [{ iso6391: 'en', displayName: 'English' }]}
+              onChange={(preferences) => field.onChange({ preferences })}
+            />
+          )}
+        />
+      </FormControl>
+      <Divider sx={{ mt: 2 }} />
       <Typography variant="h5" sx={{ mt: 2, mb: 1 }}>
         Transcoding Configs
       </Typography>
@@ -437,5 +457,6 @@ export default function FfmpegSettingsPage() {
         }}
       />
     </Box>
+
   );
 }


### PR DESCRIPTION
- Add language preferences to FFmpeg settings to control audio stream selection
- Implement language matching logic in both FFmpeg implementations
- Add UI component for managing language preferences with ISO 639-1 codes
- Update PlexStreamDetails to correctly map language fields
- Add migration to set default English language preference

BREAKING CHANGE: FFmpeg settings schema updated to include languagePreferences

Resolves #1005

![image](https://github.com/user-attachments/assets/1e3c0929-fad8-4c6f-8bc4-b0ccdc2b573d)