### PR TITLE
feat: improvements to random slot weighting

### DIFF
--- a/types/src/api/Scheduling.ts
+++ b/types/src/api/Scheduling.ts
@@ -168,6 +168,9 @@ export const RandomSlotScheduleSchema = z.object({
   timeZoneOffset: z.number().optional(), // Timezone offset in minutes
   randomDistribution: z.union([z.literal('uniform'), z.literal('weighted')]),
   periodMs: z.number().optional(),
+  // Purely for UI purposes. Adjusting weight of one program affects the
+  // weights of all others if lock weights === true.
+  lockWeights: z.boolean().default(false),
 });
 
 export type RandomSlotSchedule = z.infer<typeof RandomSlotScheduleSchema>;

--- a/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
+++ b/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Divider,
   FormControl,
+  FormControlLabel,
   FormGroup,
   FormHelperText,
   Grid2 as Grid,
@@ -28,7 +29,10 @@ import { useSnackbar } from 'notistack';
 import pluralize from 'pluralize';
 import { Controller, useFormContext } from 'react-hook-form';
 import { RotatingLoopIcon } from '../base/LoadingIcon';
-import { NumericFormControllerText } from '../util/TypedController';
+import {
+  CheckboxFormController,
+  NumericFormControllerText,
+} from '../util/TypedController';
 
 const distributionOptions: DropdownOption<string>[] = [
   { value: 'uniform', description: 'Uniform' },
@@ -50,7 +54,7 @@ export const RandomSlotSettingsForm = ({
   onCalculateEnd,
 }: Props) => {
   const { control, getValues, watch } = useFormContext<RandomSlotForm>();
-  const padTime = watch('padMs');
+  const [padTime, distributionType] = watch(['padMs', 'randomDistribution']);
 
   const { materializeOriginalProgramList } = useChannelEditorLazy();
   const snackbar = useSnackbar();
@@ -78,10 +82,6 @@ export const RandomSlotSettingsForm = ({
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    // let buf: UIChannelProgram[] = [];
-    // let offset = 0,
-    // index = 0;
-
     try {
       const previewPrograms = await scheduleRandomSlots(
         {
@@ -92,23 +92,6 @@ export const RandomSlotSettingsForm = ({
         materializeOriginalProgramList(),
         now,
       );
-      // for await (const program of schedulePreviewGenerator) {
-      //   buf.push({
-      //     ...program,
-      //     originalIndex: index,
-      //     startTimeOffset: offset,
-      //   });
-
-      //   offset += program.duration;
-      //   index++;
-
-      //   // TODO: Look into if we really want this...
-      //   if (buf.length % 10000 === 0) {
-      //     appendToCurrentLineup(buf);
-      //     buf = [];
-      //   }
-      // }
-      // appendToCurrentLineup(buf);
       setCurrentLineup(previewPrograms);
       performance.mark('guide-end');
       const { duration: ms } = performance.measure(
@@ -251,6 +234,28 @@ export const RandomSlotSettingsForm = ({
             </FormHelperText>
           </FormGroup>
         </Grid>
+        {distributionType === 'weighted' && (
+          <Grid size={{ sm: 12, md: 6 }}>
+            <FormGroup row>
+              <FormControlLabel
+                control={
+                  <CheckboxFormController
+                    control={control}
+                    name="lockWeights"
+                  />
+                }
+                label="Lock Weights"
+              />
+
+              <FormHelperText sx={{ ml: 1 }}>
+                If true, adjusting the weight of one slot will scale the weights
+                of other slots such that all weights total 100%. Otherwise,
+                weights can be adjusted freely and the weight of each slot is
+                only relative to the total weight.
+              </FormHelperText>
+            </FormGroup>
+          </Grid>
+        )}
       </Grid>
       <Divider sx={{ my: 4 }} />
       <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>

--- a/web/src/components/slot_scheduler/TimeSlotTable.tsx
+++ b/web/src/components/slot_scheduler/TimeSlotTable.tsx
@@ -39,7 +39,7 @@ dayjs.extend(localizedFormat);
 export const TimeSlotTable = () => {
   const { watch, slotArray } = useTimeSlotFormContext();
   const [currentPeriod, latenessMs] = watch(['period', 'latenessMs']);
-  const programOptions = useSlotProgramOptions();
+  const { dropdownOpts: programOptions } = useSlotProgramOptions();
   const startOfPeriod = dayjs().startOf(currentPeriod);
   const slotIds = useMemo(
     () =>

--- a/web/src/helpers/slotSchedulerUtil.ts
+++ b/web/src/helpers/slotSchedulerUtil.ts
@@ -174,10 +174,10 @@ export const getTimeSlotId = (programming: TimeSlotProgramming): SlotId => {
 export const getRandomSlotId = (programming: RandomSlotProgramming): SlotId => {
   switch (programming.type) {
     case 'show': {
-      return `show.${programming.showId}`;
+      return `${programming.type}.${programming.showId}`;
     }
     case 'redirect': {
-      return `redirect.${programming.channelId}`;
+      return `${programming.type}.${programming.channelId}`;
     }
     case 'custom-show': {
       return `${programming.type}.${programming.customShowId}`;

--- a/web/src/hooks/slot_scheduler/useAdjustRandomSlotWeights.ts
+++ b/web/src/hooks/slot_scheduler/useAdjustRandomSlotWeights.ts
@@ -5,7 +5,7 @@ import { useCallback, useMemo } from 'react';
 export const useAdjustRandomSlotWeights = () => {
   const { watch } = useRandomSlotFormContext();
 
-  const currentSlots = watch('slots');
+  const [currentSlots] = watch(['slots']);
   const weights = useMemo(() => map(currentSlots, 'weight'), [currentSlots]);
 
   return useCallback(
@@ -14,12 +14,15 @@ export const useAdjustRandomSlotWeights = () => {
       if (isNaN(newWeight)) {
         return;
       }
+
       newWeight /= upscaleAmt;
+
       const oldWeight = weights[idx];
       const scale = round((newWeight - oldWeight) / oldWeight, 2);
       if (scale === 0) {
         return;
       }
+
       const newRemainingWeight = 100 - newWeight;
       const oldRemainingWeight = 100 - oldWeight;
 

--- a/web/src/pages/channels/TimeSlotEditorPage.tsx
+++ b/web/src/pages/channels/TimeSlotEditorPage.tsx
@@ -116,7 +116,7 @@ export default function TimeSlotEditorPage() {
   const snackbar = useSnackbar();
   const theme = useTheme();
   const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
-  const programOptions = useSlotProgramOptions();
+  const { dropdownOpts: programOptions } = useSlotProgramOptions();
 
   const [isCalculatingSlots, toggleIsCalculatingSlots] = useToggle(false);
 


### PR DESCRIPTION
Includes the ability to keep weights locked to one another - or by
default, keep them "unlocked" (the classic DTV experience). This is
mainly a UX feature, but serves as the basis for implementing certain
programming tools as random slots (coming in a follow-up). Additionally,
we show actual weights of generated schedules in a tooltip.
