### PR TITLE
feat: implement existing program tools using random slots

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "main": "src/index.ts",
   "bin": "dist/index.js",
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json --noEmit",
     "build-dev": "NODE_ENV=development tsc -p tsconfig.build.json --noEmit --watch",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "bundle": "dotenv -- tsx scripts/bundle.ts",

--- a/server/src/db/ChannelDB.ts
+++ b/server/src/db/ChannelDB.ts
@@ -12,7 +12,7 @@ import { LoggerFactory } from '@/util/logging/LoggerFactory.ts';
 import { MutexMap } from '@/util/mutexMap.ts';
 import { Timer } from '@/util/perf.ts';
 import { booleanToNumber } from '@/util/sqliteUtil.ts';
-import { scheduleRandomSlots, scheduleTimeSlots } from '@tunarr/shared';
+import { RandomSlotScheduler, scheduleTimeSlots } from '@tunarr/shared';
 import { forProgramType, seq } from '@tunarr/shared/util';
 import {
   ChannelProgram,
@@ -770,7 +770,10 @@ export class ChannelDB {
       } else {
         const start = dayjs.tz();
         startTime = +start;
-        programs = await scheduleRandomSlots(req.schedule, req.programs, start);
+        programs = new RandomSlotScheduler(req.schedule).generateSchedule(
+          req.programs,
+          start,
+        );
       }
 
       const newLineup = await createNewLineup(programs);

--- a/server/src/migration/lineups/ChannelLineupMigrator.ts
+++ b/server/src/migration/lineups/ChannelLineupMigrator.ts
@@ -1,5 +1,6 @@
 import { ChannelDB } from '@/db/ChannelDB.ts';
 import { ProgramDB } from '@/db/ProgramDB.ts';
+import { RandomSlotDurationSpecMigration } from '@/migration/lineups/RandomSlotDurationSpecMigration.ts';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.ts';
 import { findIndex, map } from 'lodash-es';
 import {
@@ -9,19 +10,20 @@ import {
 import { ChannelLineupMigration } from './ChannelLineupMigration.ts';
 import { SlotShowIdMigration } from './SlotShowIdMigration.ts';
 
-type MigrationFactory = (
+type MigrationFactory<From extends number, To extends number> = (
   channelDB: ChannelDB,
   programDB: ProgramDB,
-) => ChannelLineupMigration<number, number>;
+) => ChannelLineupMigration<From, To>;
 
-type MigrationStep<From extends number = number, To extends number = number> = [
+type MigrationStep<From extends number, To extends number> = [
   From,
   To,
-  MigrationFactory,
+  MigrationFactory<From, To>,
 ];
 
-const MigrationSteps: MigrationStep[] = [
+const MigrationSteps: MigrationStep<number, number>[] = [
   [0, 1, (cdb, pdb) => new SlotShowIdMigration(cdb, pdb)],
+  [1, 2, (cdb, pdb) => new RandomSlotDurationSpecMigration(cdb, pdb)],
 ] as const;
 
 type MigrationPipeline = [

--- a/server/src/migration/lineups/RandomSlotDurationSpecMigration.ts
+++ b/server/src/migration/lineups/RandomSlotDurationSpecMigration.ts
@@ -1,0 +1,34 @@
+import { Lineup } from '@/db/derived_types/Lineup.ts';
+import { ChannelLineupMigration } from '@/migration/lineups/ChannelLineupMigration.ts';
+import { isUndefined } from 'lodash-es';
+
+export class RandomSlotDurationSpecMigration extends ChannelLineupMigration<
+  1,
+  2
+> {
+  readonly from = 1;
+  readonly to = 2;
+
+  migrate(schema: Lineup): Promise<void> {
+    if (!schema.schedule) {
+      return Promise.resolve();
+    }
+
+    if (schema.schedule.type === 'time') {
+      return Promise.resolve();
+    }
+
+    schema.schedule.slots.forEach((slot) => {
+      if (isUndefined(slot.durationMs)) {
+        return;
+      }
+
+      slot.durationSpec = {
+        type: 'fixed',
+        durationMs: slot.durationMs,
+      };
+    });
+
+    return Promise.resolve();
+  }
+}

--- a/server/src/migration/lineups/SlotShowIdMigration.ts
+++ b/server/src/migration/lineups/SlotShowIdMigration.ts
@@ -22,7 +22,6 @@ export class SlotShowIdMigration extends ChannelLineupMigration<0, 1> {
       switch (slot.programming.type) {
         case 'show':
           await this.handleSlot(slot.programming);
-          console.log(slot.programming);
           break;
         default:
           continue;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,10 +1,10 @@
-import { ExternalId, SingleExternalId, MultiExternalId } from '@tunarr/types';
+import { ExternalId, MultiExternalId, SingleExternalId } from '@tunarr/types';
 import { PlexMedia } from '@tunarr/types/plex';
 import {
   SingleExternalIdType,
   type ExternalIdType,
 } from '@tunarr/types/schemas';
-export { scheduleRandomSlots } from './services/randomSlotsService.js';
+export { RandomSlotScheduler } from './services/randomSlotsService.js';
 export { scheduleTimeSlots } from './services/timeSlotService.js';
 export { mod as dayjsMod } from './util/dayjsExtensions.js';
 

--- a/shared/src/util/debug.ts
+++ b/shared/src/util/debug.ts
@@ -1,0 +1,8 @@
+import { isFunction } from 'lodash-es';
+
+export function devAssert(condition: boolean | (() => boolean)) {
+  const res = isFunction(condition) ? condition() : condition;
+  if (!res) {
+    console.warn(new Error(), 'dev assert failed!');
+  }
+}

--- a/shared/src/util/env.ts
+++ b/shared/src/util/env.ts
@@ -1,0 +1,11 @@
+// Duplicated from server - reference these instead.
+// export const currentEnv = once(() => {
+//   const env = process.env['NODE_ENV'];
+//   return env ?? 'production';
+// });
+
+// export const isProduction = currentEnv() === 'production';
+// export const isDev = currentEnv() === 'development';
+// export const isTest = currentEnv() === 'test';
+// export const isEdgeBuild = process.env['TUNARR_EDGE_BUILD'] === 'true';
+// export const tunarrBuild = process.env['TUNARR_BUILD'];

--- a/shared/src/util/seq.ts
+++ b/shared/src/util/seq.ts
@@ -41,8 +41,17 @@ export function groupBy<T, Key extends string | number | symbol>(
 
   for (const t of arr) {
     const key = f(t);
-    ret[key] ? ret[key].push(t) : (ret[key] = [t]);
+    const v = ret[key];
+    if (v) {
+      v.push(t);
+    } else {
+      ret[key] = [t];
+    }
   }
 
   return ret;
+}
+
+export function rotateArray<T>(arr: T[], positions: number): T[] {
+  return arr.slice(positions, arr.length).concat(arr.slice(0, positions));
 }

--- a/web/src/components/base/StyledMenu.tsx
+++ b/web/src/components/base/StyledMenu.tsx
@@ -1,0 +1,44 @@
+import { Menu, MenuProps, alpha, styled } from '@mui/material';
+
+export const StyledMenu = styled((props: MenuProps) => (
+  <Menu
+    elevation={0}
+    anchorOrigin={{
+      vertical: 'bottom',
+      horizontal: 'right',
+    }}
+    transformOrigin={{
+      vertical: 'top',
+      horizontal: 'right',
+    }}
+    {...props}
+  />
+))(({ theme }) => ({
+  '& .MuiPaper-root': {
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 180,
+    color:
+      theme.palette.mode === 'light'
+        ? 'rgb(55, 65, 81)'
+        : theme.palette.grey[300],
+    boxShadow:
+      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+    '& .MuiMenu-list': {
+      padding: '4px 0',
+    },
+    '& .MuiMenuItem-root': {
+      '& .MuiSvgIcon-root': {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      '&:active': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity,
+        ),
+      },
+    },
+  },
+}));

--- a/web/src/components/channel_config/AddProgrammingButton.tsx
+++ b/web/src/components/channel_config/AddProgrammingButton.tsx
@@ -10,66 +10,20 @@ import {
 import {
   Button,
   ButtonGroup,
-  Menu,
   MenuItem,
-  MenuProps,
   Tooltip,
-  alpha,
-  styled,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import { Link } from '@tanstack/react-router';
 import { isNull } from 'lodash-es';
 import { useState } from 'react';
-import { Link } from '@tanstack/react-router';
+import { StyledMenu } from '../base/StyledMenu';
 import AddBreaksModal from '../programming_controls/AddBreaksModal';
 import AddFlexModal from '../programming_controls/AddFlexModal';
 import AddPaddingModal from '../programming_controls/AddPaddingModal';
 import AddRedirectModal from '../programming_controls/AddRedirectModal';
 import AddRestrictHoursModal from '../programming_controls/AddRestrictHoursModal';
-
-const StyledMenu = styled((props: MenuProps) => (
-  <Menu
-    elevation={0}
-    anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'right',
-    }}
-    transformOrigin={{
-      vertical: 'top',
-      horizontal: 'right',
-    }}
-    {...props}
-  />
-))(({ theme }) => ({
-  '& .MuiPaper-root': {
-    borderRadius: 6,
-    marginTop: theme.spacing(1),
-    minWidth: 180,
-    color:
-      theme.palette.mode === 'light'
-        ? 'rgb(55, 65, 81)'
-        : theme.palette.grey[300],
-    boxShadow:
-      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
-    '& .MuiMenu-list': {
-      padding: '4px 0',
-    },
-    '& .MuiMenuItem-root': {
-      '& .MuiSvgIcon-root': {
-        fontSize: 18,
-        color: theme.palette.text.secondary,
-        marginRight: theme.spacing(1.5),
-      },
-      '&:active': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity,
-        ),
-      },
-    },
-  },
-}));
 
 export default function AddProgrammingButton() {
   const [addRedirectModalOpen, setAddRedirectModalOpen] = useState(false);

--- a/web/src/components/slot_scheduler/AddRandomSlotButton.tsx
+++ b/web/src/components/slot_scheduler/AddRandomSlotButton.tsx
@@ -88,10 +88,13 @@ export const AddRandomSlotButton = ({
 
     const newSlot = {
       programming: programOptionToSlotProgram(programOption),
-      durationMs: dayjs.duration({ minutes: 30 }).asMilliseconds(),
       cooldownMs: 0,
       order: 'next',
       weight,
+      durationSpec: {
+        type: 'fixed',
+        durationMs: dayjs.duration({ minutes: 30 }).asMilliseconds(),
+      },
     } satisfies RandomSlot;
 
     onAdd(newSlot);

--- a/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
+++ b/web/src/components/slot_scheduler/RandomSlotSettingsForm.tsx
@@ -21,7 +21,7 @@ import {
   Select,
   Typography,
 } from '@mui/material';
-import { scheduleRandomSlots } from '@tunarr/shared';
+import { RandomSlotScheduler } from '@tunarr/shared';
 import { RandomSlotSchedule } from '@tunarr/types/api';
 import { useToggle } from '@uidotdev/usehooks';
 import dayjs from 'dayjs';
@@ -83,15 +83,11 @@ export const RandomSlotSettingsForm = ({
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     try {
-      const previewPrograms = await scheduleRandomSlots(
-        {
-          ...getValues(),
-          timeZoneOffset: new Date().getTimezoneOffset(),
-          type: 'random',
-        },
-        materializeOriginalProgramList(),
-        now,
-      );
+      const previewPrograms = new RandomSlotScheduler({
+        ...getValues(),
+        timeZoneOffset: new Date().getTimezoneOffset(),
+        type: 'random',
+      }).generateSchedule(materializeOriginalProgramList(), now);
       setCurrentLineup(previewPrograms);
       performance.mark('guide-end');
       const { duration: ms } = performance.measure(

--- a/web/src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx
+++ b/web/src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx
@@ -150,8 +150,8 @@ export const SlotProgrammingTooLongWarningDetails = ({
             <p>
               {warning.programs.length} of {slot.programCount}{' '}
               {pluralize('program', slot.programCount)} exceed the length of
-              this slot ({betterHumanize(dayjs.duration(slot.durationMs))}).
-              Average program length: {averageLength.humanize()}
+              this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}
+              ). Average program length: {averageLength.humanize()}
               <br />
               This could cause the following slot's programs to go unscheduled.
               Possible solutions include:

--- a/web/src/components/slot_scheduler/SlotTypes.ts
+++ b/web/src/components/slot_scheduler/SlotTypes.ts
@@ -15,7 +15,7 @@ export type RandomSlotTableDataType = FieldArrayWithId<RandomSlotForm, 'slots'>;
 export type SlotTableWarnings = {
   warnings: SlotWarning[];
   programCount: number;
-  durationMs: number;
+  durationMs?: number;
 };
 
 export type TimeSlotTableRowType = TimeSlotTableDataType &

--- a/web/src/helpers/slotSchedulerUtil.ts
+++ b/web/src/helpers/slotSchedulerUtil.ts
@@ -129,6 +129,10 @@ export const showOrderOptions = [
     value: 'shuffle',
     description: 'Shuffle',
   },
+  {
+    value: 'ordered_shuffle',
+    description: 'Ordered Shuffle',
+  },
 ];
 
 export const ProgramOptionTypes: DropdownOption<ProgramOption['type']>[] = [

--- a/web/src/hooks/slot_scheduler/useAdjustRandomSlotWeights.ts
+++ b/web/src/hooks/slot_scheduler/useAdjustRandomSlotWeights.ts
@@ -16,6 +16,7 @@ export const useAdjustRandomSlotWeights = () => {
       }
 
       newWeight /= upscaleAmt;
+      console.log(newWeight);
 
       const oldWeight = weights[idx];
       const scale = round((newWeight - oldWeight) / oldWeight, 2);

--- a/web/src/hooks/slot_scheduler/useCalculatorProgramFrequency.ts
+++ b/web/src/hooks/slot_scheduler/useCalculatorProgramFrequency.ts
@@ -1,0 +1,39 @@
+import { useChannelEditorLazy } from '@/store/selectors.ts';
+import { groupBy, mapValues, round } from 'lodash-es';
+import { useCallback } from 'react';
+
+export const useCalculateProgramFrequency = () => {
+  const { materializeNewProgramList } = useChannelEditorLazy();
+
+  const calculateProgramFrequency = useCallback(() => {
+    const lineup = materializeNewProgramList();
+    const total = lineup.length;
+    return mapValues(
+      groupBy(lineup, (program) => {
+        switch (program.type) {
+          case 'content':
+            {
+              switch (program.subtype) {
+                case 'movie':
+                  return 'movie';
+                case 'episode':
+                  return `show.${program.showId}`;
+                case 'track':
+                  return `artist.${program.artistId}`;
+              }
+            }
+            break;
+          case 'custom':
+            return `custom-show.${program.customShowId}`;
+          case 'flex':
+            return 'flex';
+          case 'redirect':
+            return `redirect.${program.channel}`;
+        }
+      }),
+      (group) => round((group.length / total) * 100, 2),
+    );
+  }, [materializeNewProgramList]);
+
+  return calculateProgramFrequency;
+};

--- a/web/src/pages/channels/RandomSlotEditorPage.tsx
+++ b/web/src/pages/channels/RandomSlotEditorPage.tsx
@@ -31,7 +31,7 @@ import {
   mapValues,
   round,
 } from 'lodash-es';
-import { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import PaddedPaper from '../../components/base/PaddedPaper';
@@ -170,12 +170,12 @@ export default function RandomSlotEditorPage() {
       }
 
       return (
-        <>
+        <React.Fragment key={key}>
           <span key={key}>
             {name}: {round((sums[key] / total) * 100, 2)}%
           </span>
           <br />
-        </>
+        </React.Fragment>
       );
     });
   }, [newLineup, programOptionNameById]);


### PR DESCRIPTION
    This change begins the concept of creating schedules based on existing
    programming tools using the slot schedulers. The first of these is
    recreating "cyclic shuffle" + "tweak weights" functionality directly in
    the random slot scheduler. To do this, the following functionality was
    added to the random slot scheduler:

    1. Ability to create slots based on absolute # of programs per slot,
       rather than a fixed duration
    2. A new program orderer called "ordered shuffle". This is effectively
       the "cyclic shuffle' functionality. Namely, chronological (or index
       based for custom shows) ordering with a random start point

    The concept is called "presets" - this allows users to generate a
    schedule that would normally require tinkering with program tools. The
    idea is to bake in various "presets" based on these existing tools, plus
    other convenience functions, to ease channel creation.