### PR TITLE
feat(ffmpeg): add audio language preferences

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
 
   web:
     dependencies:
+      '@cospired/i18n-iso-languages':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@emotion/react':
         specifier: ^11.11.1
         version: 11.11.1(@types/react@18.2.15)(react@18.2.0)
@@ -1022,6 +1025,10 @@ packages:
   '@commitlint/types@19.0.3':
     resolution: {integrity: sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==}
     engines: {node: '>=v18'}
+
+  '@cospired/i18n-iso-languages@4.2.0':
+    resolution: {integrity: sha512-vy8cq1176MTxVwB1X9niQjcIYOH29F8Huxtx8hLmT5Uz3l1ztGDGri8KN/4zE7LV2mCT7JrcAoNV/I9yb+lNUw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7956,6 +7963,8 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.0
       chalk: 5.3.0
+
+  '@cospired/i18n-iso-languages@4.2.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/server/src/api/hdhrSettingsApi.ts
+++ b/server/src/api/hdhrSettingsApi.ts
@@ -1,5 +1,4 @@
 import { RouterPluginCallback } from '@/types/serverType.js';
-import { firstDefined } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { HdhrSettings } from '@tunarr/types';
 import { BaseErrorSchema } from '@tunarr/types/api';
@@ -72,7 +71,7 @@ export const hdhrSettingsRouter: RouterPluginCallback = (
           module: 'hdhr',
           detail: {
             action: 'action',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });
@@ -117,7 +116,7 @@ export const hdhrSettingsRouter: RouterPluginCallback = (
           module: 'hdhr',
           detail: {
             action: 'reset',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });

--- a/server/src/api/mediaSourceApi.ts
+++ b/server/src/api/mediaSourceApi.ts
@@ -4,7 +4,7 @@ import { JellyfinApiClient } from '@/external/jellyfin/JellyfinApiClient.js';
 import { GlobalScheduler } from '@/services/Scheduler.ts';
 import { UpdateXmlTvTask } from '@/tasks/UpdateXmlTvTask.js';
 import { RouterPluginAsyncCallback } from '@/types/serverType.js';
-import { firstDefined, nullToUndefined, wait } from '@/util/index.js';
+import { nullToUndefined, wait } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { numberToBoolean } from '@/util/sqliteUtil.ts';
 import { MediaSourceSettings, tag } from '@tunarr/types';
@@ -15,7 +15,7 @@ import {
   UpdateMediaSourceRequestSchema,
 } from '@tunarr/types/api';
 import { MediaSourceSettingsSchema } from '@tunarr/types/schemas';
-import { isError, isNil, isObject, map } from 'lodash-es';
+import { isError, isNil, map } from 'lodash-es';
 import { match } from 'ts-pattern';
 import z from 'zod';
 
@@ -263,9 +263,7 @@ export const mediaSourceRouter: RouterPluginAsyncCallback = async (
         let modifiedPrograms = 0;
         let destroyedPrograms = 0;
         report.forEach((r) => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           modifiedPrograms += r.modifiedPrograms;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           destroyedPrograms += r.destroyedPrograms;
         });
         req.serverCtx.eventService.push({
@@ -288,8 +286,8 @@ export const mediaSourceRouter: RouterPluginAsyncCallback = async (
           module: 'media-source',
           detail: {
             action: 'update',
-            serverName: firstDefined(req, 'body', 'name'),
-            error: isObject(err) ? firstDefined(err, 'message') : 'unknown',
+            serverName: req.body.name,
+            error: isError(err) ? err.message : JSON.stringify(err),
           },
           level: 'error',
         });
@@ -338,7 +336,7 @@ export const mediaSourceRouter: RouterPluginAsyncCallback = async (
           detail: {
             action: 'add',
             serverName: req.body.name,
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : JSON.stringify(err),
           },
           level: 'error',
         });

--- a/server/src/api/plexSettingsApi.ts
+++ b/server/src/api/plexSettingsApi.ts
@@ -1,5 +1,4 @@
 import { RouterPluginCallback } from '@/types/serverType.js';
-import { firstDefined } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { PlexStreamSettings, defaultPlexStreamSettings } from '@tunarr/types';
 import { PlexStreamSettingsSchema } from '@tunarr/types/schemas';
@@ -73,7 +72,7 @@ export const plexSettingsRouter: RouterPluginCallback = (
           module: 'plex',
           detail: {
             action: 'update',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });
@@ -118,7 +117,7 @@ export const plexSettingsRouter: RouterPluginCallback = (
           module: 'plex',
           detail: {
             action: 'reset',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });

--- a/server/src/api/xmltvSettingsApi.ts
+++ b/server/src/api/xmltvSettingsApi.ts
@@ -3,7 +3,6 @@ import { serverOptions } from '@/globals.js';
 import { GlobalScheduler } from '@/services/Scheduler.ts';
 import { UpdateXmlTvTask } from '@/tasks/UpdateXmlTvTask.js';
 import { RouterPluginCallback } from '@/types/serverType.js';
-import { firstDefined } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { XmlTvSettings } from '@tunarr/types';
 import { BaseErrorSchema } from '@tunarr/types/api';
@@ -82,7 +81,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
           module: 'xmltv',
           detail: {
             action: 'update',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });
@@ -128,7 +127,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
           module: 'xmltv',
           detail: {
             action: 'reset',
-            error: isError(err) ? firstDefined(err, 'message') : 'unknown',
+            error: isError(err) ? err.message : 'unknown',
           },
           level: 'error',
         });

--- a/server/src/db/SettingsDB.test.ts
+++ b/server/src/db/SettingsDB.test.ts
@@ -1,0 +1,18 @@
+import { Low, Memory } from 'lowdb';
+
+type Data = {
+  obj: {
+    x: number;
+    y: string;
+  };
+};
+
+test('LowDB referential uppdates', async () => {
+  const db = new Low<Data>(new Memory(), { obj: { x: 1, y: 'string' } });
+  await db.read();
+  const data = db.data;
+  console.log(data);
+  data.obj.x = 100;
+  await db.write();
+  console.log(db.data);
+});

--- a/server/src/db/SettingsDB.ts
+++ b/server/src/db/SettingsDB.ts
@@ -112,6 +112,8 @@ type SettingsChangeEvents = {
   change(): void;
 };
 
+export type ReadableFfmpegSettings = DeepReadonly<FfmpegSettings>;
+
 abstract class ITypedEventEmitter extends (events.EventEmitter as new () => TypedEventEmitter<SettingsChangeEvents>) {}
 
 export class SettingsDB extends ITypedEventEmitter {
@@ -161,7 +163,7 @@ export class SettingsDB extends ITypedEventEmitter {
     return this.db.data.settings.plexStream;
   }
 
-  ffmpegSettings(): DeepReadonly<FfmpegSettings> {
+  ffmpegSettings(): ReadableFfmpegSettings {
     return this.db.data.settings.ffmpeg;
   }
 

--- a/server/src/db/schema/TranscodeConfig.ts
+++ b/server/src/db/schema/TranscodeConfig.ts
@@ -1,10 +1,6 @@
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import { booleanToNumber } from '@/util/sqliteUtil.ts';
-import {
-  FfmpegSettings,
-  Resolution,
-  TupleToUnion,
-  defaultFfmpegSettings,
-} from '@tunarr/types';
+import { Resolution, TupleToUnion, defaultFfmpegSettings } from '@tunarr/types';
 import {
   Generated,
   Insertable,
@@ -165,7 +161,7 @@ export type NewTranscodeConfig = Insertable<TrannscodeConfigTable>;
 export type TranscodeConfigUpdate = Updateable<TrannscodeConfigTable>;
 
 export const transcodeConfigFromLegacySettings = (
-  legacySettings: FfmpegSettings,
+  legacySettings: ReadableFfmpegSettings,
   isDefault?: boolean,
 ): NewTranscodeConfig => {
   const audioSetting = TranscodeAudioOutputFormats.find(

--- a/server/src/ffmpeg/FFmpegFactory.ts
+++ b/server/src/ffmpeg/FFmpegFactory.ts
@@ -1,17 +1,14 @@
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import { Channel } from '@/db/schema/Channel.ts';
 import { TranscodeConfig } from '@/db/schema/TranscodeConfig.ts';
-import {
-  ChannelStreamMode,
-  ChannelStreamModes,
-  FfmpegSettings,
-} from '@tunarr/types';
+import { ChannelStreamMode, ChannelStreamModes } from '@tunarr/types';
 import { FfmpegStreamFactory } from './FfmpegStreamFactory.ts';
 import { FFMPEG } from './ffmpeg.ts';
 import { IFFMPEG } from './ffmpegBase.ts';
 
 export class FFmpegFactory {
   static getFFmpegPipelineBuilder(
-    settings: FfmpegSettings,
+    settings: ReadableFfmpegSettings,
     transcodeConfig: TranscodeConfig,
     channel: Channel,
     streamMode: ChannelStreamMode,

--- a/server/src/ffmpeg/FfmpegProcess.ts
+++ b/server/src/ffmpeg/FfmpegProcess.ts
@@ -1,9 +1,12 @@
-import { SettingsDB, getSettings } from '@/db/SettingsDB.ts';
+import {
+  ReadableFfmpegSettings,
+  SettingsDB,
+  getSettings,
+} from '@/db/SettingsDB.ts';
 import { TypedEventEmitter } from '@/types/eventEmitter.js';
 import { Maybe, Nullable } from '@/types/util.js';
 import { isDefined, isWindows } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
-import { FfmpegSettings } from '@tunarr/types';
 import { FfmpegNumericLogLevels } from '@tunarr/types/schemas';
 import { isNull, isUndefined } from 'lodash-es';
 import { ChildProcessByStdio, exec, spawn } from 'node:child_process';
@@ -38,7 +41,7 @@ export class FfmpegProcess extends (events.EventEmitter as new () => TypedEventE
   #sentData = false;
 
   constructor(
-    private ffmpegSettings: FfmpegSettings,
+    private ffmpegSettings: ReadableFfmpegSettings,
     private ffmpegName: string,
     private ffmpegArgs: string[],
     private environmentVariables: NodeJS.ProcessEnv = {},

--- a/server/src/ffmpeg/FfmpegStreamFactory.ts
+++ b/server/src/ffmpeg/FfmpegStreamFactory.ts
@@ -1,16 +1,17 @@
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import { Channel } from '@/db/schema/Channel.ts';
 import { TranscodeConfig } from '@/db/schema/TranscodeConfig.ts';
 import { InfiniteLoopInputOption } from '@/ffmpeg/builder/options/input/InfiniteLoopInputOption.ts';
-import { HttpStreamSource } from '@/stream/types.ts';
+import { AudioStreamDetails, HttpStreamSource } from '@/stream/types.ts';
 import { Maybe, Nullable } from '@/types/util.ts';
 import { isDefined, isLinux, isNonEmptyString } from '@/util/index.ts';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.ts';
 import { makeLocalUrl } from '@/util/serverUtil.ts';
-import { ChannelStreamModes, FfmpegSettings } from '@tunarr/types';
+import { ChannelStreamModes } from '@tunarr/types';
 import dayjs from 'dayjs';
 import { Duration } from 'dayjs/plugin/duration.js';
-import { find, first, isUndefined } from 'lodash-es';
-import { DeepReadonly } from 'ts-essentials';
+import { isUndefined } from 'lodash-es';
+import { DeepReadonly, NonEmptyArray } from 'ts-essentials';
 import { FfmpegPlaybackParamsCalculator } from './FfmpegPlaybackParamsCalculator.ts';
 import { FfmpegProcess } from './FfmpegProcess.ts';
 import { FfmpegTranscodeSession } from './FfmpegTrancodeSession.ts';
@@ -55,7 +56,7 @@ export class FfmpegStreamFactory extends IFFMPEG {
   private pipelineBuilderFactory: PipelineBuilderFactory;
 
   constructor(
-    private ffmpegSettings: DeepReadonly<FfmpegSettings>,
+    private ffmpegSettings: ReadableFfmpegSettings,
     private transcodeConfig: TranscodeConfig,
     private channel: Channel,
   ) {
@@ -363,10 +364,8 @@ export class FfmpegStreamFactory extends IFFMPEG {
 
     let audioInput: AudioInputSource;
     if (isDefined(streamDetails.audioDetails)) {
-      const audioStream =
-        find(streamDetails.audioDetails, { selected: true }) ??
-        find(streamDetails.audioDetails, { default: true }) ??
-        first(streamDetails.audioDetails);
+      // Find the best matching audio stream based on language preferences
+      const audioStream = this.findBestAudioStream(streamDetails.audioDetails);
       const audioStreamIndex = isNonEmptyString(audioStream.index)
         ? parseInt(audioStream.index)
         : 1;
@@ -702,13 +701,38 @@ export class FfmpegStreamFactory extends IFFMPEG {
     return isNonEmptyString(this.transcodeConfig.vaapiDevice)
       ? this.transcodeConfig.vaapiDevice
       : isLinux()
-        ? '/dev/dri/renderD128'
-        : undefined;
+      ? '/dev/dri/renderD128'
+      : undefined;
   }
 
   private getVaapiDriver() {
     return this.transcodeConfig.vaapiDriver !== 'system'
       ? this.transcodeConfig.vaapiDriver
       : null;
+  }
+
+  private findBestAudioStream(
+    audioDetails: NonEmptyArray<AudioStreamDetails>,
+  ): AudioStreamDetails {
+    // First try to find a stream matching our language preferences in order
+    for (const pref of this.ffmpegSettings.languagePreferences.preferences) {
+      const matchingStream = audioDetails.find((stream) => {
+        return (
+          stream.languageCodeISO6392?.toLowerCase() === pref.iso6392 ||
+          stream.languageCodeISO6391 === pref.iso6391 ||
+          stream.language?.toLowerCase() === pref.displayName.toLowerCase()
+        );
+      });
+      if (matchingStream) {
+        return matchingStream;
+      }
+    }
+
+    // If no language match, fallback to default/selected stream
+    const fallbackStream =
+      audioDetails.find((stream) => stream.selected) ??
+      audioDetails.find((stream) => stream.default) ??
+      audioDetails[0];
+    return fallbackStream;
   }
 }

--- a/server/src/ffmpeg/builder/capabilities/HardwareCapabilitiesFactory.ts
+++ b/server/src/ffmpeg/builder/capabilities/HardwareCapabilitiesFactory.ts
@@ -1,3 +1,4 @@
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import {
   HardwareAccelerationMode,
   TranscodeConfig,
@@ -10,13 +11,12 @@ import { DefaultHardwareCapabilities } from '@/ffmpeg/builder/capabilities/Defau
 import { NoHardwareCapabilities } from '@/ffmpeg/builder/capabilities/NoHardwareCapabilities.ts';
 import { NvidiaHardwareCapabilitiesFactory } from '@/ffmpeg/builder/capabilities/NvidiaHardwareCapabilitiesFactory.ts';
 import { VaapiHardwareCapabilitiesFactory } from '@/ffmpeg/builder/capabilities/VaapiHardwareCapabilitiesFactory.ts';
-import { FfmpegSettings } from '@tunarr/types';
 
 export class HardwareCapabilitiesFactory
   implements FfmpegHardwareCapabilitiesFactory
 {
   constructor(
-    private ffmpegSettings: FfmpegSettings,
+    private ffmpegSettings: ReadableFfmpegSettings,
     private transcodeConfig: TranscodeConfig,
   ) {}
 

--- a/server/src/ffmpeg/builder/capabilities/NvidiaHardwareCapabilitiesFactory.ts
+++ b/server/src/ffmpeg/builder/capabilities/NvidiaHardwareCapabilitiesFactory.ts
@@ -1,3 +1,4 @@
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import {
   BaseFfmpegHardwareCapabilities,
   FfmpegHardwareCapabilitiesFactory,
@@ -8,7 +9,6 @@ import { ChildProcessHelper } from '@/util/ChildProcessHelper.ts';
 import { cacheGetOrSet } from '@/util/cache.ts';
 import dayjs from '@/util/dayjs.ts';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.ts';
-import { FfmpegSettings } from '@tunarr/types';
 import {
   attempt,
   drop,
@@ -40,7 +40,7 @@ export class NvidiaHardwareCapabilitiesFactory
     return `${path}_${command}`;
   }
 
-  constructor(private settings: FfmpegSettings) {}
+  constructor(private settings: ReadableFfmpegSettings) {}
 
   async getCapabilities(): Promise<BaseFfmpegHardwareCapabilities> {
     const result = await attempt(async () => {

--- a/server/src/ffmpeg/builder/pipeline/PipelineBuilderFactory.ts
+++ b/server/src/ffmpeg/builder/pipeline/PipelineBuilderFactory.ts
@@ -1,4 +1,8 @@
-import { SettingsDB, getSettings } from '@/db/SettingsDB.ts';
+import {
+  ReadableFfmpegSettings,
+  SettingsDB,
+  getSettings,
+} from '@/db/SettingsDB.ts';
 import {
   HardwareAccelerationMode,
   TranscodeConfig,
@@ -10,7 +14,6 @@ import { VideoInputSource } from '@/ffmpeg/builder/input/VideoInputSource.ts';
 import { WatermarkInputSource } from '@/ffmpeg/builder/input/WatermarkInputSource.ts';
 import { FfmpegInfo } from '@/ffmpeg/ffmpegInfo.ts';
 import { Nullable } from '@/types/util.ts';
-import { FfmpegSettings } from '@tunarr/types';
 import { isUndefined } from 'lodash-es';
 import { PipelineBuilder } from './PipelineBuilder.js';
 import { NvidiaPipelineBuilder } from './hardware/NvidiaPipelineBuilder.ts';
@@ -39,7 +42,7 @@ class PipelineBuilderFactory$Builder {
     HardwareAccelerationMode.None;
 
   constructor(
-    private ffmpegSettings: FfmpegSettings,
+    private ffmpegSettings: ReadableFfmpegSettings,
     private transcodeConfig: TranscodeConfig,
   ) {}
 

--- a/server/src/ffmpeg/ffmpeg.ts
+++ b/server/src/ffmpeg/ffmpeg.ts
@@ -17,19 +17,12 @@ import {
   Watermark,
 } from '@tunarr/types';
 
+import { ReadableFfmpegSettings } from '@/db/SettingsDB.ts';
 import { NvidiaHardwareCapabilitiesFactory } from '@/ffmpeg/builder/capabilities/NvidiaHardwareCapabilitiesFactory.ts';
 import { ChannelConcatStreamMode } from '@tunarr/types/schemas';
 import dayjs from 'dayjs';
 import { Duration } from 'dayjs/plugin/duration.js';
-import {
-  find,
-  first,
-  isEmpty,
-  isNil,
-  isUndefined,
-  merge,
-  round,
-} from 'lodash-es';
+import { first, isEmpty, isNil, isUndefined, merge, round } from 'lodash-es';
 import path from 'path';
 import { DeepReadonly, DeepRequired } from 'ts-essentials';
 import {
@@ -157,10 +150,22 @@ export type StreamSessionOptions = StreamOptions & {
   streamDetails: StreamDetails;
 };
 
+interface AudioStreamDetails {
+  index?: string;
+  codec?: string;
+  channels?: number;
+  language?: string;
+  languageTag?: string;
+  languageCode?: string;
+  selected?: boolean;
+  default?: boolean;
+}
+
 export class FFMPEG implements IFFMPEG {
   private logger: Logger;
   private errorPicturePath: string;
   private ffmpegName: string;
+  private readonly settings: ReadableFfmpegSettings;
 
   private wantedW: number;
   private wantedH: number;
@@ -173,11 +178,18 @@ export class FFMPEG implements IFFMPEG {
   private nvidiaCapabilities: NvidiaHardwareCapabilitiesFactory;
 
   constructor(
-    private opts: DeepReadonly<FfmpegSettings>,
+    opts: DeepReadonly<FfmpegSettings>,
     private transcodeConfig: TranscodeConfig,
     private channel: Channel,
     private audioOnly: boolean = false,
   ) {
+    this.settings = {
+      ...opts,
+      languagePreferences: {
+        ...opts.languagePreferences,
+        preferences: [...opts.languagePreferences.preferences],
+      },
+    };
     this.logger = LoggerFactory.child({
       caller: import.meta,
       className: FFMPEG.name,
@@ -186,12 +198,14 @@ export class FFMPEG implements IFFMPEG {
     this.errorPicturePath = makeLocalUrl('/images/generic-error-screen.png');
     this.ffmpegName = 'unnamed ffmpeg';
     this.channel = channel;
-    this.ffmpegInfo = new FfmpegInfo(this.opts);
-    this.nvidiaCapabilities = new NvidiaHardwareCapabilitiesFactory(this.opts);
+    this.ffmpegInfo = new FfmpegInfo(this.settings);
+    this.nvidiaCapabilities = new NvidiaHardwareCapabilitiesFactory(
+      this.settings,
+    );
     this.wantedW = transcodeConfig.resolution.widthPx;
     this.wantedH = transcodeConfig.resolution.heightPx;
     this.apad = true;
-    this.ensureResolution = this.opts.normalizeResolution;
+    this.ensureResolution = this.settings.normalizeResolution;
     this.volumePercent = this.transcodeConfig.audioVolumePercent;
   }
 
@@ -205,7 +219,7 @@ export class FFMPEG implements IFFMPEG {
       `-threads`,
       '1',
       '-loglevel',
-      this.opts.logLevel,
+      this.settings.logLevel,
       '-user_agent',
       `Ffmpeg Tunarr/${getTunarrVersion()}`,
       `-fflags`,
@@ -307,7 +321,7 @@ export class FFMPEG implements IFFMPEG {
       '1',
       '-hide_banner',
       '-loglevel',
-      this.opts.logLevel,
+      this.settings.logLevel,
       '-user_agent',
       `Ffmpeg Tunarr/${getTunarrVersion()}`,
       '-nostats',
@@ -441,14 +455,16 @@ export class FFMPEG implements IFFMPEG {
       `-fflags`,
       `+genpts+discardcorrupt+igndts`,
       '-loglevel',
-      this.opts.logLevel,
+      this.settings.logLevel,
     ];
 
     const videoStream = first(streamStats?.videoDetails);
-    const audioStream =
-      find(streamStats?.audioDetails, { selected: true }) ??
-      find(streamStats?.audioDetails, { default: true }) ??
-      first(streamStats?.audioDetails);
+    this.logger.debug(
+      'Finding best audio stream from:',
+      streamStats?.audioDetails,
+    );
+    const audioStream = this.findBestAudioStream(streamStats?.audioDetails);
+    this.logger.debug('Selected audio stream:', audioStream);
 
     // Initialize like this because we're not checking whether or not
     // the input is hardware decodeable, yet.
@@ -456,8 +472,8 @@ export class FFMPEG implements IFFMPEG {
       const vaapiDevice = isNonEmptyString(this.transcodeConfig.vaapiDevice)
         ? this.transcodeConfig.vaapiDevice
         : isLinux()
-          ? '/dev/dri/renderD128'
-          : undefined;
+        ? '/dev/dri/renderD128'
+        : undefined;
       ffmpegArgs.push(
         // Crude workaround for no av1 decoding support
         ...(videoStream?.codec === 'av1' ? [] : ['-hwaccel', 'vaapi']),
@@ -512,9 +528,11 @@ export class FFMPEG implements IFFMPEG {
     }
 
     // Map correct audio index. '?' so doesn't fail if no stream available.
-    const audioIndex = isUndefined(audioStream)
-      ? 'a'
-      : `${audioStream.index ?? 'a'}`;
+    const audioStreamIndex = audioStream?.index
+      ? parseInt(audioStream.index)
+      : 1;
+
+    this.logger.debug(`Using audio stream index: ${audioStreamIndex}`);
 
     //TODO: Do something about missing audio stream
     let inputFiles = 0;
@@ -553,7 +571,7 @@ export class FFMPEG implements IFFMPEG {
     const videoIndex = isNonEmptyString(videoStream?.streamIndex)
       ? videoStream?.streamIndex
       : 'v';
-    let audioComplex = `;[${audioFile}:${audioIndex}]anull[audio]`;
+    let audioComplex = `;[${audioFile}:${audioStreamIndex}]anull[audio]`;
     let videoComplex = `;[${videoFile}:${videoIndex}]null[video]`;
 
     // This is only tracked for the vaapi path at the moment
@@ -1001,7 +1019,7 @@ export class FFMPEG implements IFFMPEG {
     if (currentAudio !== '[audio]') {
       filterComplex += audioComplex;
     } else {
-      currentAudio = `${audioFile}:${audioIndex}`;
+      currentAudio = `${audioFile}:${audioStreamIndex}`;
     }
 
     //If there is a filter complex, add it.
@@ -1119,7 +1137,11 @@ export class FFMPEG implements IFFMPEG {
     ffmpegArgs: string[],
     streamDuration?: Duration,
   ): FfmpegTranscodeSession {
-    const process = new FfmpegProcess(this.opts, this.ffmpegName, ffmpegArgs);
+    const process = new FfmpegProcess(
+      this.settings,
+      this.ffmpegName,
+      ffmpegArgs,
+    );
 
     // TODO: Do we need a more accurate measure of "streamEndTime" by passing in
     // the request start time? Or is this really inaccurate because we still have
@@ -1257,6 +1279,58 @@ export class FFMPEG implements IFFMPEG {
     );
 
     return audioOutputOpts;
+  }
+
+  private findBestAudioStream(
+    audioDetails?: AudioStreamDetails[],
+  ): AudioStreamDetails | undefined {
+    if (!audioDetails?.length) {
+      return undefined;
+    }
+
+    this.logger.debug('Available audio streams:', audioDetails);
+    this.logger.debug(
+      'Language preferences:',
+      this.settings.languagePreferences,
+    );
+
+    // First try to find a stream matching our language preferences in order
+    for (const pref of this.settings.languagePreferences.preferences) {
+      this.logger.debug(
+        `Trying to match language preference: ${pref.iso6391} (${pref.displayName})`,
+      );
+      const matchingStream = audioDetails.find((stream) => {
+        const matches = [
+          // Match on ISO 639-1 code (languageTag)
+          stream.languageTag === pref.iso6391,
+          // Match on ISO 639-2 code (languageCode)
+          stream.languageCode?.toLowerCase() === pref.iso6391,
+          // Match on full language name
+          stream.language?.toLowerCase() === pref.displayName.toLowerCase(),
+        ];
+        this.logger.debug(
+          `Stream ${stream.index} (${stream.language}) matches:`,
+          matches,
+        );
+        return matches.some((match) => match);
+      });
+      if (matchingStream) {
+        this.logger.debug(`Found matching stream:`, matchingStream);
+        return matchingStream;
+      }
+    }
+
+    // If no language match, fallback to default/selected stream
+    const fallbackStream =
+      audioDetails.find((stream) => stream.selected) ??
+      audioDetails.find((stream) => stream.default) ??
+      audioDetails[0];
+
+    this.logger.debug(
+      `No language match found, using fallback stream:`,
+      fallbackStream,
+    );
+    return fallbackStream;
   }
 }
 

--- a/server/src/ffmpeg/ffmpegInfo.ts
+++ b/server/src/ffmpeg/ffmpegInfo.ts
@@ -20,6 +20,7 @@ import {
   trim,
 } from 'lodash-es';
 import NodeCache from 'node-cache';
+import { DeepReadonly } from 'ts-essentials';
 import { format } from 'util';
 import { attempt, isNonEmptyString, parseIntOrNull } from '../util/index.ts';
 import { FfmpegCapabilities } from './builder/capabilities/FfmpegCapabilities.ts';
@@ -72,7 +73,7 @@ export class FfmpegInfo {
   private ffmpegPath: string;
   private ffprobePath: string;
 
-  constructor(opts: FfmpegSettings) {
+  constructor(opts: DeepReadonly<FfmpegSettings>) {
     this.ffmpegPath = opts.ffmpegExecutablePath;
     this.ffprobePath = opts.ffprobeExecutablePath;
   }

--- a/server/src/migration/legacy_migration/legacyDbMigration.ts
+++ b/server/src/migration/legacy_migration/legacyDbMigration.ts
@@ -484,6 +484,7 @@ export class LegacyDbMigrator {
                 (ffmpegSettings['disablePreludes'] as Maybe<boolean>) ?? false,
               useNewFfmpegPipeline: false,
               hlsDirectOutputFormat: 'mpegts',
+              languagePreferences: defaultFfmpegSettings.languagePreferences,
             },
             defaultFfmpegSettings,
           );

--- a/server/src/services/XmlTvWriter.ts
+++ b/server/src/services/XmlTvWriter.ts
@@ -175,8 +175,6 @@ export class XmlTvWriter {
           },
         ];
       }
-    } else {
-      console.log(program);
     }
 
     return partial;

--- a/server/src/stream/ConcatStream.ts
+++ b/server/src/stream/ConcatStream.ts
@@ -1,15 +1,18 @@
-import { SettingsDB, getSettings } from '@/db/SettingsDB.ts';
+import {
+  ReadableFfmpegSettings,
+  SettingsDB,
+  getSettings,
+} from '@/db/SettingsDB.ts';
 import { ChannelWithTranscodeConfig } from '@/db/schema/derivedTypes.js';
 import { FFmpegFactory } from '@/ffmpeg/FFmpegFactory.ts';
 import { FfmpegTranscodeSession } from '@/ffmpeg/FfmpegTrancodeSession.ts';
 import { MpegTsOutputFormat } from '@/ffmpeg/builder/constants.ts';
 import { ConcatStreamModeToChildMode } from '@/ffmpeg/ffmpegBase.ts';
 import { makeFfmpegPlaylistUrl, makeLocalUrl } from '@/util/serverUtil.js';
-import { FfmpegSettings } from '@tunarr/types';
 import { ChannelConcatStreamMode } from '@tunarr/types/schemas';
 
 export class ConcatStream {
-  #ffmpegSettings: FfmpegSettings;
+  #ffmpegSettings: ReadableFfmpegSettings;
 
   constructor(
     private channel: ChannelWithTranscodeConfig,

--- a/server/src/stream/jellyfin/JellyfinStreamDetails.ts
+++ b/server/src/stream/jellyfin/JellyfinStreamDetails.ts
@@ -280,6 +280,7 @@ export class JellyfinStreamDetails {
           language: nullToUndefined(audioStream.Language),
           profile: nullToUndefined(audioStream.Profile),
           title: nullToUndefined(audioStream.Title),
+          languageCodeISO6392: nullToUndefined(audioStream.Language),
         } satisfies AudioStreamDetails;
       },
     );

--- a/server/src/stream/plex/PlexStreamDetails.ts
+++ b/server/src/stream/plex/PlexStreamDetails.ts
@@ -284,8 +284,8 @@ export class PlexStreamDetails {
           videoStream.scanType === 'interlaced'
             ? 'interlaced'
             : videoStream.scanType === 'progressive'
-              ? 'progressive'
-              : 'unknown',
+            ? 'progressive'
+            : 'unknown',
         width: videoStream.width,
         height: videoStream.height,
         framerate: videoStream.frameRate,
@@ -328,7 +328,9 @@ export class PlexStreamDetails {
           // to pick these streams.
           selected: audioStream.selected,
           default: audioStream.default,
-          language: audioStream.languageCode,
+          language: audioStream.language,
+          languageCodeISO6391: audioStream.languageTag,
+          languageCodeISO6392: audioStream.languageCode,
           title: audioStream.displayTitle,
         } satisfies AudioStreamDetails;
       },

--- a/server/src/stream/types.ts
+++ b/server/src/stream/types.ts
@@ -53,6 +53,8 @@ export type AudioStreamDetails = {
   selected?: boolean;
   title?: string;
   language?: string;
+  languageCodeISO6391?: string;
+  languageCodeISO6392?: string;
   forced?: boolean;
 };
 

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -30,6 +30,7 @@ import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { format } from 'node:util';
 import { isPromise } from 'node:util/types';
+import { DeepReadonly, DeepWritable } from 'ts-essentials';
 
 dayjs.extend(duration);
 
@@ -241,20 +242,6 @@ export const wait = (ms?: number | Duration) => {
   }
   return new Promise((resolve) => setTimeout(resolve, ms ?? 0));
 };
-
-export function firstDefined(obj: object, ...args: string[]): string {
-  if (isEmpty(args)) {
-    return String(obj);
-  }
-
-  for (const arg of args) {
-    if (!isUndefined(obj[arg])) {
-      return String(obj[arg]);
-    }
-  }
-
-  return 'missing';
-}
 
 type NativeFuncOrApply<In, Out> = ((input: In) => Out) | Func<In, Out>;
 
@@ -524,4 +511,8 @@ export function gcd(a: number, b: number) {
       return a;
     }
   }
+}
+
+export function makeWritable<T>(obj: DeepReadonly<T>): DeepWritable<T> {
+  return obj as DeepWritable<T>; // here be hacks
 }

--- a/types/src/FfmpegSettings.ts
+++ b/types/src/FfmpegSettings.ts
@@ -1,5 +1,5 @@
-import { FfmpegSettingsSchema } from './schemas/settingsSchemas.js';
 import z from 'zod';
+import { FfmpegSettingsSchema } from './schemas/settingsSchemas.js';
 
 export type FfmpegSettings = z.infer<typeof FfmpegSettingsSchema>;
 

--- a/types/src/LanguagePreferences.ts
+++ b/types/src/LanguagePreferences.ts
@@ -1,0 +1,12 @@
+import z from 'zod';
+import {
+  LanguagePreferenceSchema,
+  LanguagePreferencesSchema,
+} from './schemas/settingsSchemas.js';
+
+export type LanguagePreference = z.infer<typeof LanguagePreferenceSchema>;
+export type LanguagePreferences = z.infer<typeof LanguagePreferencesSchema>;
+
+export const defaultLanguagePreferences = LanguagePreferencesSchema.parse({
+  preferences: [{ iso6391: 'en', iso6392: 'eng', displayName: 'English' }],
+});

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -14,3 +14,4 @@ export * from './TranscodeConfig.js';
 export * from './XmlTvSettings.js';
 export * from './misc.js';
 export * from './util.js';
+export * from './LanguagePreferences.js';

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -73,6 +73,18 @@ export const FfmpegNumericLogLevels: Record<
   trace: 56,
 };
 
+export const LanguagePreferenceSchema = z.object({
+  // ISO 639-1 (2-letter)
+  iso6391: z.string().length(2),
+  // ISO 639-2 (3-letter)
+  iso6392: z.string().length(3),
+  displayName: z.string(),
+});
+
+export const LanguagePreferencesSchema = z.object({
+  preferences: z.array(LanguagePreferenceSchema).min(1),
+});
+
 export const FfmpegSettingsSchema = z.object({
   configVersion: z.number().default(5),
   ffmpegExecutablePath: z.string().default('/usr/bin/ffmpeg'),
@@ -82,6 +94,9 @@ export const FfmpegSettingsSchema = z.object({
   enableLogging: z.boolean().default(false),
   enableFileLogging: z.boolean().default(false),
   logLevel: z.enum(FfmpegLogLevels).optional().default('warning'),
+  languagePreferences: LanguagePreferencesSchema.default({
+    preferences: [{ iso6391: 'en', iso6392: 'eng', displayName: 'English' }],
+  }),
   // DEPRECATED
   enableTranscoding: z.boolean().default(true).describe('DEPRECATED'),
   audioVolumePercent: z.number().default(100),

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
+    "@cospired/i18n-iso-languages": "^4.2.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/web/src/components/LanguagePreferencesList.tsx
+++ b/web/src/components/LanguagePreferencesList.tsx
@@ -1,0 +1,90 @@
+import { isNonEmptyString } from '@/helpers/util';
+import languages from '@cospired/i18n-iso-languages';
+import en from '@cospired/i18n-iso-languages/langs/en.json';
+import { Autocomplete, Stack, TextField, Typography } from '@mui/material';
+import { seq } from '@tunarr/shared/util';
+import { LanguagePreference } from '@tunarr/types';
+import { entries, map, reject, sortBy } from 'lodash-es';
+import { FieldError } from 'react-hook-form';
+
+// Initialize the languages database with English names
+languages.registerLocale(en);
+
+interface LanguagePreferencesListProps {
+  preferences: LanguagePreference[];
+  onChange: (preferences: LanguagePreference[]) => void;
+  error?: FieldError;
+}
+
+// Get all available languages as a map of ISO 639-1 codes to display names
+const languageOptions = sortBy(
+  seq.collect(entries(languages.getNames('en')), ([code, name]) => {
+    const iso6392 = languages.alpha2ToAlpha3B(code);
+    if (!iso6392) {
+      return;
+    }
+    return {
+      iso6391: code,
+      iso6392,
+      displayName: name,
+    } satisfies LanguagePreference;
+  }),
+  (opt) => opt.displayName,
+);
+
+export function LanguagePreferencesList({
+  preferences,
+  onChange,
+  error,
+}: LanguagePreferencesListProps) {
+  console.log(error);
+  const handleChange = (value: LanguagePreference[]) => {
+    onChange(value);
+  };
+
+  const preferenceCodes = map(preferences, (pref) => pref.iso6392);
+
+  return (
+    <Stack>
+      <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>
+        Audio Language Preferences
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mb: 2 }}>
+        Configure preferred audio languages globally.
+      </Typography>
+      <Autocomplete
+        multiple
+        fullWidth
+        value={preferences}
+        onChange={(_, newValue) => handleChange(newValue)}
+        options={reject(languageOptions, ({ iso6392 }) =>
+          preferenceCodes.includes(iso6392),
+        )}
+        getOptionLabel={(option) => option.displayName}
+        isOptionEqualToValue={(option, value) =>
+          option.iso6391 === value.iso6391
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Language"
+            variant="outlined"
+            helperText={
+              <span>
+                The selected languages will be considered in order they are
+                selected.
+                {isNonEmptyString(error?.message) && (
+                  <>
+                    <br />
+                    {error.message}
+                  </>
+                )}
+              </span>
+            }
+            error={!!error}
+          />
+        )}
+      />
+    </Stack>
+  );
+}

--- a/web/src/pages/settings/FfmpegSettingsPage.tsx
+++ b/web/src/pages/settings/FfmpegSettingsPage.tsx
@@ -28,7 +28,7 @@ import {
   defaultFfmpegSettings,
 } from '@tunarr/types';
 import { FfmpegLogLevels } from '@tunarr/types/schemas';
-import { capitalize, isEqual, isNull, map, some } from 'lodash-es';
+import { capitalize, isEmpty, isEqual, isNull, map, some } from 'lodash-es';
 import {
   MRT_ColumnDef,
   MRT_Row,
@@ -42,6 +42,7 @@ import UnsavedNavigationAlert from '../../components/settings/UnsavedNavigationA
 import { CheckboxFormController } from '../../components/util/TypedController.tsx';
 
 import { DeleteConfirmationDialog } from '@/components/DeleteConfirmationDialog.tsx';
+import { LanguagePreferencesList } from '@/components/LanguagePreferencesList';
 import AddCircle from '@mui/icons-material/AddCircle';
 import {
   useFfmpegSettings,
@@ -96,8 +97,10 @@ export default function FfmpegSettingsPage() {
     handleSubmit,
     watch,
   } = useForm<Omit<FfmpegSettings, 'configVersion'>>({
-    defaultValues: defaultFfmpegSettings,
-    mode: 'onBlur',
+    defaultValues: {
+      ...defaultFfmpegSettings,
+    },
+    mode: 'onChange',
   });
 
   const [ffmpegConsoleLoggingEnabled, ffmpegFileLoggingEnabled] = watch([
@@ -271,7 +274,7 @@ export default function FfmpegSettingsPage() {
       <Typography variant="h5" sx={{ mb: 2 }}>
         Global Options
       </Typography>
-      <Stack spacing={3} useFlexGap>
+      <Stack spacing={3} useFlexGap sx={{ mb: 2 }}>
         {!systemSettings.data.adminMode && (
           <Alert severity="info">
             Tunarr must be run in admin mode in order to update the FFmpeg and
@@ -279,6 +282,7 @@ export default function FfmpegSettingsPage() {
             command line.
           </Alert>
         )}
+
         <FormControl fullWidth>
           <Controller
             control={control}
@@ -429,30 +433,60 @@ export default function FfmpegSettingsPage() {
             the selected container format.
           </FormHelperText>
         </FormControl>
-        <Stack spacing={2} direction="row" justifyContent="right">
-          {(isDirty || (isDirty && !isSubmitting) || restoreTunarrDefaults) && (
-            <Button
-              variant="outlined"
-              onClick={() => {
-                reset(data);
-                setRestoreTunarrDefaults(false);
-              }}
-            >
-              Reset Changes
-            </Button>
-          )}
+      </Stack>
+      <Divider sx={{ my: 1 }} />
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        Audio Options
+      </Typography>
+      <Stack spacing={3} sx={{ mb: 2 }}>
+        <FormControl fullWidth>
+          <Controller
+            control={control}
+            name="languagePreferences.preferences"
+            rules={{
+              validate: {
+                minLength: (v) =>
+                  isEmpty(v)
+                    ? 'Must define at least one language preference'
+                    : undefined,
+              },
+            }}
+            render={({ field, fieldState: { error } }) => (
+              <LanguagePreferencesList
+                preferences={
+                  field.value ?? [{ iso6391: 'en', displayName: 'English' }]
+                }
+                onChange={field.onChange}
+                error={error}
+              />
+            )}
+          />
+        </FormControl>
+      </Stack>
+      <Stack spacing={2} direction="row" justifyContent="right">
+        {(isDirty || (isDirty && !isSubmitting) || restoreTunarrDefaults) && (
           <Button
-            variant="contained"
-            disabled={
-              !isValid || isSubmitting || (!isDirty && !restoreTunarrDefaults)
-            }
-            type="submit"
+            variant="outlined"
+            onClick={() => {
+              reset(data);
+              setRestoreTunarrDefaults(false);
+            }}
           >
-            Save
+            Reset Changes
           </Button>
-        </Stack>
+        )}
+        <Button
+          variant="contained"
+          disabled={
+            !isValid || isSubmitting || (!isDirty && !restoreTunarrDefaults)
+          }
+          type="submit"
+        >
+          Save
+        </Button>
       </Stack>
       <Divider sx={{ mt: 2 }} />
+
       <Typography variant="h5" sx={{ mt: 2, mb: 1 }}>
         Transcoding Configs
       </Typography>


### PR DESCRIPTION
- Add language preferences to FFmpeg settings to control audio stream selection
- Implement language matching logic in both FFmpeg implementations
- Add UI component for managing language preferences with ISO 639-1 codes
- Update PlexStreamDetails to correctly map language fields
- Add migration to set default English language preference

Many thanks to @AugusDogus for starting this up!!

Fixes #1005