### PR TITLE
Fix duplicated id in bug_report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -34,7 +34,7 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: version
+    id: encoder
     attributes:
       label: FFMPEG encoder type
       description: If this issue is related to streaming, please provide which type of encoder family you are using


### PR DESCRIPTION
The bug report issue template isn't showing up when I try to create a new issue on Github due to the following error:

> There is a problem with this template
> 
> Body must have unique ids. [Learn more about this error.](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#body-must-have-unique-ids)

This change replaces the duplicated `version` id with `encoder` for the new FFMPEG encoder type field.