### PR TITLE
Disable filtering on non-library tabs

### DIFF
--- a/web/src/components/base/StandaloneToggleButton.tsx
+++ b/web/src/components/base/StandaloneToggleButton.tsx
@@ -1,11 +1,14 @@
-import ToggleButton, { ToggleButtonProps } from '@mui/material/ToggleButton';
+import ToggleButton, {
+  type ToggleButtonProps,
+} from '@mui/material/ToggleButton';
 import React from 'react';
 
 type Props = {
   children: React.ReactNode;
   selected: boolean;
-  onToggle(): void;
+  onToggle: () => void;
   toggleButtonProps?: Partial<ToggleButtonProps>;
+  disabled?: boolean;
 };
 
 const defaultProps: Partial<Props> = {
@@ -17,10 +20,12 @@ export default function StandaloneToggleButton({
   selected,
   onToggle,
   toggleButtonProps,
+  disabled = false,
 }: Props) {
   return (
     <ToggleButton
       {...(toggleButtonProps ?? defaultProps.toggleButtonProps)}
+      disabled={disabled}
       value="check"
       selected={selected}
       onChange={() => {

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -24,13 +24,13 @@ import {
   Tooltip,
 } from '@mui/material';
 import { tag } from '@tunarr/types';
-import { PlexFilter } from '@tunarr/types/api';
+import { type PlexFilter } from '@tunarr/types/api';
 import {
-  PlexChildListing,
-  PlexMedia,
   isPlexParentItem,
+  type PlexChildListing,
+  type PlexMedia,
 } from '@tunarr/types/plex';
-import { MediaSourceId } from '@tunarr/types/schemas';
+import { type MediaSourceId } from '@tunarr/types/schemas';
 import { usePrevious } from '@uidotdev/usehooks';
 import {
   chain,
@@ -74,9 +74,9 @@ import { ProgramViewToggleButton } from '../base/ProgramViewToggleButton.tsx';
 import StandaloneToggleButton from '../base/StandaloneToggleButton.tsx';
 import ConnectMediaSources from '../settings/ConnectMediaSources.tsx';
 import {
-  GridInlineModalProps,
-  GridItemProps,
   MediaItemGrid,
+  type GridInlineModalProps,
+  type GridItemProps,
 } from './MediaItemGrid.tsx';
 import { PlexFilterBuilder } from './PlexFilterBuilder.tsx';
 import { PlexGridItem } from './PlexGridItem.tsx';
@@ -553,6 +553,7 @@ export default function PlexProgrammingSelector() {
               <>
                 <Stack direction="row" gap={1} sx={{ mt: 2 }}>
                   <StandaloneToggleButton
+                    disabled={tabValue !== TabValues.Library}
                     selected={searchVisible}
                     onToggle={() => {
                       toggleSearchVisible();
@@ -580,8 +581,7 @@ export default function PlexProgrammingSelector() {
                       </ToggleButtonGroup>
                     </Grow>
                   )}
-
-                  <PlexSortField />
+                  {tabValue === TabValues.Library && <PlexSortField />}
                 </Stack>
                 <Collapse in={searchVisible} mountOnEnter>
                   <Box sx={{ py: 1 }}>


### PR DESCRIPTION
Just a quick tiny change to disable plex filtering for non-library tabs since filtering only works on the library tab.

Separating this out from my other work because there are some larger structural implications to a different change I am making.