### PR TITLE
fix!: properly scope Jellyfin/Emby requests to the auth'd user

### DIFF
--- a/server/drizzle/0002_violet_sheva_callister.sql
+++ b/server/drizzle/0002_violet_sheva_callister.sql
@@ -1,0 +1,28 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_program_external_id` (
+	`uuid` text PRIMARY KEY NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	`direct_file_path` text,
+	`external_file_path` text,
+	`external_key` text NOT NULL,
+	`external_source_id` text,
+	`media_source_id` text,
+	`program_uuid` text NOT NULL,
+	`source_type` text NOT NULL,
+	FOREIGN KEY (`media_source_id`) REFERENCES `media_source`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`program_uuid`) REFERENCES `program`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "source_type" CHECK("__new_program_external_id"."source_type" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby'))
+);
+--> statement-breakpoint
+INSERT INTO `__new_program_external_id`("uuid", "created_at", "updated_at", "direct_file_path", "external_file_path", "external_key", "external_source_id", "media_source_id", "program_uuid", "source_type") SELECT "uuid", "created_at", "updated_at", "direct_file_path", "external_file_path", "external_key", "external_source_id", "media_source_id", "program_uuid", "source_type" FROM `program_external_id`;--> statement-breakpoint
+DROP TABLE `program_external_id`;--> statement-breakpoint
+ALTER TABLE `__new_program_external_id` RENAME TO `program_external_id`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `program_external_id_program_uuid_index` ON `program_external_id` (`program_uuid`);--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_program_multiple_external_id` ON `program_external_id` (`program_uuid`,`source_type`,`external_source_id`) WHERE `external_source_id` is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_program_single_external_id` ON `program_external_id` (`program_uuid`,`source_type`,`external_source_id`) WHERE `external_source_id` is null;--> statement-breakpoint
+ALTER TABLE `media_source` ADD `username` text;--> statement-breakpoint
+ALTER TABLE `media_source` ADD `user_id` text;--> statement-breakpoint
+ALTER TABLE `program` ADD `media_source_id` text REFERENCES media_source(uuid);--> statement-breakpoint
+ALTER TABLE `program_grouping_external_id` ADD `media_source_id` text REFERENCES media_source(uuid);

--- a/server/drizzle/meta/0002_snapshot.json
+++ b/server/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1496 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ff43308e-9a4c-4e6f-b707-419720ab6b09",
+  "prevId": "db0d32a4-fdb6-4f95-ae3c-071c5961b52a",
+  "tables": {
+    "cached_image": {
+      "name": "cached_image",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_custom_show": {
+      "name": "channel_custom_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_custom_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_custom_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_custom_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_custom_show_program_uuid_program_uuid_fk": {
+          "name": "channel_custom_show_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_custom_show",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_custom_show_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_custom_show_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_filler_show": {
+      "name": "channel_filler_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_filler_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_filler_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_filler_show_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "channel_filler_show_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_filler_show_channel_uuid_filler_show_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "filler_show_uuid"
+          ],
+          "name": "channel_filler_show_channel_uuid_filler_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_programs": {
+      "name": "channel_programs",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_programs_channel_uuid_channel_uuid_fk": {
+          "name": "channel_programs_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_programs_program_uuid_program_uuid_fk": {
+          "name": "channel_programs_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_programs_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_programs_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show": {
+      "name": "custom_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_content": {
+      "name": "custom_show_content",
+      "columns": {
+        "content_uuid": {
+          "name": "content_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_show_uuid": {
+          "name": "custom_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_content_custom_show_uuid_custom_show_uuid_fk": {
+          "name": "custom_show_content_custom_show_uuid_custom_show_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_show_content_content_uuid_custom_show_uuid_pk": {
+          "columns": [
+            "content_uuid",
+            "custom_show_uuid"
+          ],
+          "name": "custom_show_content_content_uuid_custom_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show": {
+      "name": "filler_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show_content": {
+      "name": "filler_show_content",
+      "columns": {
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_content_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "filler_show_content_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "filler_show_content_program_uuid_program_uuid_fk": {
+          "name": "filler_show_content_program_uuid_program_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filler_show_content_filler_show_uuid_program_uuid_pk": {
+          "columns": [
+            "filler_show_uuid",
+            "program_uuid"
+          ],
+          "name": "filler_show_content_filler_show_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_source": {
+      "name": "media_source",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_identifier": {
+          "name": "client_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "send_channel_updates": {
+          "name": "send_channel_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_guide_updates": {
+          "name": "send_guide_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_source_type_check": {
+          "name": "media_source_type_check",
+          "value": "\"media_source\".\"type\" in ('plex', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program": {
+      "name": "program",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_uuid": {
+          "name": "album_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode": {
+          "name": "episode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_icon": {
+          "name": "episode_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_external_key": {
+          "name": "grandparent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_air_date": {
+          "name": "original_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_external_key": {
+          "name": "parent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_file_path": {
+          "name": "plex_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_icon": {
+          "name": "season_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_uuid": {
+          "name": "season_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_title": {
+          "name": "show_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tv_show_uuid": {
+          "name": "tv_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_season_uuid_index": {
+          "name": "program_season_uuid_index",
+          "columns": [
+            "season_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_tv_show_uuid_index": {
+          "name": "program_tv_show_uuid_index",
+          "columns": [
+            "tv_show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_album_uuid_index": {
+          "name": "program_album_uuid_index",
+          "columns": [
+            "album_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_artist_uuid_index": {
+          "name": "program_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_source_type_external_source_id_external_key_unique": {
+          "name": "program_source_type_external_source_id_external_key_unique",
+          "columns": [
+            "source_type",
+            "external_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "program_album_uuid_program_grouping_uuid_fk": {
+          "name": "program_album_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "album_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_media_source_id_media_source_uuid_fk": {
+          "name": "program_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_season_uuid_program_grouping_uuid_fk": {
+          "name": "program_season_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "season_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_tv_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_tv_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "tv_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "program_type_check": {
+          "name": "program_type_check",
+          "value": "\"program\".\"type\" in ('movie', 'episode', 'track')"
+        },
+        "program_source_type_check": {
+          "name": "program_source_type_check",
+          "value": "\"program\".\"source_type\" in ('plex', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_external_id": {
+      "name": "program_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direct_file_path": {
+          "name": "direct_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_external_id_program_uuid_index": {
+          "name": "program_external_id_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_multiple_external_id": {
+          "name": "unique_program_multiple_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is not null"
+        },
+        "unique_program_single_external_id": {
+          "name": "unique_program_single_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is null"
+        }
+      },
+      "foreignKeys": {
+        "program_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_external_id_program_uuid_program_uuid_fk": {
+          "name": "program_external_id_program_uuid_program_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type": {
+          "name": "source_type",
+          "value": "\"program_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_grouping": {
+      "name": "program_grouping",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_uuid": {
+          "name": "show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_grouping_show_uuid_index": {
+          "name": "program_grouping_show_uuid_index",
+          "columns": [
+            "show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_grouping_artist_uuid_index": {
+          "name": "program_grouping_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_grouping_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type_check": {
+          "name": "type_check",
+          "value": "\"program_grouping\".\"type\" in ('show', 'season', 'artist', 'album')"
+        }
+      }
+    },
+    "program_grouping_external_id": {
+      "name": "program_grouping_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_uuid": {
+          "name": "group_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_grouping_group_uuid_index": {
+          "name": "program_grouping_group_uuid_index",
+          "columns": [
+            "group_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_external_id_group_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_external_id_group_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type_check": {
+          "name": "source_type_check",
+          "value": "\"program_grouping_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "transcode_config": {
+      "name": "transcode_config",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_count": {
+          "name": "thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hardware_acceleration_mode": {
+          "name": "hardware_acceleration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vaapi_driver": {
+          "name": "vaapi_driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "vaapi_device": {
+          "name": "vaapi_device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_format": {
+          "name": "video_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_profile": {
+          "name": "video_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_preset": {
+          "name": "video_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_bit_depth": {
+          "name": "video_bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 8
+        },
+        "video_bit_rate": {
+          "name": "video_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_buffer_size": {
+          "name": "video_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_bit_rate": {
+          "name": "audio_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_buffer_size": {
+          "name": "audio_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_sample_rate": {
+          "name": "audio_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_volume_percent": {
+          "name": "audio_volume_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "normalize_frame_rate": {
+          "name": "normalize_frame_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deinterlace_video": {
+          "name": "deinterlace_video",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "disable_channel_overlay": {
+          "name": "disable_channel_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_screen": {
+          "name": "error_screen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pic'"
+        },
+        "error_screen_audio": {
+          "name": "error_screen_audio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'silent'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcode_config_hardware_accel_check": {
+          "name": "transcode_config_hardware_accel_check",
+          "value": "\"transcode_config\".\"hardware_acceleration_mode\" in ('none', 'cuda', 'vaapi', 'qsv', 'videotoolbox')"
+        },
+        "transcode_config_vaapi_driver_check": {
+          "name": "transcode_config_vaapi_driver_check",
+          "value": "\"transcode_config\".\"vaapi_driver\" in ('system', 'ihd', 'i965', 'radeonsi', 'nouveau')"
+        },
+        "transcode_config_video_format_check": {
+          "name": "transcode_config_video_format_check",
+          "value": "\"transcode_config\".\"video_format\" in ('h264', 'hevc', 'mpeg2video')"
+        },
+        "transcode_config_audio_format_check": {
+          "name": "transcode_config_audio_format_check",
+          "value": "\"transcode_config\".\"audio_format\" in ('aac', 'ac3', 'copy', 'mp3')"
+        },
+        "transcode_config_error_screen_check": {
+          "name": "transcode_config_error_screen_check",
+          "value": "\"transcode_config\".\"error_screen\" in ('static', 'pic', 'blank', 'testsrc', 'text', 'kill')"
+        },
+        "transcode_config_error_screen_audio_check": {
+          "name": "transcode_config_error_screen_audio_check",
+          "value": "\"transcode_config\".\"error_screen_audio\" in ('silent', 'sine', 'whitenoise')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1739896270684,
       "tag": "0001_orange_alex_power",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1744916940644,
+      "tag": "0002_violet_sheva_callister",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/api/debug/debugJellyfinApi.ts
+++ b/server/src/api/debug/debugJellyfinApi.ts
@@ -24,11 +24,11 @@ export const DebugJellyfinApiRouter: RouterPluginAsyncCallback = async (
     },
     async (req, res) => {
       const client = new JellyfinApiClient({
-        uri: req.query.uri,
+        url: req.query.uri,
         accessToken: req.query.apiKey,
         userId: req.query.userId,
         name: 'debug',
-        clientIdentifier: null,
+        username: null,
       });
 
       await res.send(await client.getUserLibraries(req.query.userId));
@@ -55,10 +55,11 @@ export const DebugJellyfinApiRouter: RouterPluginAsyncCallback = async (
     },
     async (req, res) => {
       const client = new JellyfinApiClient({
-        uri: req.query.uri,
+        url: req.query.uri,
         accessToken: req.query.apiKey,
         name: 'debug',
-        clientIdentifier: null,
+        userId: null,
+        username: null,
       });
 
       let pageParams: Nilable<{ offset: number; limit: number }> = null;

--- a/server/src/api/embyApi.ts
+++ b/server/src/api/embyApi.ts
@@ -66,7 +66,10 @@ export const embyApiRouter: RouterPluginCallback = (fastify, _, done) => {
         req.serverCtx.settings.clientId(),
       );
 
-      return res.send({ accessToken: nullToUndefined(response.AccessToken) });
+      return res.send({
+        accessToken: nullToUndefined(response.AccessToken),
+        userId: nullToUndefined(response.User?.Id),
+      });
     },
   );
 
@@ -80,7 +83,7 @@ export const embyApiRouter: RouterPluginCallback = (fastify, _, done) => {
     (req, res) =>
       withEmbyMediaSource(req, res, async (mediaSource) => {
         const api =
-          await req.serverCtx.mediaSourceApiFactory.getEmbyApiClient(
+          await req.serverCtx.mediaSourceApiFactory.getEmbyApiClientForMediaSource(
             mediaSource,
           );
 
@@ -159,7 +162,7 @@ export const embyApiRouter: RouterPluginCallback = (fastify, _, done) => {
     (req, res) =>
       withEmbyMediaSource(req, res, async (mediaSource) => {
         const api =
-          await req.serverCtx.mediaSourceApiFactory.getEmbyApiClient(
+          await req.serverCtx.mediaSourceApiFactory.getEmbyApiClientForMediaSource(
             mediaSource,
           );
 

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -276,7 +276,9 @@ export const apiRouter: RouterPluginAsyncCallback = async (fastify) => {
       }
 
       const plex =
-        await req.serverCtx.mediaSourceApiFactory.getPlexApiClient(server);
+        await req.serverCtx.mediaSourceApiFactory.getPlexApiClientForMediaSource(
+          server,
+        );
       return res.send(await plex.doGetPath(req.query.path));
     },
   );

--- a/server/src/api/jellyfinApi.ts
+++ b/server/src/api/jellyfinApi.ts
@@ -66,7 +66,10 @@ export const jellyfinApiRouter: RouterPluginCallback = (fastify, _, done) => {
         req.serverCtx.settings.clientId(),
       );
 
-      return res.send({ accessToken: nullToUndefined(response.AccessToken) });
+      return res.send({
+        accessToken: nullToUndefined(response.AccessToken),
+        userId: nullToUndefined(response.User?.Id),
+      });
     },
   );
 
@@ -80,7 +83,7 @@ export const jellyfinApiRouter: RouterPluginCallback = (fastify, _, done) => {
     (req, res) =>
       withJellyfinMediaSource(req, res, async (mediaSource) => {
         const api =
-          await req.serverCtx.mediaSourceApiFactory.getJellyfinApiClient(
+          await req.serverCtx.mediaSourceApiFactory.getJellyfinApiClientForMediaSource(
             mediaSource,
           );
 
@@ -154,7 +157,7 @@ export const jellyfinApiRouter: RouterPluginCallback = (fastify, _, done) => {
     (req, res) =>
       withJellyfinMediaSource(req, res, async (mediaSource) => {
         const api =
-          await req.serverCtx.mediaSourceApiFactory.getJellyfinApiClient(
+          await req.serverCtx.mediaSourceApiFactory.getJellyfinApiClientForMediaSource(
             mediaSource,
           );
 

--- a/server/src/db/schema/MediaSource.ts
+++ b/server/src/db/schema/MediaSource.ts
@@ -32,6 +32,8 @@ export const MediaSource = sqliteTable(
     sendGuideUpdates: integer({ mode: 'boolean' }).default(false),
     type: text({ enum: MediaSourceTypes }).notNull(),
     uri: text().notNull(),
+    username: text(),
+    userId: text(),
   },
   (table) => [
     check(
@@ -52,6 +54,8 @@ export const MediaSourceFields: (keyof MediaSourceTable)[] = [
   'type',
   'updatedAt',
   'uri',
+  'userId',
+  'username',
   'uuid',
 ] as const;
 

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -26,6 +26,7 @@ import Migration1738604866_AddEmby from './db/Migration1738604866_AddEmby.ts';
 import Migration1740691984_ProgramMediaSourceId from './db/Migration1740691984_ProgramMediaSourceId.ts';
 import Migration1741297998_AddProgramIndexes from './db/Migration1741297998_AddProgramIndexes.ts';
 import Migration1741658292_MediaSourceIndex from './db/Migration1741658292_MediaSourceIndex.ts';
+import Migration1744918641_AddMediaSourceUserInfo from './db/Migration1744918641_AddMediaSourceUserInfo.ts';
 
 export const LegacyMigrationNameToNewMigrationName = [
   ['Migration20240124115044', '_Legacy_Migration00'],
@@ -96,6 +97,7 @@ export class DirectMigrationProvider implements MigrationProvider {
           migration1740691984: Migration1740691984_ProgramMediaSourceId,
           migration1741297998: Migration1741297998_AddProgramIndexes,
           migration1741658292: Migration1741658292_MediaSourceIndex,
+          migration1744918641: Migration1744918641_AddMediaSourceUserInfo,
         },
         wrapWithTransaction,
       ),
@@ -117,4 +119,9 @@ function wrapWithTransaction(m: Migration): Migration {
       });
     },
   } satisfies Migration;
+}
+
+export interface TunarrDatabaseMigration extends Migration {
+  inPlace?: boolean;
+  fullCopy?: boolean;
 }

--- a/server/src/migration/db/Migration1738604866_AddEmby.ts
+++ b/server/src/migration/db/Migration1738604866_AddEmby.ts
@@ -1,6 +1,5 @@
 import { CompiledQuery, sql, type Kysely } from 'kysely';
 import { copyTable, swapTables } from '../../db/migrationUtil.ts';
-import { MediaSourceFields } from '../../db/schema/MediaSource.ts';
 
 export default {
   fullCopy: true,
@@ -244,10 +243,23 @@ CREATE TABLE IF NOT EXISTS "program_grouping_tmp" (
       )
       .execute();
 
+    const columns = [
+      'uuid',
+      'created_at',
+      'updated_at',
+      'name',
+      'uri',
+      'access_token',
+      'send_guide_updates',
+      'send_channel_updates',
+      'index',
+      'client_identifier',
+      'type',
+    ];
     await db
       .insertInto('media_source_alter_temp')
-      .columns(MediaSourceFields)
-      .expression(db.selectFrom('media_source').select(MediaSourceFields))
+      .columns(columns)
+      .expression(db.selectFrom('media_source').select(columns))
       .execute();
 
     await db.schema

--- a/server/src/migration/db/Migration1744918641_AddMediaSourceUserInfo.ts
+++ b/server/src/migration/db/Migration1744918641_AddMediaSourceUserInfo.ts
@@ -1,0 +1,53 @@
+import { CompiledQuery, type Kysely } from 'kysely';
+import { isNonEmptyString } from '../../util/index.ts';
+import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+
+// low-fi ... copied from the generated one by drizzle
+
+const expr = String.raw`
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE "__new_program_external_id" (
+	"uuid" text PRIMARY KEY NOT NULL,
+	"created_at" integer,
+	"updated_at" integer,
+	"direct_file_path" text,
+	"external_file_path" text,
+	"external_key" text NOT NULL,
+	"external_source_id" text,
+	"media_source_id" text,
+	"program_uuid" text NOT NULL,
+	"source_type" text NOT NULL,
+	FOREIGN KEY ("media_source_id") REFERENCES "media_source"("uuid") ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY ("program_uuid") REFERENCES "program"("uuid") ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "source_type" CHECK("__new_program_external_id"."source_type" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby'))
+);
+--> statement-breakpoint
+INSERT INTO "__new_program_external_id"("uuid", "created_at", "updated_at", "direct_file_path", "external_file_path", "external_key", "external_source_id", "media_source_id", "program_uuid", "source_type") SELECT "uuid", "created_at", "updated_at", "direct_file_path", "external_file_path", "external_key", "external_source_id", "media_source_id", "program_uuid", "source_type" FROM "program_external_id";--> statement-breakpoint
+DROP TABLE "program_external_id";--> statement-breakpoint
+ALTER TABLE "__new_program_external_id" RENAME TO "program_external_id";--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX "program_external_id_program_uuid_index" ON "program_external_id" ("program_uuid");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_program_multiple_external_id" ON "program_external_id" ("program_uuid","source_type","external_source_id") WHERE "external_source_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_program_single_external_id" ON "program_external_id" ("program_uuid","source_type","external_source_id") WHERE "external_source_id" is null;--> statement-breakpoint
+ALTER TABLE "media_source" ADD "username" text;--> statement-breakpoint
+ALTER TABLE "media_source" ADD "user_id" text;--> statement-breakpoint
+`;
+
+// ALTER TABLE "program" ADD "media_source_id" text REFERENCES media_source(uuid);--> statement-breakpoint
+// ALTER TABLE "program_grouping_external_id" ADD "media_source_id" text REFERENCES media_source(uuid);
+export default {
+  up: async (db: Kysely<unknown>) => {
+    const queries = expr
+      .split('--> statement-breakpoint')
+      .map((s) => s.trim())
+      .filter(isNonEmptyString)
+      .map((s) => CompiledQuery.raw(s));
+
+    console.log(queries);
+
+    for (const query of queries) {
+      await db.executeQuery(query);
+    }
+  },
+  fullCopy: true,
+} satisfies TunarrDatabaseMigration;

--- a/server/src/migration/legacy_migration/legacyDbMigration.ts
+++ b/server/src/migration/legacy_migration/legacyDbMigration.ts
@@ -258,9 +258,10 @@ export class LegacyDbMigrator {
           for (const entity of entities) {
             const plexApi = await this.mediaSourceApiFactory.getPlexApiClient({
               accessToken: entity.accessToken,
-              clientIdentifier: entity.clientIdentifier ?? null,
               name: entity.name,
-              uri: entity.uri,
+              url: entity.uri,
+              userId: null,
+              username: null,
             });
             const healthy = await plexApi.checkServerStatus();
             if (healthy) {

--- a/server/src/migration/legacy_migration/metadataBackfill.ts
+++ b/server/src/migration/legacy_migration/metadataBackfill.ts
@@ -185,7 +185,8 @@ export class LegacyMetadataBackfiller {
       }
 
       // Otherwise, we need to go and find details...
-      const plex = await this.mediaSourceApiFactory.getPlexApiClient(server);
+      const plex =
+        await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(server);
 
       // This where the types have to diverge, because the Plex
       // API types differ.

--- a/server/src/stream/emby/EmbyStreamDetails.ts
+++ b/server/src/stream/emby/EmbyStreamDetails.ts
@@ -77,7 +77,10 @@ export class EmbyStreamDetails {
       return null;
     }
 
-    this.emby = await this.mediaSourceApiFactory.getEmbyApiClient(mediaSource);
+    this.emby =
+      await this.mediaSourceApiFactory.getEmbyApiClientForMediaSource(
+        mediaSource,
+      );
 
     const expectedItemType = item.programType;
     const itemMetadataResult = await this.emby.getItem(item.externalKey);
@@ -188,9 +191,9 @@ export class EmbyStreamDetails {
     let videoStreamDetails: Maybe<VideoStreamDetails>;
     if (isDefined(videoStream)) {
       const isAnamorphic =
-        videoStream.IsAnamorphic ??
+        (videoStream.IsAnamorphic ??
         (isNonEmptyString(videoStream.AspectRatio) &&
-          videoStream.AspectRatio.includes(':'))
+          videoStream.AspectRatio.includes(':')))
           ? extractIsAnamorphic(
               videoStream.Width ?? 1,
               videoStream.Height ?? 1,
@@ -278,8 +281,8 @@ export class EmbyStreamDetails {
       // TODO Use our proxy endpoint here
       const placeholderThumbPath =
         media.Type === 'Audio'
-          ? media.AlbumId ?? first(media.ArtistItems)?.Id ?? media.Id
-          : media.SeasonId ?? media.Id;
+          ? (media.AlbumId ?? first(media.ArtistItems)?.Id ?? media.Id)
+          : (media.SeasonId ?? media.Id);
 
       // We have to check that we can hit this URL or the stream will not work
       if (isNonEmptyString(placeholderThumbPath)) {

--- a/server/src/stream/jellyfin/JellyfinStreamDetails.ts
+++ b/server/src/stream/jellyfin/JellyfinStreamDetails.ts
@@ -78,7 +78,9 @@ export class JellyfinStreamDetails {
     }
 
     this.jellyfin =
-      await this.mediaSourceApiFactory.getJellyfinApiClient(mediaSource);
+      await this.mediaSourceApiFactory.getJellyfinApiClientForMediaSource(
+        mediaSource,
+      );
 
     const expectedItemType = item.programType;
     const itemMetadataResult = await this.jellyfin.getItem(item.externalKey);
@@ -192,9 +194,9 @@ export class JellyfinStreamDetails {
     let videoStreamDetails: Maybe<VideoStreamDetails>;
     if (isDefined(videoStream)) {
       const isAnamorphic =
-        videoStream.IsAnamorphic ??
+        (videoStream.IsAnamorphic ??
         (isNonEmptyString(videoStream.AspectRatio) &&
-          videoStream.AspectRatio.includes(':'))
+          videoStream.AspectRatio.includes(':')))
           ? extractIsAnamorphic(
               videoStream.Width ?? 1,
               videoStream.Height ?? 1,
@@ -282,8 +284,8 @@ export class JellyfinStreamDetails {
       // TODO Use our proxy endpoint here
       const placeholderThumbPath =
         media.Type === 'Audio'
-          ? media.AlbumId ?? first(media.ArtistItems)?.Id ?? media.Id
-          : media.SeasonId ?? media.Id;
+          ? (media.AlbumId ?? first(media.ArtistItems)?.Id ?? media.Id)
+          : (media.SeasonId ?? media.Id);
 
       // We have to check that we can hit this URL or the stream will not work
       if (isNonEmptyString(placeholderThumbPath)) {

--- a/server/src/stream/plex/PlexStreamDetails.ts
+++ b/server/src/stream/plex/PlexStreamDetails.ts
@@ -84,7 +84,8 @@ export class PlexStreamDetails {
       return null;
     }
 
-    this.plex = await this.mediaSourceApiFactory.getPlexApiClient(server);
+    this.plex =
+      await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(server);
 
     const expectedItemType = item.programType;
     const itemMetadataResult = await this.plex.getItemMetadata(
@@ -376,7 +377,7 @@ export class PlexStreamDetails {
     if (audioOnly) {
       // TODO Use our proxy endpoint here
       const placeholderThumbPath = isPlexMusicTrack(media)
-        ? media.parentThumb ?? media.grandparentThumb ?? media.thumb
+        ? (media.parentThumb ?? media.grandparentThumb ?? media.thumb)
         : media.thumb;
 
       // We have to check that we can hit this URL or the stream will not work

--- a/server/src/tasks/UpdateXmlTvTask.ts
+++ b/server/src/tasks/UpdateXmlTvTask.ts
@@ -91,7 +91,9 @@ export class UpdateXmlTvTask extends Task<[string | undefined]> {
 
     await mapAsyncSeq(allMediaSources, async (plexServer) => {
       const plex =
-        await this.mediaSourceApiFactory.getPlexApiClient(plexServer);
+        await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(
+          plexServer,
+        );
       let dvrs: PlexDvr[] = [];
 
       if (!plexServer.sendGuideUpdates && !plexServer.sendChannelUpdates) {

--- a/server/src/tasks/fixers/BackfillProgramExternalIds.ts
+++ b/server/src/tasks/fixers/BackfillProgramExternalIds.ts
@@ -118,7 +118,9 @@ export class BackfillProgramExternalIds extends Fixer {
 
       for (const server of serverSettings) {
         plexConnections[server.name] =
-          await this.mediaSourceApiFactory.getPlexApiClient(server);
+          await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(
+            server,
+          );
       }
 
       for await (const result of asyncPool(

--- a/server/src/tasks/fixers/addPlexServerIds.ts
+++ b/server/src/tasks/fixers/addPlexServerIds.ts
@@ -27,7 +27,8 @@ export class AddPlexServerIdsFixer extends Fixer {
       .where('type', '=', MediaSourceType.Plex)
       .execute();
     for (const server of plexServers) {
-      const api = await this.mediaSourceApiFactory.getPlexApiClient(server);
+      const api =
+        await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(server);
       const devices = await api.getDevices();
       if (!isNil(devices) && devices.MediaContainer.Device) {
         const matchingServer = find(

--- a/server/src/tasks/fixers/missingSeasonNumbersFixer.ts
+++ b/server/src/tasks/fixers/missingSeasonNumbersFixer.ts
@@ -62,7 +62,7 @@ export class MissingSeasonNumbersFixer extends Fixer {
     const plexByName: Record<string, PlexApiClient> = {};
     for (const server of allPlexServers) {
       plexByName[server.name] =
-        await this.mediaSourceApiFactory.getPlexApiClient(server);
+        await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(server);
     }
 
     const updatedPrograms: RawProgram[] = [];
@@ -219,7 +219,8 @@ export class MissingSeasonNumbersFixer extends Fixer {
         continue;
       }
 
-      const plex = await this.mediaSourceApiFactory.getPlexApiClient(server);
+      const plex =
+        await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(server);
       const plexResult = await plex.doGetPath<PlexSeasonView>(
         '/library/metadata/' + ref.externalKey,
       );

--- a/server/src/tasks/jellyfin/UpdateJellyfinPlayStatusTask.ts
+++ b/server/src/tasks/jellyfin/UpdateJellyfinPlayStatusTask.ts
@@ -117,9 +117,10 @@ class UpdateJellyfinPlayStatusTask extends Task {
   }
 
   protected async runInternal(): Promise<boolean> {
-    const jellyfin = await this.mediaSourceApiFactory.getJellyfinApiClient(
-      this.jellyfinServer,
-    );
+    const jellyfin =
+      await this.mediaSourceApiFactory.getJellyfinApiClientForMediaSource(
+        this.jellyfinServer,
+      );
 
     const deviceName = `tunarr-channel-${this.request.channelNumber}`;
     try {

--- a/server/src/tasks/plex/UpdatePlexPlayStatusTask.ts
+++ b/server/src/tasks/plex/UpdatePlexPlayStatusTask.ts
@@ -131,9 +131,10 @@ class UpdatePlexPlayStatusTask extends Task {
   }
 
   protected async runInternal(): Promise<boolean> {
-    const plex = await this.mediaSourceApiFactory.getPlexApiClient(
-      this.plexServer,
-    );
+    const plex =
+      await this.mediaSourceApiFactory.getPlexApiClientForMediaSource(
+        this.plexServer,
+      );
 
     const deviceName = `tunarr-channel-${this.request.channelNumber}`;
     const params = {

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -330,3 +330,22 @@ export const JellyfinGetLibraryItemsQuerySchema = z.object({
   nameStartsWith: z.string().min(1).optional(),
   nameLessThan: z.string().min(1).optional(),
 });
+
+export const MediaSourceHealthyStatusSchema = z.object({
+  healthy: z.literal(true),
+});
+
+export const MediaSourceUnhealthyStatusSchema = z.object({
+  healthy: z.literal(false),
+  status: z.enum(['unreachable', 'auth', 'timeout', 'bad_response', 'unknown']),
+});
+
+export type MediaSourceUnhealthyStatus = z.infer<
+  typeof MediaSourceUnhealthyStatusSchema
+>;
+
+export const MediaSourceStatusSchema = MediaSourceHealthyStatusSchema.or(
+  MediaSourceUnhealthyStatusSchema,
+);
+
+export type MediaSourceStatus = z.infer<typeof MediaSourceStatusSchema>;

--- a/types/src/jellyfin/index.ts
+++ b/types/src/jellyfin/index.ts
@@ -957,28 +957,22 @@ const JellyfinUserPolicy = z.object({
   // SyncPlayAccess: SyncPlayUserAccessType.optional(),
 });
 
-export const JellyfinUser = z
-  .object({
-    Name: z.string().nullable().optional(),
-    ServerId: z.string().nullable().optional(),
-    ServerName: z.string().nullable().optional(),
-    Id: z.string(),
-    PrimaryImageTag: z.string().nullable().optional(),
-    HasPassword: z.boolean(),
-    HasConfiguredPassword: z.boolean(),
-    HasConfiguredEasyPassword: z.boolean(),
-    EnableAutoLogin: z.boolean().nullable().optional(),
-    LastLoginDate: z.string().datetime({ offset: true }).nullable().optional(),
-    LastActivityDate: z
-      .string()
-      .datetime({ offset: true })
-      .nullable()
-      .optional(),
-    Configuration: JellyfinUserConfiguration.nullable().optional(),
-    Policy: JellyfinUserPolicy.nullable().optional(),
-    PrimaryImageAspectRatio: z.number().nullable().optional(),
-  })
-  .partial();
+export const JellyfinUser = z.object({
+  Name: z.string().nullish(),
+  ServerId: z.string().nullish(),
+  ServerName: z.string().nullish(),
+  Id: z.string(),
+  PrimaryImageTag: z.string().nullish(),
+  HasPassword: z.boolean().nullish(),
+  HasConfiguredPassword: z.boolean().nullish(),
+  HasConfiguredEasyPassword: z.boolean().nullish(),
+  EnableAutoLogin: z.boolean().nullish().nullish(),
+  LastLoginDate: z.string().datetime({ offset: true }).nullish(),
+  LastActivityDate: z.string().datetime({ offset: true }).nullish(),
+  Configuration: JellyfinUserConfiguration.nullish(),
+  Policy: JellyfinUserPolicy.nullish(),
+  PrimaryImageAspectRatio: z.number().nullish(),
+});
 
 export const JellyfinAuthenticationResult = z
   .object({

--- a/types/src/plex/index.ts
+++ b/types/src/plex/index.ts
@@ -1,9 +1,16 @@
 import z from 'zod';
-import { FindChild } from '../util.js';
-
+import type { FindChild } from '../util.js';
 export * from './dvr.js';
 
 type Alias<t> = t & { _?: never };
+
+// https://clients.plex.tv/api/v2/user with a token
+// Only has the fields we really care about here.
+export const PlexUserSchema = z.object({
+  id: z.number(),
+  uuid: z.string(),
+  username: z.string(),
+});
 
 // Marker field used to allow directories and non-directories both have
 // this field. This is never defined for non-directories, but can be

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -161,6 +161,8 @@ const BaseMediaSourceSettingsSchema = z.object({
   name: z.string(),
   uri: z.string(),
   accessToken: z.string(),
+  userId: z.string().nullable(),
+  username: z.string().nullable(),
 });
 
 export const PlexServerSettingsSchema = BaseMediaSourceSettingsSchema.extend({

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -82,7 +82,9 @@ export function EditChannelForm({
   isNew,
   initialTab,
 }: EditChannelFormProps) {
-  const navigate = useNavigate({ from: '/channels/$channelId/edit' });
+  const navigate = useNavigate({
+    from: isNew ? '/channels/new' : '/channels/$channelId/edit',
+  });
   const [currentTab, setCurrentTab] = useState<EditChannelTabs>(
     initialTab ?? 'properties',
   );

--- a/web/src/components/settings/media_source/EmbyServerEditDialog.tsx
+++ b/web/src/components/settings/media_source/EmbyServerEditDialog.tsx
@@ -44,7 +44,6 @@ type Props = {
 };
 
 export type EmbyServerSettingsForm = MarkOptional<EmbyServerSettings, 'id'> & {
-  username?: string;
   password?: string;
 };
 
@@ -55,6 +54,7 @@ const emptyDefaults: EmbyServerSettingsForm = {
   accessToken: '',
   username: '',
   password: '',
+  userId: '',
 };
 
 export function EmbyServerEditDialog({ open, onClose, server }: Props) {
@@ -136,7 +136,12 @@ export function EmbyServerEditDialog({ open, onClose, server }: Props) {
 
     if (isNonEmptyString(accessToken)) {
       void handleSubmit(
-        (data) => updateSourceMutation.mutate(data),
+        (data) =>
+          updateSourceMutation.mutate({
+            ...data,
+            userId: null,
+            username: null,
+          }),
         showErrorSnack,
       )(e);
     } else if (isNonEmptyString(username) && isNonEmptyString(password)) {
@@ -147,12 +152,16 @@ export function EmbyServerEditDialog({ open, onClose, server }: Props) {
           uri,
         });
 
-        if (isNonEmptyString(result.accessToken)) {
+        if (
+          isNonEmptyString(result.accessToken) &&
+          isNonEmptyString(result.userId)
+        ) {
           void handleSubmit(
             (data) =>
               updateSourceMutation.mutate({
                 ...data,
                 accessToken: result.accessToken!,
+                userId: result.userId!,
               }),
             showErrorSnack,
           )(e);

--- a/web/src/components/settings/media_source/JelllyfinServerEditDialog.tsx
+++ b/web/src/components/settings/media_source/JelllyfinServerEditDialog.tsx
@@ -47,7 +47,6 @@ export type JellyfinServerSettingsForm = MarkOptional<
   JellyfinServerSettings,
   'id'
 > & {
-  username?: string;
   password?: string;
 };
 
@@ -58,6 +57,7 @@ const emptyDefaults: JellyfinServerSettingsForm = {
   accessToken: '',
   username: '',
   password: '',
+  userId: '',
 };
 
 export function JellyfinServerEditDialog({ open, onClose, server }: Props) {
@@ -139,7 +139,12 @@ export function JellyfinServerEditDialog({ open, onClose, server }: Props) {
 
     if (isNonEmptyString(accessToken)) {
       void handleSubmit(
-        (data) => updateSourceMutation.mutate(data),
+        (data) =>
+          updateSourceMutation.mutate({
+            ...data,
+            userId: null,
+            username: null,
+          }),
         showErrorSnack,
       )(e);
     } else if (isNonEmptyString(username) && isNonEmptyString(password)) {
@@ -150,16 +155,23 @@ export function JellyfinServerEditDialog({ open, onClose, server }: Props) {
           uri,
         });
 
-        if (isNonEmptyString(result.accessToken)) {
+        if (
+          isNonEmptyString(result.accessToken) &&
+          isNonEmptyString(result.userId)
+        ) {
           void handleSubmit(
             (data) =>
               updateSourceMutation.mutate({
                 ...data,
                 accessToken: result.accessToken!,
+                userId: result.userId!,
               }),
             showErrorSnack,
           )(e);
         } else {
+          showErrorSnack(
+            'Did not receive an accessToken or userId from Jellyfin server.',
+          );
           // Pop snackbar
         }
       } catch (e) {
@@ -212,7 +224,6 @@ export function JellyfinServerEditDialog({ open, onClose, server }: Props) {
           id: server?.id && !isDirty ? server.id : undefined,
           accessToken: value.accessToken ?? '',
           uri: value.uri ?? '',
-          // type: 'jellyfin' as const,
         });
       }
     });

--- a/web/src/components/settings/media_source/MediaSourceTableRow.tsx
+++ b/web/src/components/settings/media_source/MediaSourceTableRow.tsx
@@ -2,10 +2,13 @@ import { useTunarrApi } from '@/hooks/useTunarrApi.ts';
 import { CloudDoneOutlined, CloudOff, Delete, Edit } from '@mui/icons-material';
 import { IconButton, Link, TableCell, TableRow } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { MediaSourceSettings } from '@tunarr/types';
+import type { MediaSourceSettings } from '@tunarr/types';
 import { capitalize, isNull, isUndefined } from 'lodash-es';
 import { useState } from 'react';
+import { match } from 'ts-pattern';
+import { Emby, Jellyfin, Plex } from '../../../helpers/constants.ts';
 import { RotatingLoopIcon } from '../../base/LoadingIcon.tsx';
+import { EmbyServerEditDialog } from './EmbyServerEditDialog.tsx';
 import { JellyfinServerEditDialog } from './JelllyfinServerEditDialog.tsx';
 import { MediaSourceDeleteDialog } from './MediaSourceDeleteDialog.tsx';
 import { PlexServerEditDialog } from './PlexServerEditDialog.tsx';
@@ -31,24 +34,29 @@ export function MediaSourceTableRow({ server }: MediaSourceTableRowProps) {
     backendStatus.healthy;
 
   const renderEditDialog = () => {
-    switch (server.type) {
-      case 'plex':
-        return (
-          <PlexServerEditDialog
-            open={editDialogOpen}
-            onClose={() => setEditDialogOpen(false)}
-            server={server}
-          />
-        );
-      case 'jellyfin':
-        return (
-          <JellyfinServerEditDialog
-            open={editDialogOpen}
-            onClose={() => setEditDialogOpen(false)}
-            server={server}
-          />
-        );
-    }
+    return match(server)
+      .with({ type: Plex }, (plex) => (
+        <PlexServerEditDialog
+          open={editDialogOpen}
+          onClose={() => setEditDialogOpen(false)}
+          server={plex}
+        />
+      ))
+      .with({ type: Jellyfin }, (jf) => (
+        <JellyfinServerEditDialog
+          open={editDialogOpen}
+          onClose={() => setEditDialogOpen(false)}
+          server={jf}
+        />
+      ))
+      .with({ type: Emby }, (emby) => (
+        <EmbyServerEditDialog
+          open={editDialogOpen}
+          onClose={() => setEditDialogOpen(false)}
+          server={emby}
+        />
+      ))
+      .exhaustive();
   };
 
   return (

--- a/web/src/components/settings/media_source/PlexServerEditDialog.tsx
+++ b/web/src/components/settings/media_source/PlexServerEditDialog.tsx
@@ -28,11 +28,12 @@ import {
   TextField,
 } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { PlexServerSettings } from '@tunarr/types';
+import type { PlexServerSettings } from '@tunarr/types';
 import { isUndefined } from 'lodash-es';
-import { FormEvent, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { MarkOptional } from 'ts-essentials';
+import type { MarkOptional } from 'ts-essentials';
 import { useDebounceValue } from 'usehooks-ts';
 
 type Props = {
@@ -54,6 +55,8 @@ const emptyDefaults: PlexServerSettingsForm = {
   sendGuideUpdates: false,
   index: 0,
   type: 'plex',
+  userId: '',
+  username: '',
 };
 
 export function PlexServerEditDialog({ open, onClose, server }: Props) {

--- a/web/src/external/settingsApi.ts
+++ b/web/src/external/settingsApi.ts
@@ -141,7 +141,10 @@ const jellyfinLogin = makeEndpoint({
   path: '/api/jellyfin/login',
   parameters: parametersBuilder().addBody(JellyfinLoginRequest).build(),
   alias: 'jellyfinUserLogin',
-  response: z.object({ accessToken: z.string().optional() }),
+  response: z.object({
+    accessToken: z.string().optional(),
+    userId: z.string().optional(),
+  }),
 });
 
 const embyLogin = makeEndpoint({
@@ -149,7 +152,10 @@ const embyLogin = makeEndpoint({
   path: '/api/emby/login',
   parameters: parametersBuilder().addBody(EmbyLoginRequest).build(),
   alias: 'embyUserLogin',
-  response: z.object({ accessToken: z.string().optional() }),
+  response: z.object({
+    accessToken: z.string().optional(),
+    userId: z.string().optional(),
+  }),
 });
 
 const systemHealthChecks = makeEndpoint({

--- a/web/src/hooks/plex/usePlexLogin.tsx
+++ b/web/src/hooks/plex/usePlexLogin.tsx
@@ -1,9 +1,9 @@
-import { plexLoginFlow, checkNewPlexServers } from '@/helpers/plexLogin.ts';
-import { useQueryClient, useMutation } from '@tanstack/react-query';
-import { InsertMediaSourceRequest } from '@tunarr/types/api';
+import { checkNewPlexServers, plexLoginFlow } from '@/helpers/plexLogin.ts';
+import { useTunarrApi } from '@/hooks/useTunarrApi.ts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { InsertMediaSourceRequest } from '@tunarr/types/api';
 import { isEmpty } from 'lodash-es';
 import { useSnackbar } from 'notistack';
-import { useTunarrApi } from '@/hooks/useTunarrApi.ts';
 import { useCallback } from 'react';
 
 export const usePlexLogin = () => {
@@ -45,6 +45,9 @@ export const usePlexLogin = () => {
             uri: connection.uri,
             accessToken: server.accessToken,
             clientIdentifier: server.clientIdentifier,
+            // These will be backfilled later, they require use of a different API
+            userId: null,
+            username: null,
             type: 'plex',
           }),
         );


### PR DESCRIPTION
There are 2 methods of auth with JF/Emby: username + pw or access token.
Tunarr used to erroneously attempt to get the user ID of the admin of
the server and then use that user ID when making requests. This presents
issues if authenticated using username/pw as a user who is NOT the admin
on the server. Additionally, this could present issues when
authenticated using access token (which does not belong to a certain
user).

This change does the following:
* When authenticating using username + pw for Jellyfin / Emby, we now
  save the userId and username in the DB. Passwords are still, and will
never be, saved. We then use this saved userId when making queries
* For existing connections, we attempt to backfill this information by
  hitting /Users/Me on Jellyfin. Emby users may have to reconnect their
server.
* For connections that use a server-level access token (and not username
  / pw), we continue to get the userId of the server admin for
subsequent queries.

This is a breaking change because it requires a DB migration that cannot
be undone.
