### PR TITLE
feat: improvements to restrict hours tool

### DIFF
--- a/web/src/components/channel_config/AddProgrammingButton.tsx
+++ b/web/src/components/channel_config/AddProgrammingButton.tsx
@@ -8,10 +8,11 @@ import {
   Directions as RedirectIcon,
   Nightlight as RestrictHoursIcon,
 } from '@mui/icons-material';
-import { Button, ButtonGroup, MenuItem, Tooltip } from '@mui/material';
+import { Button, ButtonGroup, MenuItem } from '@mui/material';
 import { useNavigate } from '@tanstack/react-router';
 import { isNull } from 'lodash-es';
 import { useState } from 'react';
+import { ElevatedTooltip } from '../base/ElevatedTooltip.tsx';
 import { StyledMenu } from '../base/StyledMenu';
 import AddBreaksModal from '../programming_controls/AddBreaksModal';
 import AddFlexModal from '../programming_controls/AddFlexModal';
@@ -125,12 +126,8 @@ export default function AddProgrammingButton() {
         onClose={() => setAddBreaksModalOpen(false)}
       />
 
-      <ButtonGroup
-        variant="contained"
-        aria-label="Add Programming Button Group"
-      >
+      <ButtonGroup aria-label="Add Programming Button Group">
         <Button
-          variant="contained"
           onClick={addProgrammingOptions[lastSelection].callback}
           startIcon={addProgrammingOptions[lastSelection].icon}
         >
@@ -147,7 +144,12 @@ export default function AddProgrammingButton() {
               {item.name}
             </MenuItem>
           ) : (
-            <Tooltip key={item.name} title={item.description} placement="right">
+            <ElevatedTooltip
+              elevation={5}
+              key={item.name}
+              title={item.description}
+              placement="right"
+            >
               <MenuItem
                 disableRipple
                 onClick={() => {
@@ -158,7 +160,7 @@ export default function AddProgrammingButton() {
               >
                 {item.icon} {item.name}
               </MenuItem>
-            </Tooltip>
+            </ElevatedTooltip>
           ),
         )}
       </StyledMenu>

--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -16,6 +16,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  Divider,
   IconButton,
   Stack,
   ToggleButton,
@@ -49,7 +50,6 @@ export function ChannelProgrammingConfig() {
   } = useChannelEditor();
   const theme = useTheme();
   const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
-  const mediumViewport = useMediaQuery(theme.breakpoints.between('md', 'lg'));
   const programsDirty = useStore((s) => s.channelEditor.dirty.programs);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const snackbar = useSnackbar();
@@ -211,109 +211,117 @@ export function ChannelProgrammingConfig() {
   return (
     <>
       <Stack gap={2}>
-        <Stack direction="row" flexGrow={1} alignItems={'center'}>
-          <Box flex={1}></Box>
-          <Box alignSelf={'flex-end'}>
-            <ToggleButtonGroup
-              value={view}
-              exclusive
-              onChange={(_, v) => setView(v as ViewType)}
-            >
-              <Tooltip title="List">
-                <ToggleButton value="list">
-                  <List />
-                </ToggleButton>
+        <Stack direction={{ md: 'column', lg: 'row' }} justifyContent="center">
+          <Stack
+            direction="row"
+            flexGrow={1}
+            alignItems={'center'}
+            alignSelf={['center']}
+            flex={1}
+          >
+            <Box>
+              <ToggleButtonGroup
+                value={view}
+                exclusive
+                onChange={(_, v) => setView(v as ViewType)}
+              >
+                <Tooltip title="List">
+                  <ToggleButton value="list">
+                    <List />
+                  </ToggleButton>
+                </Tooltip>
+                <Tooltip title="Day">
+                  <ToggleButton value="day">
+                    <CalendarViewDay />
+                  </ToggleButton>
+                </Tooltip>
+                <Tooltip title="Week">
+                  <ToggleButton value="week">
+                    <CalendarViewWeek />
+                  </ToggleButton>
+                </Tooltip>
+                <Tooltip title="Month">
+                  <ToggleButton value="month">
+                    <CalendarViewMonth />
+                  </ToggleButton>
+                </Tooltip>
+              </ToggleButtonGroup>
+            </Box>
+          </Stack>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            gap={{ xs: 1 }}
+            sx={{
+              display: 'flex',
+              columnGap: 1,
+              alignItems: 'center',
+              justifyContent: { sm: 'flex-end' },
+              alignSelf: ['center'],
+              mt: { xs: 1 },
+            }}
+          >
+            <ChannelProgrammingTools />
+            <ChannelProgrammingSort />
+            <AddProgrammingButton />
+            <Divider sx={{ mx: 1 }} orientation="vertical" flexItem />
+
+            {programsDirty && (
+              <Tooltip
+                title="Reset changes made to the channel's lineup"
+                placement="top"
+              >
+                {smallViewport ? (
+                  <IconButton
+                    onClick={() => resetLineup()}
+                    disabled={!programsDirty}
+                  >
+                    <Undo />
+                  </IconButton>
+                ) : (
+                  <Button
+                    onClick={() => resetLineup()}
+                    disabled={!programsDirty}
+                    startIcon={<Undo />}
+                  >
+                    Reset
+                  </Button>
+                )}
               </Tooltip>
-              <Tooltip title="Day">
-                <ToggleButton value="day">
-                  <CalendarViewDay />
-                </ToggleButton>
-              </Tooltip>
-              <Tooltip title="Week">
-                <ToggleButton value="week">
-                  <CalendarViewWeek />
-                </ToggleButton>
-              </Tooltip>
-              <Tooltip title="Month">
-                <ToggleButton value="month">
-                  <CalendarViewMonth />
-                </ToggleButton>
-              </Tooltip>
-            </ToggleButtonGroup>
-          </Box>
-        </Stack>
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          gap={{ xs: 1 }}
-          sx={{
-            display: 'flex',
-            pt: 1,
-            columnGap: 1,
-            alignItems: 'center',
-            justifyContent: { sm: 'flex-end' },
-          }}
-        >
-          <ChannelProgrammingTools />
-          <ChannelProgrammingSort />
-          <AddProgrammingButton />
-          {programsDirty && (
-            <Tooltip
-              title="Reset changes made to the channel's lineup"
-              placement="top"
-            >
-              {mediumViewport ? (
-                <IconButton
-                  onClick={() => resetLineup()}
-                  disabled={!programsDirty}
-                  color="primary"
-                >
-                  <Undo />
-                </IconButton>
-              ) : (
-                <Button
-                  variant="contained"
-                  onClick={() => resetLineup()}
-                  disabled={!programsDirty}
-                  startIcon={<Undo />}
-                >
-                  Reset
-                </Button>
-              )}
-            </Tooltip>
-          )}
-          {mediumViewport ? (
-            <IconButton
-              onClick={() => onSave()}
-              disabled={!programsDirty || isSubmitting}
-            >
-              {isSubmitting ? (
-                <CircularProgress
-                  size="20px"
-                  sx={{ mx: 1, color: 'inherit' }}
-                />
-              ) : (
-                <Save />
-              )}
-            </IconButton>
-          ) : (
-            <Button
-              variant="contained"
-              onClick={() => onSave()}
-              disabled={!programsDirty || isSubmitting}
-              startIcon={
-                isSubmitting ? (
+            )}
+            {smallViewport ? (
+              <IconButton
+                onClick={() => onSave()}
+                disabled={!programsDirty || isSubmitting}
+              >
+                {isSubmitting ? (
                   <CircularProgress
                     size="20px"
                     sx={{ mx: 1, color: 'inherit' }}
                   />
                 ) : (
                   <Save />
-                )
-              }
-            >
-              Save
-            </Button>
-          )}
+                )}
+              </IconButton>
+            ) : (
+              <Button
+                variant="contained"
+                onClick={() => onSave()}
+                disabled={!programsDirty || isSubmitting}
+                startIcon={
+                  isSubmitting ? (
+                    <CircularProgress
+                      size="20px"
+                      sx={{ mx: 1, color: 'inherit' }}
+                    />
+                  ) : (
+                    <Save />
+                  )
+                }
+              >
+                Save
+              </Button>
+            )}
+          </Stack>
         </Stack>
 
         {renderView()}

--- a/web/src/components/channel_config/ChannelProgrammingSort.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingSort.tsx
@@ -8,7 +8,7 @@ import {
   SortByAlpha as SortByAlphaIcon,
   LiveTv as SortTVIcon,
 } from '@mui/icons-material';
-import { Button, ButtonGroup, MenuItem, Tooltip } from '@mui/material';
+import { Button, ButtonGroup, MenuItem } from '@mui/material';
 import { useState } from 'react';
 import { useAlphaSort } from '../../hooks/programming_controls/useAlphaSort.ts';
 import { useBlockShuffle } from '../../hooks/programming_controls/useBlockShuffle.ts';
@@ -17,6 +17,7 @@ import { useEpisodeNumberSort } from '../../hooks/programming_controls/useEpisod
 import { useRandomSort } from '../../hooks/programming_controls/useRandomSort.ts';
 import { useReleaseDateSort } from '../../hooks/programming_controls/useReleaseDateSort.ts';
 import { strings } from '../../strings.ts';
+import { ElevatedTooltip } from '../base/ElevatedTooltip.tsx';
 import { StyledMenu } from '../base/StyledMenu.tsx';
 import AddBlockShuffleModal from '../programming_controls/AddBlockShuffleModal.tsx';
 
@@ -56,7 +57,7 @@ export function ChannelProgrammingSort() {
 
   return (
     <>
-      <ButtonGroup variant="contained" aria-label="Basic button group">
+      <ButtonGroup aria-label="Sort tools button group">
         {!sort && (
           <Button
             startIcon={<ManualIcon />}
@@ -128,7 +129,11 @@ export function ChannelProgrammingSort() {
         <MenuItem divider disabled>
           Sort By...
         </MenuItem>
-        <Tooltip title={strings.SHUFFLE_TOOLTIP} placement="right">
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.SHUFFLE_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -139,9 +144,13 @@ export function ChannelProgrammingSort() {
           >
             <ShuffleIcon /> Random
           </MenuItem>
-        </Tooltip>
+        </ElevatedTooltip>
 
-        <Tooltip title={strings.CYCLIC_SHUFFLE_TOOLTIP} placement="right">
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.CYCLIC_SHUFFLE_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -153,9 +162,13 @@ export function ChannelProgrammingSort() {
             <CyclicIcon />
             Cyclic Shuffle
           </MenuItem>
-        </Tooltip>
+        </ElevatedTooltip>
 
-        <Tooltip title={strings.ALPHA_SORT_TOOLTIP} placement="right">
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.ALPHA_SORT_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -167,9 +180,13 @@ export function ChannelProgrammingSort() {
             <SortByAlphaIcon />
             Alphabetically
           </MenuItem>
-        </Tooltip>
+        </ElevatedTooltip>
 
-        <Tooltip title={strings.RELEASE_SORT_TOOLTIP} placement="right">
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.RELEASE_SORT_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -181,8 +198,12 @@ export function ChannelProgrammingSort() {
             <ReleaseDateIcon />
             Release Date
           </MenuItem>
-        </Tooltip>
-        <Tooltip title={strings.EPISODE_SORT_TOOLTIP} placement="right">
+        </ElevatedTooltip>
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.EPISODE_SORT_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -194,8 +215,12 @@ export function ChannelProgrammingSort() {
             <SortTVIcon />
             Sort TV Shows
           </MenuItem>
-        </Tooltip>
-        <Tooltip title={strings.BLOCK_SHUFFLE_TOOLTIP} placement="right">
+        </ElevatedTooltip>
+        <ElevatedTooltip
+          elevation={5}
+          title={strings.BLOCK_SHUFFLE_TOOLTIP}
+          placement="right"
+        >
           <MenuItem
             disableRipple
             onClick={() => {
@@ -207,7 +232,7 @@ export function ChannelProgrammingSort() {
             <BlockShuffleIcon />
             Block Shuffle
           </MenuItem>
-        </Tooltip>
+        </ElevatedTooltip>
       </StyledMenu>
       <AddBlockShuffleModal
         open={addBlockShuffleModalOpen}

--- a/web/src/helpers/util.ts
+++ b/web/src/helpers/util.ts
@@ -89,7 +89,7 @@ export function grayBackground(mode: PaletteMode) {
   if (mode === 'light') {
     return colors.grey[100];
   } else {
-    return colors.grey[700];
+    return colors.grey[600];
   }
 }
 


### PR DESCRIPTION
Improves the restrict hours programming tool:
1. Restrictions can end at midnight
2. Restrictions can cross the day boundary
3. Fixes bug where run-over programs do not get dropped

Also includes some UI/UX tweaks around the channel program config.
