### PR TITLE
fix: set recursive=true certain types of Jellyfin "libraries"

### DIFF
--- a/web/src/components/channel_config/JellyfinProgrammingSelector.tsx
+++ b/web/src/components/channel_config/JellyfinProgrammingSelector.tsx
@@ -135,7 +135,7 @@ export function JellyfinProgrammingSelector() {
   const jellyfinItemsQuery = useInfiniteJellyfinLibraryItems(
     selectedServer?.id ?? tag<MediaSourceId>(''),
     isEmpty(parentContext)
-      ? selectedLibrary?.view.Id ?? ''
+      ? (selectedLibrary?.view.Id ?? '')
       : last(parentContext)!.Id,
     itemTypes,
     true,
@@ -148,6 +148,10 @@ export function JellyfinProgrammingSelector() {
           ? alphanumericFilter.toUpperCase()
           : undefined,
       sortBy,
+      recursive:
+        selectedLibrary?.view.Type === 'UserView' ||
+        selectedLibrary?.view.Type === 'UserRootFolder' ||
+        selectedLibrary?.view.Type === 'Folder',
     },
   );
 

--- a/web/src/hooks/useTunarrTheme.ts
+++ b/web/src/hooks/useTunarrTheme.ts
@@ -77,6 +77,5 @@ export const useSetColorScheme = () => {
 };
 
 export const useIsDarkMode = () => {
-  const theme = useTunarrTheme();
-  return theme.palette.mode === 'dark';
+  return useColorScheme().mode === 'dark';
 };


### PR DESCRIPTION
Also contains a fix for the background color of the inline modal
