### PR TITLE
Programming Selector Actions Sticky Bar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -211,7 +211,7 @@ export function Root({ children }: { children?: React.ReactNode }) {
         sx={{
           flexGrow: 1,
           // height: '100vh', // Uncommenting this breaks any use of scrollTo()
-          overflow: 'auto',
+          // overflow: 'auto', // Commenting out to support position: sticky
           ml: [undefined, '60px'],
         }}
       >

--- a/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
+++ b/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
@@ -38,6 +38,7 @@ import {
 import { useTunarrApi } from '../../hooks/useTunarrApi.ts';
 import useStore from '../../store';
 import { addSelectedMedia } from '../../store/programmingSelector/actions';
+import SelectedProgrammingActions from './SelectedProgrammingActions.tsx';
 
 dayjs.extend(duration);
 
@@ -173,7 +174,6 @@ export function CustomShowProgrammingSelector({
   );
 
   const renderListItems = () => {
-    console.log(customShows);
     return map(customShows, (cs) => {
       return (
         <CustomShowListItem
@@ -194,6 +194,10 @@ export function CustomShowProgrammingSelector({
           marginTop: 1,
         }}
       />
+
+      <SelectedProgrammingActions
+        toggleOrSetSelectedProgramsDrawer={toggleOrSetSelectedProgramsDrawer}
+      />
       <List
         component="nav"
         sx={{
@@ -210,7 +214,6 @@ export function CustomShowProgrammingSelector({
         {renderListItems()}
         <div style={{ height: 40 }} ref={ref}></div>
       </List>
-
       <Divider sx={{ mt: 3, mb: 2 }} />
     </Box>
   );

--- a/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
+++ b/web/src/components/channel_config/CustomShowProgrammingSelector.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CustomShow, isCustomProgram } from '@tunarr/types';
+import { isCustomProgram, type CustomShow } from '@tunarr/types';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import {
@@ -28,7 +28,7 @@ import {
   negate,
 } from 'lodash-es';
 import pluralize from 'pluralize';
-import { Fragment, MouseEvent, useCallback, useState } from 'react';
+import { Fragment, useCallback, useState, type MouseEvent } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { toggle, typedProperty } from '../../helpers/util';
 import {
@@ -44,6 +44,10 @@ dayjs.extend(duration);
 type CustomShowListItemProps = {
   customShow: CustomShow;
   selectShow: (show: CustomShow) => Promise<void>;
+};
+
+type Props = {
+  toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
 };
 
 function CustomShowListItem({
@@ -125,7 +129,9 @@ function CustomShowListItem({
   );
 }
 
-export function CustomShowProgrammingSelector() {
+export function CustomShowProgrammingSelector({
+  toggleOrSetSelectedProgramsDrawer,
+}: Props) {
   const apiClient = useTunarrApi();
   const { data: customShows, isPending } = useCustomShows();
   const viewType = useStore((state) => state.theme.programmingSelectorView);

--- a/web/src/components/channel_config/EmbyProgrammingSelector.tsx
+++ b/web/src/components/channel_config/EmbyProgrammingSelector.tsx
@@ -38,16 +38,22 @@ import { ProgramViewToggleButton } from '../base/ProgramViewToggleButton.tsx';
 import { EmbyGridItem } from './EmbyGridItem.tsx';
 import { EmbyListItem } from './EmbyListItem.tsx';
 import {
+  MediaItemGrid,
   type GridInlineModalProps,
   type GridItemProps,
-  MediaItemGrid,
 } from './MediaItemGrid.tsx';
 
 enum TabValues {
   Library = 0,
 }
 
-export function EmbyProgrammingSelector() {
+type Props = {
+  toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
+};
+
+export function EmbyProgrammingSelector({
+  toggleOrSetSelectedProgramsDrawer,
+}: Props) {
   const selectedServer = useCurrentMediaSource(Emby);
   const selectedLibrary = useCurrentMediaSourceView(Emby);
   const prevSelectedLibrary = usePrevious(selectedLibrary?.view?.Id);
@@ -105,7 +111,7 @@ export function EmbyProgrammingSelector() {
   const itemsQuery = useInfiniteEmbyLibraryItems(
     selectedServer?.id ?? tag<MediaSourceId>(''),
     isEmpty(parentContext)
-      ? selectedLibrary?.view.Id ?? ''
+      ? (selectedLibrary?.view.Id ?? '')
       : last(parentContext)!.Id,
     itemTypes,
     true,

--- a/web/src/components/channel_config/EmbyProgrammingSelector.tsx
+++ b/web/src/components/channel_config/EmbyProgrammingSelector.tsx
@@ -42,6 +42,7 @@ import {
   type GridInlineModalProps,
   type GridItemProps,
 } from './MediaItemGrid.tsx';
+import SelectedProgrammingActions from './SelectedProgrammingActions.tsx';
 
 enum TabValues {
   Library = 0,
@@ -287,6 +288,11 @@ export function EmbyProgrammingSelector({
         >
           <ProgramViewToggleButton />
         </Stack>
+
+        <SelectedProgrammingActions
+          toggleOrSetSelectedProgramsDrawer={toggleOrSetSelectedProgramsDrawer}
+        />
+
         {isListView && renderContextBreadcrumbs()}
         <Tabs
           value={tabValue}

--- a/web/src/components/channel_config/JellyfinProgrammingSelector.tsx
+++ b/web/src/components/channel_config/JellyfinProgrammingSelector.tsx
@@ -37,10 +37,11 @@ import { ProgramViewToggleButton } from '../base/ProgramViewToggleButton.tsx';
 import { JellyfinGridItem } from './JellyfinGridItem.tsx';
 import { JellyfinListItem } from './JellyfinListItem.tsx';
 import {
+  MediaItemGrid,
   type GridInlineModalProps,
   type GridItemProps,
-  MediaItemGrid,
 } from './MediaItemGrid.tsx';
+import SelectedProgrammingActions from './SelectedProgrammingActions.tsx';
 
 enum TabValues {
   Library = 0,
@@ -66,6 +67,10 @@ function isParentItem(item: JellyfinItem) {
   }
 }
 
+type Props = {
+  toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
+};
+
 const childJellyfinType = forJellyfinItem<JellyfinItemKind>({
   Season: 'Episode',
   Series: 'Season',
@@ -77,7 +82,9 @@ type Size = {
   height?: number;
 };
 
-export function JellyfinProgrammingSelector() {
+export function JellyfinProgrammingSelector({
+  toggleOrSetSelectedProgramsDrawer,
+}: Props) {
   const selectedServer = useCurrentMediaSource(Jellyfin);
   const selectedLibrary = useCurrentMediaSourceView(Jellyfin);
   const prevSelectedLibrary = usePrevious(selectedLibrary?.view?.Id);
@@ -311,6 +318,11 @@ export function JellyfinProgrammingSelector() {
         >
           <ProgramViewToggleButton />
         </Stack>
+
+        <SelectedProgrammingActions
+          toggleOrSetSelectedProgramsDrawer={toggleOrSetSelectedProgramsDrawer}
+        />
+
         {isListView && renderContextBreadcrumbs()}
         <Tabs
           value={tabValue}
@@ -342,7 +354,6 @@ export function JellyfinProgrammingSelector() {
                 )} */}
         </Tabs>
       </Box>
-
       <MediaItemGrid
         getPageDataSize={(page) => ({
           total: page.TotalRecordCount,

--- a/web/src/components/channel_config/MediaGridItem.tsx
+++ b/web/src/components/channel_config/MediaGridItem.tsx
@@ -102,7 +102,6 @@ const MediaGridItemInner = <T,>(
 
   const handleItem = useCallback(
     (e: MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
-      console.log('handle');
       e.stopPropagation();
       if (isSelected) {
         removeSelectedMedia([selectedMediaItem]);

--- a/web/src/components/channel_config/PlexFilterBuilder.tsx
+++ b/web/src/components/channel_config/PlexFilterBuilder.tsx
@@ -18,11 +18,14 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { DatePicker } from '@mui/x-date-pickers';
 import {
-  PlexFilter,
-  PlexFilterOperatorNode,
-  PlexFilterValueNode,
+  type PlexFilter,
+  type PlexFilterOperatorNode,
+  type PlexFilterValueNode,
 } from '@tunarr/types/api';
-import { PlexFilterResponseMeta, PlexFilterType } from '@tunarr/types/plex';
+import {
+  type PlexFilterResponseMeta,
+  type PlexFilterType,
+} from '@tunarr/types/plex';
 import dayjs from 'dayjs';
 import { find, first, isEmpty, isUndefined, map, size } from 'lodash-es';
 import {
@@ -36,10 +39,10 @@ import {
 import {
   Controller,
   FormProvider,
-  SubmitHandler,
   useFieldArray,
   useForm,
   useFormContext,
+  type SubmitHandler,
 } from 'react-hook-form';
 import { useSelectedLibraryPlexFilters } from '../../hooks/plex/usePlexFilters.ts';
 import { usePlexTags } from '../../hooks/plex/usePlexTags.ts';

--- a/web/src/components/channel_config/PlexProgrammingSelector.tsx
+++ b/web/src/components/channel_config/PlexProgrammingSelector.tsx
@@ -24,13 +24,10 @@ import {
   Tooltip,
 } from '@mui/material';
 import { tag } from '@tunarr/types';
-import { type PlexFilter } from '@tunarr/types/api';
-import {
-  isPlexParentItem,
-  type PlexChildListing,
-  type PlexMedia,
-} from '@tunarr/types/plex';
-import { type MediaSourceId } from '@tunarr/types/schemas';
+import type { PlexFilter } from '@tunarr/types/api';
+import type { PlexChildListing, PlexMedia } from '@tunarr/types/plex';
+import { isPlexParentItem } from '@tunarr/types/plex';
+import type { MediaSourceId } from '@tunarr/types/schemas';
 import { usePrevious } from '@uidotdev/usehooks';
 import {
   chain,
@@ -73,15 +70,17 @@ import { TabPanel } from '../TabPanel.tsx';
 import { ProgramViewToggleButton } from '../base/ProgramViewToggleButton.tsx';
 import StandaloneToggleButton from '../base/StandaloneToggleButton.tsx';
 import ConnectMediaSources from '../settings/ConnectMediaSources.tsx';
-import {
-  MediaItemGrid,
-  type GridInlineModalProps,
-  type GridItemProps,
-} from './MediaItemGrid.tsx';
+import type { GridInlineModalProps, GridItemProps } from './MediaItemGrid.tsx';
+import { MediaItemGrid } from './MediaItemGrid.tsx';
 import { PlexFilterBuilder } from './PlexFilterBuilder.tsx';
 import { PlexGridItem } from './PlexGridItem.tsx';
 import { PlexListItem } from './PlexListItem.tsx';
 import { PlexSortField } from './PlexSortField.tsx';
+import SelectedProgrammingActions from './SelectedProgrammingActions.tsx';
+
+type Props = {
+  toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
+};
 
 function a11yProps(index: number) {
   return {
@@ -101,7 +100,9 @@ type Size = {
   height?: number;
 };
 
-export default function PlexProgrammingSelector() {
+export default function PlexProgrammingSelector({
+  toggleOrSetSelectedProgramsDrawer,
+}: Props) {
   const { data: mediaSources } = useMediaSources();
   const plexServers = filter(mediaSources, { type: 'plex' });
   const selectedServer = useCurrentMediaSource('plex');
@@ -547,64 +548,75 @@ export default function PlexProgrammingSelector() {
       {!isNil(directoryChildren) &&
         directoryChildren.size > 0 &&
         selectedLibrary && (
-          <Box sx={{ mt: 1 }}>
-            {selectedLibrary.view.type !==
-              PlexMediaSourceLibraryViewType.Playlists && (
-              <>
-                <Stack direction="row" gap={1} sx={{ mt: 2 }}>
-                  <StandaloneToggleButton
-                    disabled={tabValue !== TabValues.Library}
-                    selected={searchVisible}
-                    onToggle={() => {
-                      toggleSearchVisible();
-                      setPlexFilter(undefined);
-                    }}
-                    toggleButtonProps={{
-                      size: 'small',
-                      sx: { mr: 1 },
-                      color: 'primary',
-                    }}
-                  >
-                    <FilterAlt />
-                  </StandaloneToggleButton>
-                  {searchVisible && (
-                    <Grow in={searchVisible}>
-                      <ToggleButtonGroup
-                        size="small"
-                        color="primary"
-                        exclusive
-                        value={useAdvancedSearch ? 'advanced' : 'basic'}
-                        onChange={() => setUseAdvancedSearch(toggle)}
-                      >
-                        <ToggleButton value="basic">Basic</ToggleButton>
-                        <ToggleButton value="advanced">Advanced</ToggleButton>
-                      </ToggleButtonGroup>
-                    </Grow>
-                  )}
-                  {tabValue === TabValues.Library && <PlexSortField />}
-                </Stack>
-                <Collapse in={searchVisible} mountOnEnter>
-                  <Box sx={{ py: 1 }}>
-                    <PlexFilterBuilder advanced={useAdvancedSearch} />
-                  </Box>
-                </Collapse>
-              </>
-            )}
-
-            <Stack
-              direction={{ xs: 'column', sm: 'row' }}
+          <>
+            <Box
               sx={{
-                display: 'flex',
-                pt: 1,
-                columnGap: 1,
-                alignItems: 'flex-end',
-                justifyContent: 'flex-end',
-                flexGrow: 1,
+                mt: 1,
               }}
             >
-              <ProgramViewToggleButton />
-            </Stack>
-          </Box>
+              {selectedLibrary.view.type !==
+                PlexMediaSourceLibraryViewType.Playlists && (
+                <>
+                  <Stack direction="row" gap={1} sx={{ mt: 2 }}>
+                    <StandaloneToggleButton
+                      selected={searchVisible}
+                      onToggle={() => {
+                        toggleSearchVisible();
+                        setPlexFilter(undefined);
+                      }}
+                      toggleButtonProps={{
+                        size: 'small',
+                        sx: { mr: 1 },
+                        color: 'primary',
+                      }}
+                    >
+                      <FilterAlt />
+                    </StandaloneToggleButton>
+                    {searchVisible && (
+                      <Grow in={searchVisible}>
+                        <ToggleButtonGroup
+                          size="small"
+                          color="primary"
+                          exclusive
+                          value={useAdvancedSearch ? 'advanced' : 'basic'}
+                          onChange={() => setUseAdvancedSearch(toggle)}
+                        >
+                          <ToggleButton value="basic">Basic</ToggleButton>
+                          <ToggleButton value="advanced">Advanced</ToggleButton>
+                        </ToggleButtonGroup>
+                      </Grow>
+                    )}
+
+                    <PlexSortField />
+                  </Stack>
+                  <Collapse in={searchVisible} mountOnEnter>
+                    <Box sx={{ py: 1 }}>
+                      <PlexFilterBuilder advanced={useAdvancedSearch} />
+                    </Box>
+                  </Collapse>
+                </>
+              )}
+
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                sx={{
+                  display: 'flex',
+                  py: 2,
+                  columnGap: 1,
+                  alignItems: 'flex-end',
+                  justifyContent: 'flex-end',
+                  flexGrow: 1,
+                }}
+              >
+                <ProgramViewToggleButton />
+              </Stack>
+            </Box>
+            <SelectedProgrammingActions
+              toggleOrSetSelectedProgramsDrawer={
+                toggleOrSetSelectedProgramsDrawer
+              }
+            />
+          </>
         )}
       {plexServers?.length === 0 ? (
         <Box

--- a/web/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web/src/components/channel_config/ProgrammingSelector.tsx
@@ -68,7 +68,6 @@ export default function ProgrammingSelector({
   const knownMedia = useKnownMedia();
   const [mediaSource, setMediaSource] = useState(selectedServer?.name);
   const navigate = Route.useNavigate();
-  const [open, setOpen] = useState(false);
 
   // Convenience sub-selectors for specific library types
   const selectedPlexLibrary =

--- a/web/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web/src/components/channel_config/ProgrammingSelector.tsx
@@ -53,9 +53,13 @@ import PlexProgrammingSelector from './PlexProgrammingSelector.tsx';
 type Props = {
   initialMediaSourceId?: string;
   initialLibraryId?: string;
+  toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
 };
 
-export default function ProgrammingSelector({ initialMediaSourceId }: Props) {
+export default function ProgrammingSelector({
+  initialMediaSourceId,
+  toggleOrSetSelectedProgramsDrawer,
+}: Props) {
   const { entityType } = useProgrammingSelectionContext();
   const { data: mediaSources, isLoading: mediaSourcesLoading } =
     useMediaSources();
@@ -64,6 +68,7 @@ export default function ProgrammingSelector({ initialMediaSourceId }: Props) {
   const knownMedia = useKnownMedia();
   const [mediaSource, setMediaSource] = useState(selectedServer?.name);
   const navigate = Route.useNavigate();
+  const [open, setOpen] = useState(false);
 
   // Convenience sub-selectors for specific library types
   const selectedPlexLibrary =
@@ -241,13 +246,37 @@ export default function ProgrammingSelector({ initialMediaSourceId }: Props) {
     if (selectedLibrary) {
       switch (selectedLibrary.type) {
         case Plex:
-          return <PlexProgrammingSelector />;
+          return (
+            <PlexProgrammingSelector
+              toggleOrSetSelectedProgramsDrawer={
+                toggleOrSetSelectedProgramsDrawer
+              }
+            />
+          );
         case Jellyfin:
-          return <JellyfinProgrammingSelector />;
+          return (
+            <JellyfinProgrammingSelector
+              toggleOrSetSelectedProgramsDrawer={
+                toggleOrSetSelectedProgramsDrawer
+              }
+            />
+          );
         case Emby:
-          return <EmbyProgrammingSelector />;
+          return (
+            <EmbyProgrammingSelector
+              toggleOrSetSelectedProgramsDrawer={
+                toggleOrSetSelectedProgramsDrawer
+              }
+            />
+          );
         case 'custom-show':
-          return <CustomShowProgrammingSelector />;
+          return (
+            <CustomShowProgrammingSelector
+              toggleOrSetSelectedProgramsDrawer={
+                toggleOrSetSelectedProgramsDrawer
+              }
+            />
+          );
       }
     }
 
@@ -400,7 +429,7 @@ export default function ProgrammingSelector({ initialMediaSourceId }: Props) {
                 value={
                   viewingCustomShows
                     ? 'custom-shows'
-                    : initialMediaSourceId ?? selectedServer?.id ?? ''
+                    : (initialMediaSourceId ?? selectedServer?.id ?? '')
                 }
                 onChange={(e) => onMediaSourceChange(e.target.value)}
               >

--- a/web/src/components/channel_config/SelectedProgrammingActions.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingActions.tsx
@@ -92,8 +92,6 @@ export default function SelectedProgrammingActions({
   const theme = useTheme();
   const smallViewport = useMediaQuery(theme.breakpoints.down('sm'));
   const [selectAllLoading, setSelectAllLoading] = useState(false);
-  const [selectAllCount, setSelectAllCount] = useState(selectedMedia.length);
-  const [showSelectAll, setShowSelectAll] = useState(true);
   const snackbar = useSnackbar();
   const { addSelectedItems } = useAddSelectedItems();
   const removeAllItems = useCallback(() => {
@@ -227,7 +225,7 @@ export default function SelectedProgrammingActions({
       </Box>
 
       <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
-        {selectAllEnabled && showSelectAll && (
+        {selectAllEnabled && (
           <Button
             key={'select-all-programs'}
             variant="contained"

--- a/web/src/components/channel_config/SelectedProgrammingList.tsx
+++ b/web/src/components/channel_config/SelectedProgrammingList.tsx
@@ -9,14 +9,9 @@ import {
   type PlexSelectedMedia,
   type SelectedMedia,
 } from '@/store/programmingSelector/store.ts';
-import {
-  KeyboardArrowLeft,
-  KeyboardArrowRight,
-  Close as RemoveIcon,
-} from '@mui/icons-material';
+import { KeyboardArrowRight, Close as RemoveIcon } from '@mui/icons-material';
 import {
   Box,
-  Chip,
   ClickAwayListener,
   Drawer,
   IconButton,
@@ -33,7 +28,7 @@ import { isPlexDirectory } from '@tunarr/types/plex';
 import type { MediaSourceId } from '@tunarr/types/schemas';
 import { first, groupBy, mapValues } from 'lodash-es';
 import pluralize from 'pluralize';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { FixedSizeList, type ListChildComponentProps } from 'react-window';
 import { P, match } from 'ts-pattern';
 import { useWindowSize } from 'usehooks-ts';
@@ -41,9 +36,8 @@ import { Emby, Jellyfin, Plex } from '../../helpers/constants.ts';
 import { unwrapNil } from '../../helpers/util.ts';
 import { useCustomShows } from '../../hooks/useCustomShows.ts';
 import useStore from '../../store/index.ts';
-import { removeSelectedMedia } from '../../store/programmingSelector/actions.ts';
 import { type KnownMedia } from '../../store/programmingSelector/KnownMedia.ts';
-import AddSelectedMediaButton from './AddSelectedMediaButton.tsx';
+import { removeSelectedMedia } from '../../store/programmingSelector/actions.ts';
 
 type Props = {
   selectAllEnabled?: boolean;
@@ -371,29 +365,22 @@ export default function SelectedProgrammingList({
 
   const ProgrammingList = () => (
     <>
-      {selectedMedia.length > 0 && (
+      {selectedMedia.length > 0 && open && (
         <Paper
           sx={{
             position: 'fixed',
             top: 64,
             right: open ? drawerWidth : 0,
             mt: 1,
+            zIndex: 10,
           }}
         >
-          <Tooltip
-            title={
-              !open
-                ? `View selected ${pluralize('item', selectedMedia.length)}`
-                : 'Close'
-            }
-            placement="left"
-          >
+          <Tooltip title={'Close'} placement="left">
             <IconButton
               disableRipple
               onClick={() => toggleOrSetSelectedProgramsDrawer(!open)}
             >
-              {open ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
-              {!open && <Chip label={selectedMedia.length} />}
+              <KeyboardArrowRight />
             </IconButton>
           </Tooltip>
         </Paper>
@@ -435,20 +422,11 @@ export default function SelectedProgrammingList({
             Selected {pluralize('Item', selectedMedia.length)} (
             {selectedMedia.length}):
           </Typography>
-          <AddSelectedMediaButton
-            buttonText={`Add ${pluralize('Item', selectedMedia.length)}`}
-            variant="contained"
-            color={'primary'}
-            sx={{
-              borderRadius: '10px',
-              width: '100%',
-            }}
-          />
           {selectedMedia.length > 0 && renderSelectedItems()}
         </Drawer>
       </ClickAwayListener>
     </>
   );
 
-  return <ProgrammingList />;
+  return selectedMedia.length && <ProgrammingList />;
 }

--- a/web/src/pages/channels/ProgrammingSelectorPage.tsx
+++ b/web/src/pages/channels/ProgrammingSelectorPage.tsx
@@ -1,4 +1,3 @@
-import SelectedProgrammingActions from '@/components/channel_config/SelectedProgrammingActions.tsx';
 import SelectedProgrammingList from '@/components/channel_config/SelectedProgrammingList.tsx';
 import { useState } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
@@ -28,13 +27,12 @@ export default function ProgrammingSelectorPage({
         <ProgrammingSelector
           initialMediaSourceId={initialMediaSourceId}
           initialLibraryId={initialLibraryId}
+          toggleOrSetSelectedProgramsDrawer={toggleDrawer}
         />
+
         <SelectedProgrammingList
           toggleOrSetSelectedProgramsDrawer={toggleDrawer}
           isOpen={open}
-        />
-        <SelectedProgrammingActions
-          toggleOrSetSelectedProgramsDrawer={toggleDrawer}
         />
       </PaddedPaper>
     </>


### PR DESCRIPTION
Removed the Speed Dial component that was used for programming selector actions and replaced it with a horizontal action bar that sticks to the top of the screen when the page is scrolled.  Screenshots provided below.

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/20f370d4-eb85-40dd-9404-9fd34eee0b4b" />

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/5fa07a9b-a305-4108-8c0d-fb19cdd1ccdd" />


<img width="1187" alt="image" src="https://github.com/user-attachments/assets/5fb8e07b-6e13-49e6-b9d8-d34dc065a246" />

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/62ccb16f-39b9-43e1-8fee-85cb2265f10a" />


