### PR TITLE
chore: upgrade to zod v4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@fastify/cors':
         specifier: ^10.0.1
         version: 10.0.1
+      '@fastify/error':
+        specifier: ^4.1.0
+        version: 4.1.0
       '@fastify/multipart':
         specifier: ^9.0.1
         version: 9.0.1
@@ -169,7 +172,7 @@ importers:
         version: 3.2.0
       fastify-type-provider-zod:
         specifier: ^4.0.1
-        version: 4.0.2(fastify@5.0.0)(zod@3.23.8)
+        version: 4.0.2(fastify@5.0.0)(zod@3.25.20)
       file-type:
         specifier: ^19.6.0
         version: 19.6.0
@@ -231,8 +234,8 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@rollup/plugin-swc':
         specifier: ^0.4.0
@@ -376,8 +379,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@types/lodash-es':
         specifier: 4.17.9
@@ -404,8 +407,8 @@ importers:
   types:
     dependencies:
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.43.0
@@ -470,15 +473,15 @@ importers:
       '@tunarr/types':
         specifier: workspace:*
         version: link:../types
+      '@tunarr/zodios-core':
+        specifier: ^11.0.2
+        version: 11.0.2(axios@1.6.0)(zod@3.25.20)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@zodios/core':
-        specifier: ^10.9.6
-        version: 10.9.6(axios@1.6.0)(zod@3.23.8)
       '@zodios/plugins':
         specifier: ^10.6.0
-        version: 10.6.0(@zodios/core@10.9.6(axios@1.6.0)(zod@3.23.8))(axios@1.6.0)
+        version: 10.6.0(@zodios/core@10.9.6(axios@1.6.0)(zod@3.25.20))(axios@1.6.0)
       axios:
         specifier: ^1.6.0
         version: 1.6.0
@@ -552,8 +555,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
       zustand:
         specifier: ^4.4.6
         version: 4.4.6(@types/react@18.2.15)(immer@10.0.3)(react@18.2.0)
@@ -757,12 +760,20 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.7':
@@ -786,8 +797,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.27.0':
-    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+  '@babel/parser@7.27.2':
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -863,8 +874,8 @@ packages:
     resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.0':
-    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.4':
@@ -1683,8 +1694,8 @@ packages:
   '@fastify/deepmerge@2.0.0':
     resolution: {integrity: sha512-fsaybTGDyQ5KpPsplQqb9yKdCf2x/pbNpMNk8Tvp3rRz7lVcupKysH4b2ELMN2P4Hak1+UqTYdTj/u4FNV2p0g==}
 
-  '@fastify/error@4.0.0':
-    resolution: {integrity: sha512-OO/SA8As24JtT1usTUTKgGH7uLvhfwZPwlptRi2Dp5P4KKmJI3gvsZ8MIHnNwDs4sLf/aai5LzTyl66xr7qMxA==}
+  '@fastify/error@4.1.0':
+    resolution: {integrity: sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ==}
 
   '@fastify/fast-json-stringify-compiler@5.0.1':
     resolution: {integrity: sha512-f2d3JExJgFE3UbdFcpPwqNUEoHWmt8pAKf8f+9YuLESdefA0WgqxeT6DrGL4Yrf/9ihXNSKOqpjEmurV405meA==}
@@ -2537,6 +2548,12 @@ packages:
 
   '@tunarr/playlist@1.1.0':
     resolution: {integrity: sha512-MxwRLHEqEsg+7nmPPnBAVenpi9LjgzUkaS3QxHiHEHW0H0cLagms7EH3fwuW8PQXglRXSHjshVcZBipcwbxTJw==}
+
+  '@tunarr/zodios-core@11.0.2':
+    resolution: {integrity: sha512-4v0BTrfbdgLe+AE5m72+vXiJupPINtV2Y6Ok1dDeNiYWC+/7kRo+d2O1OFkNOkIsHe60RLrH32PspwdaaSfcWA==}
+    peerDependencies:
+      axios: ^0.x || ^1.0.0
+      zod: ^3.25.20
 
   '@types/archiver@6.0.2':
     resolution: {integrity: sha512-KmROQqbQzKGuaAbmK+ZcytkJ51+YqDa7NmbXjmtC5YBLSyQYo21YaUnQ3HbaPFKL1ooo6RQ6OPYPIDyxfpDDXw==}
@@ -7625,8 +7642,8 @@ packages:
     peerDependencies:
       zod: ^3.23.3
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+  zod@3.25.20:
+    resolution: {integrity: sha512-z03fqpTMDF1G02VLKUMt6vyACE7rNWkh3gpXVHgPTw28NPtDFRGvcpTtPwn2kMKtQ0idtYJUTxchytmnqYswcw==}
 
   zustand@4.4.6:
     resolution: {integrity: sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==}
@@ -7824,9 +7841,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1':
+    optional: true
+
   '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    optional: true
 
   '@babel/helper-validator-option@7.24.7': {}
 
@@ -7852,9 +7875,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.7
 
-  '@babel/parser@7.27.0':
+  '@babel/parser@7.27.2':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7)':
@@ -7948,10 +7971,10 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@babel/types@7.27.0':
+  '@babel/types@7.27.1':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
     optional: true
 
   '@changesets/apply-release-plan@7.0.4':
@@ -8680,7 +8703,7 @@ snapshots:
 
   '@fastify/deepmerge@2.0.0': {}
 
-  '@fastify/error@4.0.0': {}
+  '@fastify/error@4.1.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.1':
     dependencies:
@@ -8694,7 +8717,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 3.0.0
       '@fastify/deepmerge': 2.0.0
-      '@fastify/error': 4.0.0
+      '@fastify/error': 4.1.0
       fastify-plugin: 5.0.1
       secure-json-parse: 3.0.0
 
@@ -9433,7 +9456,7 @@ snapshots:
   '@tanstack/router-generator@1.35.4':
     dependencies:
       prettier: 3.5.1
-      zod: 3.23.8
+      zod: 3.25.20
 
   '@tanstack/router-vite-plugin@1.35.4(vite@5.4.1(@types/node@22.10.7))':
     dependencies:
@@ -9452,7 +9475,7 @@ snapshots:
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
       '@vitejs/plugin-react': 4.3.1(vite@5.4.1(@types/node@22.10.7))
-      zod: 3.23.8
+      zod: 3.25.20
     transitivePeerDependencies:
       - supports-color
       - vite
@@ -9480,6 +9503,11 @@ snapshots:
     optional: true
 
   '@tunarr/playlist@1.1.0': {}
+
+  '@tunarr/zodios-core@11.0.2(axios@1.6.0)(zod@3.25.20)':
+    dependencies:
+      axios: 1.6.0
+      zod: 3.25.20
 
   '@types/archiver@6.0.2':
     dependencies:
@@ -10151,14 +10179,14 @@ snapshots:
       - encoding
       - supports-color
 
-  '@zodios/core@10.9.6(axios@1.6.0)(zod@3.23.8)':
+  '@zodios/core@10.9.6(axios@1.6.0)(zod@3.25.20)':
     dependencies:
       axios: 1.6.0
-      zod: 3.23.8
+      zod: 3.25.20
 
-  '@zodios/plugins@10.6.0(@zodios/core@10.9.6(axios@1.6.0)(zod@3.23.8))(axios@1.6.0)':
+  '@zodios/plugins@10.6.0(@zodios/core@10.9.6(axios@1.6.0)(zod@3.25.20))(axios@1.6.0)':
     dependencies:
-      '@zodios/core': 10.9.6(axios@1.6.0)(zod@3.23.8)
+      '@zodios/core': 10.9.6(axios@1.6.0)(zod@3.25.20)
       axios: 1.6.0
       qs: 6.12.0
 
@@ -10179,9 +10207,9 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
-  acorn-jsx@5.3.2(acorn@8.14.0):
+  acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
 
   acorn-walk@8.3.2: {}
 
@@ -10196,8 +10224,7 @@ snapshots:
 
   acorn@8.14.0: {}
 
-  acorn@8.14.1:
-    optional: true
+  acorn@8.14.1: {}
 
   acquerello@2.0.8: {}
 
@@ -10412,7 +10439,7 @@ snapshots:
 
   avvio@9.0.0:
     dependencies:
-      '@fastify/error': 4.0.0
+      '@fastify/error': 4.1.0
       fastq: 1.17.1
 
   axios@1.6.0:
@@ -11587,8 +11614,8 @@ snapshots:
 
   espree@10.3.0:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 4.2.0
 
   esprima@4.0.1: {}
@@ -11729,17 +11756,17 @@ snapshots:
       fastify-plugin: 4.5.1
       table: 6.8.2
 
-  fastify-type-provider-zod@4.0.2(fastify@5.0.0)(zod@3.23.8):
+  fastify-type-provider-zod@4.0.2(fastify@5.0.0)(zod@3.25.20):
     dependencies:
-      '@fastify/error': 4.0.0
+      '@fastify/error': 4.1.0
       fastify: 5.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod: 3.25.20
+      zod-to-json-schema: 3.23.3(zod@3.25.20)
 
   fastify@5.0.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.1
-      '@fastify/error': 4.0.0
+      '@fastify/error': 4.1.0
       '@fastify/fast-json-stringify-compiler': 5.0.1
       abstract-logging: 2.0.1
       avvio: 9.0.0
@@ -12780,8 +12807,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.27.2
+      '@babel/types': 7.27.1
       source-map-js: 1.2.1
     optional: true
 
@@ -13354,7 +13381,7 @@ snapshots:
     dependencies:
       '@apidevtools/swagger-parser': 10.1.0(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0
-      '@zodios/core': 10.9.6(axios@1.6.0)(zod@3.23.8)
+      '@zodios/core': 10.9.6(axios@1.6.0)(zod@3.25.20)
       axios: 1.6.0
       cac: 6.7.14
       handlebars: 4.7.8
@@ -13365,7 +13392,7 @@ snapshots:
       tanu: 0.1.13
       ts-pattern: 5.4.0
       whence: 2.0.0
-      zod: 3.23.8
+      zod: 3.25.20
     transitivePeerDependencies:
       - debug
       - react
@@ -15470,11 +15497,11 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.4.2
 
-  zod-to-json-schema@3.23.3(zod@3.23.8):
+  zod-to-json-schema@3.23.3(zod@3.25.20):
     dependencies:
-      zod: 3.23.8
+      zod: 3.25.20
 
-  zod@3.23.8: {}
+  zod@3.25.20: {}
 
   zustand@4.4.6(@types/react@18.2.15)(immer@10.0.3)(react@18.2.0):
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.1",
+    "@fastify/error": "^4.1.0",
     "@fastify/multipart": "^9.0.1",
     "@fastify/static": "^8.0.1",
     "@fastify/swagger": "^9.0.1",
@@ -71,7 +72,7 @@
     "tslib": "^2.6.2",
     "uuid": "^9.0.1",
     "yargs": "^17.7.2",
-    "zod": "^3.23.8"
+    "zod": "^3.25.20"
   },
   "devDependencies": {
     "@rollup/plugin-swc": "^0.4.0",

--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -37,7 +37,7 @@ import {
   orderBy,
   reduce,
 } from 'lodash-es';
-import z from 'zod';
+import z from 'zod/v4';
 import { dbTranscodeConfigToApiSchema } from '../db/converters/transcodeConfigConverters.ts';
 import type { SessionType } from '../stream/Session.ts';
 import type { ChannelAndLineup } from '../types/internal.ts';

--- a/server/src/api/customShowsApi.ts
+++ b/server/src/api/customShowsApi.ts
@@ -7,7 +7,7 @@ import {
 } from '@tunarr/types/api';
 import { CustomProgramSchema, CustomShowSchema } from '@tunarr/types/schemas';
 import { isNil, isNull, map, sumBy } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const customShowsApiV2: RouterPluginAsyncCallback = async (fastify) => {

--- a/server/src/api/debug/debugFfmpegApi.ts
+++ b/server/src/api/debug/debugFfmpegApi.ts
@@ -3,7 +3,7 @@ import { MpegTsOutputFormat } from '@/ffmpeg/builder/constants.js';
 import { LocalFileStreamDetails } from '@/stream/local/LocalFileStreamDetails.js';
 import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
 import dayjs from 'dayjs';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { container } from '../../container.ts';
 import type { FFmpegFactory } from '../../ffmpeg/FFmpegModule.ts';
 import type { FfmpegEncoder } from '../../ffmpeg/ffmpegInfo.ts';

--- a/server/src/api/debug/debugJellyfinApi.ts
+++ b/server/src/api/debug/debugJellyfinApi.ts
@@ -4,7 +4,7 @@ import { JellyfinItemFinder } from '@/external/jellyfin/JellyfinItemFinder.js';
 import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
 import type { Nilable } from '@/types/util.js';
 import { isNil } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const DebugJellyfinApiRouter: RouterPluginAsyncCallback = async (
   fastify,

--- a/server/src/api/debug/debugPlexApi.ts
+++ b/server/src/api/debug/debugPlexApi.ts
@@ -2,7 +2,7 @@ import { container } from '@/container.js';
 import { ProgramSourceType } from '@/db/custom_types/ProgramSourceType.js';
 import { PlexStreamDetails } from '@/stream/plex/PlexStreamDetails.js';
 import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const DebugPlexApiRouter: RouterPluginAsyncCallback = async (
   fastify,

--- a/server/src/api/debug/debugStreamApi.ts
+++ b/server/src/api/debug/debugStreamApi.ts
@@ -18,7 +18,7 @@ import dayjs from '@/util/dayjs.js';
 import { jsonObjectFrom } from 'kysely/helpers/sqlite';
 import { isNumber, isUndefined, nth, random } from 'lodash-es';
 import { PassThrough } from 'node:stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import type { ProgramStreamFactory } from '../../stream/ProgramStreamFactory.ts';
 
 export const debugStreamApiRouter: RouterPluginAsyncCallback = async (

--- a/server/src/api/debugApi.ts
+++ b/server/src/api/debugApi.ts
@@ -16,7 +16,7 @@ import dayjs from 'dayjs';
 import { jsonArrayFrom } from 'kysely/helpers/sqlite';
 import { isUndefined, map, reject, some } from 'lodash-es';
 import os from 'node:os';
-import z from 'zod';
+import z from 'zod/v4';
 import { container } from '../container.ts';
 import { debugFfmpegApiRouter } from './debug/debugFfmpegApi.ts';
 import { DebugJellyfinApiRouter } from './debug/debugJellyfinApi.js';

--- a/server/src/api/embyApi.ts
+++ b/server/src/api/embyApi.ts
@@ -15,7 +15,7 @@ import {
 } from '@tunarr/types/emby';
 import type { FastifyReply } from 'fastify/types/reply.js';
 import { filter, isEmpty, isNil, isUndefined, uniq } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import type {
   RouterPluginCallback,
   ZodFastifyRequest,

--- a/server/src/api/ffmpegSettingsApi.ts
+++ b/server/src/api/ffmpegSettingsApi.ts
@@ -11,7 +11,7 @@ import {
 } from '@tunarr/types/schemas';
 import { isError, map, merge, omit } from 'lodash-es';
 import { match, P } from 'ts-pattern';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { dbTranscodeConfigToApiSchema } from '../db/converters/transcodeConfigConverters.ts';
 import { GlobalScheduler } from '../services/Scheduler.ts';
 import { SubtitleExtractorTask } from '../tasks/SubtitleExtractorTask.ts';

--- a/server/src/api/fillerListsApi.ts
+++ b/server/src/api/fillerListsApi.ts
@@ -9,7 +9,7 @@ import {
   FillerListSchema,
 } from '@tunarr/types/schemas';
 import { isNil, map } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // We can't use the built-in zod brand because we have our own custom
 // tagged type.

--- a/server/src/api/guideApi.ts
+++ b/server/src/api/guideApi.ts
@@ -4,7 +4,7 @@ import { groupByUniq } from '@/util/index.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { ChannelLineupSchema } from '@tunarr/types/schemas';
 import { isNull } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
   const logger = LoggerFactory.child({
@@ -58,7 +58,7 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
           dateTo: z.coerce.date(),
         }),
         response: {
-          200: z.record(ChannelLineupSchema),
+          200: z.record(z.string(), ChannelLineupSchema),
           400: z.string(),
         },
       },
@@ -87,8 +87,8 @@ export const guideRouter: RouterPluginCallback = (fastify, _opts, done) => {
           id: z.string(),
         }),
         querystring: z.object({
-          dateFrom: z.string().pipe(z.date()),
-          dateTo: z.string().pipe(z.date()),
+          dateFrom: z.string().pipe(z.coerce.date()),
+          dateTo: z.string().pipe(z.coerce.date()),
         }),
       },
     },

--- a/server/src/api/hdhrApi.ts
+++ b/server/src/api/hdhrApi.ts
@@ -1,6 +1,6 @@
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import type { FastifyPluginAsync } from 'fastify';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const HdhrLineupSchema = z.object({
   GuideNumber: z.string(),

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -12,7 +12,7 @@ import { fileTypeFromStream } from 'file-type';
 import { isEmpty, isError, isNil } from 'lodash-es';
 import { createReadStream, promises as fsPromises } from 'node:fs';
 import path from 'node:path';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { container } from '../container.ts';
 import { TruthyQueryParam } from '../types/schemas.ts';
 import { isNonEmptyString, run } from '../util/index.js';

--- a/server/src/api/jellyfinApi.ts
+++ b/server/src/api/jellyfinApi.ts
@@ -15,7 +15,7 @@ import {
 } from '@tunarr/types/jellyfin';
 import type { FastifyReply } from 'fastify/types/reply.js';
 import { filter, isEmpty, isNil, uniq } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import type {
   RouterPluginCallback,
   ZodFastifyRequest,

--- a/server/src/api/mediaSourceApi.ts
+++ b/server/src/api/mediaSourceApi.ts
@@ -25,7 +25,7 @@ import {
 } from '@tunarr/types/schemas';
 import { isError, isNil } from 'lodash-es';
 import { match, P } from 'ts-pattern';
-import z from 'zod';
+import z from 'zod/v4';
 
 export const mediaSourceRouter: RouterPluginAsyncCallback = async (
   fastify,

--- a/server/src/api/metadataApi.ts
+++ b/server/src/api/metadataApi.ts
@@ -16,7 +16,7 @@ import {
 import NodeCache from 'node-cache';
 import { createHash } from 'node:crypto';
 import type stream from 'node:stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   ProgramSourceType,
   programSourceTypeFromString,

--- a/server/src/api/plexSettingsApi.ts
+++ b/server/src/api/plexSettingsApi.ts
@@ -5,7 +5,7 @@ import { defaultPlexStreamSettings } from '@tunarr/types';
 import { PlexStreamSettingsSchema } from '@tunarr/types/schemas';
 import { isError } from 'lodash-es';
 import type { DeepWritable } from 'ts-essentials';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const plexSettingsRouter: RouterPluginCallback = (
   fastify,

--- a/server/src/api/programmingApi.ts
+++ b/server/src/api/programmingApi.ts
@@ -25,7 +25,7 @@ import {
   values,
 } from 'lodash-es';
 import type stream from 'node:stream';
-import z from 'zod';
+import z from 'zod/v4';
 import {
   ProgramSourceType,
   programSourceTypeFromString,
@@ -425,7 +425,7 @@ export const programmingApi: RouterPluginAsyncCallback = async (fastify) => {
         operationId: 'batchGetProgramsByExternalIds',
         body: BatchLookupExternalProgrammingSchema,
         response: {
-          200: z.record(ContentProgramSchema),
+          200: z.record(z.string(), ContentProgramSchema),
         },
       },
     },
@@ -442,7 +442,7 @@ export const programmingApi: RouterPluginAsyncCallback = async (fastify) => {
       schema: {
         tags: ['Programs'],
         params: z.object({
-          id: z.string().uuid(),
+          id: z.uuid(),
         }),
         querystring: z.object({
           includeEpisodes: TruthyQueryParam.default(false),

--- a/server/src/api/sessionApi.ts
+++ b/server/src/api/sessionApi.ts
@@ -4,7 +4,7 @@ import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
 import { run } from '@/util/index.js';
 import { ChannelSessionsResponseSchema } from '@tunarr/types/api';
 import { isEmpty, isNil, isNumber, map } from 'lodash-es';
-import z from 'zod';
+import z from 'zod/v4';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const sessionApiRouter: RouterPluginAsyncCallback = async (fastify) => {
@@ -17,7 +17,7 @@ export const sessionApiRouter: RouterPluginAsyncCallback = async (fastify) => {
       schema: {
         tags: ['Sessions'],
         response: {
-          200: z.record(z.array(ChannelSessionsResponseSchema)),
+          200: z.record(z.string(), z.array(ChannelSessionsResponseSchema)),
         },
       },
     },

--- a/server/src/api/streamApi.ts
+++ b/server/src/api/streamApi.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { format } from 'node:util';
 import { v4 } from 'uuid';
-import z from 'zod';
+import z from 'zod/v4';
 
 export const streamApi: RouterPluginAsyncCallback = async (fastify) => {
   const logger = LoggerFactory.child({

--- a/server/src/api/systemApi.ts
+++ b/server/src/api/systemApi.ts
@@ -25,7 +25,7 @@ import { join } from 'path/posix';
 import split2 from 'split2';
 import { PassThrough } from 'stream';
 import type { DeepReadonly, Writable } from 'ts-essentials';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { container } from '../container.ts';
 import { NvidiaGpuDetectionHelper } from '../ffmpeg/builder/capabilities/NvidiaHardwareCapabilitiesFactory.ts';
 import { SystemDevicesService } from '../services/SystemDevicesService.ts';
@@ -50,7 +50,7 @@ export const systemApiRouter: RouterPluginAsyncCallback = async (
       schema: {
         tags: ['System'],
         response: {
-          200: z.record(HealthCheckSchema),
+          200: z.record(z.string(), HealthCheckSchema),
         },
       },
     },

--- a/server/src/api/tasksApi.ts
+++ b/server/src/api/tasksApi.ts
@@ -5,7 +5,7 @@ import { BaseErrorSchema } from '@tunarr/types/api';
 import { TaskSchema } from '@tunarr/types/schemas';
 import dayjs from 'dayjs';
 import { compact, isEmpty, isNil, map } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const tasksApiRouter: RouterPluginAsyncCallback = async (fastify) => {

--- a/server/src/api/videoApi.ts
+++ b/server/src/api/videoApi.ts
@@ -10,7 +10,7 @@ import dayjs from 'dayjs';
 import { isNil, isNumber } from 'lodash-es';
 import * as fsSync from 'node:fs';
 import { Readable } from 'node:stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const FfmpegPlaylistQuerySchema = z.object({
   channel: z.string().uuid(),

--- a/server/src/api/xmltvSettingsApi.ts
+++ b/server/src/api/xmltvSettingsApi.ts
@@ -8,7 +8,7 @@ import type { XmlTvSettings } from '@tunarr/types';
 import { BaseErrorSchema } from '@tunarr/types/api';
 import { XmlTvSettingsSchema } from '@tunarr/types/schemas';
 import { isError } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const xmlTvSettingsRouter: RouterPluginCallback = (
   fastify,

--- a/server/src/db/SettingsDB.ts
+++ b/server/src/db/SettingsDB.ts
@@ -35,7 +35,7 @@ import path from 'node:path';
 import { setImmediate } from 'node:timers';
 import { DeepPartial, DeepReadonly } from 'ts-essentials';
 import { v4 as uuidv4 } from 'uuid';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   getDefaultLogDirectory,
   getDefaultLogLevel,

--- a/server/src/db/derived_types/Lineup.ts
+++ b/server/src/db/derived_types/Lineup.ts
@@ -4,7 +4,7 @@ import {
   SchedulingOperationSchema,
 } from '@tunarr/types/api';
 import { first } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const BaseLineupItemSchema = z.object({
   durationMs: z.number().positive(), // Add a max
@@ -92,7 +92,7 @@ export const LineupSchema = z.object({
       if (
         first(issue?.path) === 'version' &&
         issue?.code === 'invalid_type' &&
-        issue?.received === 'undefined'
+        issue?.input === undefined
       ) {
         return 0;
       }

--- a/server/src/db/derived_types/StreamLineup.ts
+++ b/server/src/db/derived_types/StreamLineup.ts
@@ -5,7 +5,7 @@
 import { MediaSourceType } from '@/db/schema/MediaSource.js';
 import { ContentProgramTypeSchema } from '@tunarr/types/schemas';
 import type { StrictOmit } from 'ts-essentials';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const baseStreamLineupItemSchema = z.object({
   originalTimestamp: z.number().nonnegative().optional(),

--- a/server/src/db/schema/base.ts
+++ b/server/src/db/schema/base.ts
@@ -4,7 +4,7 @@ import {
   ResolutionSchema,
 } from '@tunarr/types/schemas';
 import type { ColumnType } from 'kysely';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export interface WithCreatedAt {
   createdAt: ColumnType<number, number, never>;

--- a/server/src/external/BaseApiClient.ts
+++ b/server/src/external/BaseApiClient.ts
@@ -12,7 +12,7 @@ import type {
 } from 'axios';
 import axios, { isAxiosError } from 'axios';
 import { isError, isString } from 'lodash-es';
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
 
 export type ApiClientOptions = {
   name: string;
@@ -84,7 +84,7 @@ export abstract class BaseApiClient<
     configureAxiosLogging(this.axiosInstance, this.logger);
   }
 
-  async doTypeCheckedGet<T extends z.ZodTypeAny, Out = z.infer<T>>(
+  async doTypeCheckedGet<T extends z.ZodType, Out = z.infer<T>>(
     path: string,
     schema: T,
     extraConfig: Partial<AxiosRequestConfig> = {},

--- a/server/src/external/emby/EmbyApiClient.ts
+++ b/server/src/external/emby/EmbyApiClient.ts
@@ -31,7 +31,7 @@ import {
 } from 'lodash-es';
 import { type NonEmptyArray } from 'ts-essentials';
 import { v4 } from 'uuid';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   BaseApiClient,
   isQueryError,

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -31,7 +31,7 @@ import {
   union,
 } from 'lodash-es';
 import { v4 } from 'uuid';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   type ApiClientOptions,
   BaseApiClient,

--- a/server/src/stream/ChannelCache.ts
+++ b/server/src/stream/ChannelCache.ts
@@ -7,7 +7,7 @@ import { injectable } from 'inversify';
 import { isNil, isUndefined } from 'lodash-es';
 import { Low } from 'lowdb';
 import { join } from 'node:path';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   StreamLineupItem,
   StreamLineupItemSchema,
@@ -23,9 +23,9 @@ const streamPlayCacheItemSchema = z.object({
 type StreamPlayCacheItem = z.infer<typeof streamPlayCacheItemSchema>;
 
 const channelCacheSchema = z.object({
-  streamPlayCache: z.record(streamPlayCacheItemSchema).default({}),
-  fillerPlayTimeCache: z.record(z.number()).default({}),
-  programPlayTimeCache: z.record(z.number()).default({}),
+  streamPlayCache: z.record(z.string(), streamPlayCacheItemSchema).default({}),
+  fillerPlayTimeCache: z.record(z.string(), z.number()).default({}),
+  programPlayTimeCache: z.record(z.string(), z.number()).default({}),
 });
 
 type ChannelCacheSchema = z.infer<typeof channelCacheSchema>;

--- a/server/src/types/ffmpeg.ts
+++ b/server/src/types/ffmpeg.ts
@@ -1,13 +1,13 @@
 import { parseIntOrNull } from '@/util/index.js';
 import { isNull, split } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const BaseFfprobeMediaStreamSchema = z.object({
   index: z.number(),
   codec_name: z.string(),
   codec_long_name: z.string().optional(),
   profile: z.string().optional(),
-  tags: z.record(z.string()).optional(),
+  tags: z.record(z.string(), z.string()).optional(),
 });
 
 export const FfprobeVideoStreamSchema = BaseFfprobeMediaStreamSchema.extend({

--- a/server/src/types/schemas.ts
+++ b/server/src/types/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const TruthyQueryParam = z
   .union([

--- a/server/src/types/serverType.d.ts
+++ b/server/src/types/serverType.d.ts
@@ -6,12 +6,13 @@ import type {
   RawServerDefault,
   RouteGenericInterface,
 } from 'fastify';
-import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+// import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import type { FastifyRequest } from 'fastify/types/request.d.ts';
 import type { FastifySchema } from 'fastify/types/schema.d.ts';
 import type { ResolveFastifyRequestType } from 'fastify/types/type-provider.d.ts';
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
+import type { ZodTypeProvider } from '../util/zod.ts';
 
 export type ServerType = FastifyInstance<
   RawServerDefault,

--- a/server/src/util/zod.ts
+++ b/server/src/util/zod.ts
@@ -1,0 +1,163 @@
+import createError from '@fastify/error';
+import type {
+  FastifyPluginAsync,
+  FastifyPluginCallback,
+  FastifyPluginOptions,
+  FastifySchema,
+  FastifySchemaCompiler,
+  FastifyTypeProvider,
+  RawServerBase,
+  RawServerDefault,
+} from 'fastify';
+import type { FastifySerializerCompiler } from 'fastify/types/schema.js';
+import { has } from 'lodash-es';
+import z from 'zod/v4';
+import type { $ZodType } from 'zod/v4/core';
+
+export interface ZodTypeProvider extends FastifyTypeProvider {
+  validator: this['schema'] extends z.ZodType
+    ? z.output<this['schema']>
+    : unknown;
+  serializer: this['schema'] extends z.ZodType
+    ? z.input<this['schema']>
+    : unknown;
+}
+
+export type FastifyPluginCallbackZod<
+  Options extends FastifyPluginOptions = Record<never, never>,
+  Server extends RawServerBase = RawServerDefault,
+> = FastifyPluginCallback<Options, Server, ZodTypeProvider>;
+
+export type FastifyPluginAsyncZod<
+  Options extends FastifyPluginOptions = Record<never, never>,
+  Server extends RawServerBase = RawServerDefault,
+> = FastifyPluginAsync<Options, Server, ZodTypeProvider>;
+
+export const validatorCompiler: FastifySchemaCompiler<z.ZodType> =
+  ({ schema }) =>
+  (data) => {
+    const result = schema.safeParse(data);
+    if (result.error) {
+      return { error: result.error };
+    }
+    return { value: result.data };
+  };
+
+export const InvalidSchemaError = createError<[string]>(
+  'FST_ERR_INVALID_SCHEMA',
+  'Invalid schema passed: %s',
+  500,
+);
+
+function resolveSchema(
+  maybeSchema: z.ZodTypeAny | { properties: z.ZodTypeAny },
+): z.ZodTypeAny {
+  if ('safeParse' in maybeSchema) {
+    return maybeSchema;
+  }
+  if ('properties' in maybeSchema) {
+    return maybeSchema.properties;
+  }
+  throw new InvalidSchemaError(JSON.stringify(maybeSchema));
+}
+
+export const createSerializerCompiler =
+  (): FastifySerializerCompiler<z.ZodTypeAny | { properties: z.ZodTypeAny }> =>
+  ({ schema: maybeSchema, method, url }) =>
+  (data) => {
+    const schema = resolveSchema(maybeSchema);
+
+    const result = schema.safeParse(data);
+    if (result.error) {
+      throw new ResponseSerializationError(method, url, {
+        cause: result.error,
+      });
+    }
+
+    return JSON.stringify(result.data);
+  };
+
+export const serializerCompiler = createSerializerCompiler();
+
+export class ResponseSerializationError extends createError<
+  [{ cause: z.ZodError }]
+>('FST_ERR_RESPONSE_SERIALIZATION', "Response doesn't match the schema", 500) {
+  cause!: z.ZodError;
+
+  constructor(
+    public method: string,
+    public url: string,
+    options: { cause: z.ZodError },
+  ) {
+    super({ cause: options.cause });
+  }
+}
+
+export function isResponseSerializationError(
+  value: unknown,
+): value is ResponseSerializationError {
+  return 'method' in (value as ResponseSerializationError);
+}
+
+function isZodSchema(x: unknown): x is $ZodType {
+  return has(x, '_zod');
+}
+
+type Transform<S extends FastifySchema = FastifySchema> = {
+  schema: S;
+  url: string;
+};
+
+type TransformOut = { schema: FastifySchema; url: string };
+
+export const swaggerTransform = <S extends FastifySchema = FastifySchema>({
+  schema,
+  url,
+}: Transform<S>): TransformOut => {
+  if (!schema) {
+    return { schema, url };
+  }
+  const { response, headers, querystring, body, params, hide, ...rest } =
+    schema;
+
+  const transformed: Record<string, unknown> = {};
+
+  if (hide) {
+    transformed.hide = true;
+    return { schema: transformed, url };
+  }
+
+  const zodSchemas: Record<string, unknown> = {
+    headers,
+    querystring,
+    body,
+    params,
+  };
+
+  for (const prop in zodSchemas) {
+    const zodSchema = zodSchemas[prop];
+    if (isZodSchema(zodSchema)) {
+      transformed[prop] = z.toJSONSchema(zodSchema, { unrepresentable: 'any' });
+    }
+  }
+
+  if (response) {
+    const resp = {} as Record<string, unknown>;
+    for (const prop in response) {
+      const schema: unknown = response[prop];
+      if (isZodSchema(schema)) {
+        resp[prop] = z.toJSONSchema(schema, { unrepresentable: 'any' });
+      }
+    }
+    transformed.response = resp;
+  }
+
+  for (const prop in rest) {
+    const meta: unknown = rest[prop];
+    if (meta) {
+      transformed[prop] = meta;
+    }
+  }
+
+  return { schema: transformed, url };
+};

--- a/shared/package.json
+++ b/shared/package.json
@@ -39,7 +39,7 @@
     "lodash-es": "^4.17.21",
     "random-js": "2.1.0",
     "tslib": "^2.6.2",
-    "zod": "^3.23.8"
+    "zod": "^3.25.20"
   },
   "devDependencies": {
     "@types/lodash-es": "4.17.9",

--- a/shared/src/services/ApiProgramMinter.ts
+++ b/shared/src/services/ApiProgramMinter.ts
@@ -275,7 +275,7 @@ export class ApiProgramMinter {
         .with('MusicVideo', () => ContentProgramTypeSchema.enum.music_video)
         .with('Video', () => ContentProgramTypeSchema.enum.other_video)
         .with('Episode', () => ContentProgramTypeSchema.enum.episode)
-        .with('Audio', () => ContentProgramTypeSchema.Enum.track)
+        .with('Audio', () => ContentProgramTypeSchema.enum.track)
         .exhaustive(),
       year: nullToUndefined(item.ProductionYear),
       parent: {
@@ -344,7 +344,7 @@ export class ApiProgramMinter {
         .with('MusicVideo', () => ContentProgramTypeSchema.enum.music_video)
         .with('Video', () => ContentProgramTypeSchema.enum.other_video)
         .with('Episode', () => ContentProgramTypeSchema.enum.episode)
-        .with('Audio', () => ContentProgramTypeSchema.Enum.track)
+        .with('Audio', () => ContentProgramTypeSchema.enum.track)
         .exhaustive(),
       year: nullToUndefined(item.ProductionYear),
       parent: {

--- a/types/package.json
+++ b/types/package.json
@@ -29,7 +29,7 @@
     "typescript": "5.4.3"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^3.25.20"
   },
   "exports": {
     ".": {

--- a/types/src/Channel.ts
+++ b/types/src/Channel.ts
@@ -1,4 +1,4 @@
-import type z from 'zod';
+import type z from 'zod/v4';
 import type {
   ChannelOfflineSchema,
   ChannelSchema,

--- a/types/src/CustomShow.ts
+++ b/types/src/CustomShow.ts
@@ -1,4 +1,4 @@
-import { type z } from 'zod';
+import { type z } from 'zod/v4';
 import {
   type CustomShowProgrammingSchema,
   type CustomShowSchema,

--- a/types/src/Event.ts
+++ b/types/src/Event.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
 import type {
   EventTypeSchema,
   HeartbeatEventSchema,

--- a/types/src/FfmpegSettings.ts
+++ b/types/src/FfmpegSettings.ts
@@ -1,4 +1,4 @@
-import type z from 'zod';
+import type z from 'zod/v4';
 import { FfmpegSettingsSchema } from './schemas/settingsSchemas.js';
 
 export type FfmpegSettings = z.infer<typeof FfmpegSettingsSchema>;

--- a/types/src/FillerList.ts
+++ b/types/src/FillerList.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   FillerListProgrammingSchema,
   FillerListSchema,

--- a/types/src/GuideApi.ts
+++ b/types/src/GuideApi.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import {
   ChannelLineupSchema,
   ContentGuideProgramSchema,

--- a/types/src/HdhrSettings.ts
+++ b/types/src/HdhrSettings.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import { HdhrSettingsSchema } from './schemas/settingsSchemas.js';
 
 export type HdhrSettings = z.infer<typeof HdhrSettingsSchema>;

--- a/types/src/LanguagePreferences.ts
+++ b/types/src/LanguagePreferences.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import {
   LanguagePreferenceSchema,
   LanguagePreferencesSchema,

--- a/types/src/MediaSourceSettings.ts
+++ b/types/src/MediaSourceSettings.ts
@@ -1,4 +1,4 @@
-import type z from 'zod';
+import type z from 'zod/v4';
 import {
   type EmbyServerSettingsSchema,
   type JellyfinServerSettingsSchema,

--- a/types/src/Program.ts
+++ b/types/src/Program.ts
@@ -1,4 +1,4 @@
-import type z from 'zod';
+import type z from 'zod/v4';
 import {
   type BaseProgramSchema,
   type ChannelProgramSchema,

--- a/types/src/Subtitles.ts
+++ b/types/src/Subtitles.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
 import type {
   SubtitleFilterSchema,
   SubtitlePreference,

--- a/types/src/SystemSettings.ts
+++ b/types/src/SystemSettings.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { BackupSettingsSchema } from './schemas/settingsSchemas.js';
 import { type TupleToUnion } from './util.js';
 

--- a/types/src/Tasks.ts
+++ b/types/src/Tasks.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { TaskSchema } from './schemas/tasksSchema.js';
 
 type Alias<T> = T & { _?: never };

--- a/types/src/Theme.ts
+++ b/types/src/Theme.ts
@@ -1,5 +1,5 @@
+import z from 'zod/v4';
 import { ThemeSchema } from './schemas/themeSchema.js';
-import z from 'zod';
 
 export const defaultTheme = ThemeSchema.parse({});
 export type Theme = z.infer<typeof ThemeSchema>;

--- a/types/src/TranscodeConfig.ts
+++ b/types/src/TranscodeConfig.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   SupportedTranscodeVideoOutputFormats,
   TranscodeConfigSchema,

--- a/types/src/XmlTvSettings.ts
+++ b/types/src/XmlTvSettings.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import { XmlTvSettingsSchema } from './schemas/settingsSchemas.js';
 
 export type XmlTvSettings = z.infer<typeof XmlTvSettingsSchema>;

--- a/types/src/api/Scheduling.ts
+++ b/types/src/api/Scheduling.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { PlexSearchSchema } from './plexSearch.js';
 
 const SlotProgrammingOrderSchema = z.enum([

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   CacheSettingsSchema,
   LogLevelsSchema,
@@ -148,18 +148,14 @@ export const RandomSlotProgramLineupSchema = z.object({
   schedule: RandomSlotScheduleSchema,
 });
 
-export const UpdateChannelProgrammingRequestSchema: z.ZodDiscriminatedUnion<
+export const UpdateChannelProgrammingRequestSchema = z.discriminatedUnion(
   'type',
   [
-    typeof ManualProgramLineupSchema,
-    typeof TimeBasedProgramLineupSchema,
-    typeof RandomSlotProgramLineupSchema,
-  ]
-> = z.discriminatedUnion('type', [
-  ManualProgramLineupSchema,
-  TimeBasedProgramLineupSchema,
-  RandomSlotProgramLineupSchema,
-]);
+    ManualProgramLineupSchema,
+    TimeBasedProgramLineupSchema,
+    RandomSlotProgramLineupSchema,
+  ],
+);
 
 export type UpdateChannelProgrammingRequest = z.infer<
   typeof UpdateChannelProgrammingRequestSchema
@@ -268,7 +264,7 @@ export const EmbyLoginRequest = z.object({
 });
 
 export const StreamConnectionDetailsSchema = z.object({
-  ip: z.string().ip(),
+  ip: z.ipv4().or(z.ipv6()),
   userAgent: z.string().optional(),
   lastHeartbeat: z.number().nonnegative().optional(),
 });
@@ -305,7 +301,7 @@ const CondensedChannelProgramWithNoOriginalSchema = z.discriminatedUnion(
 export const GetChannelProgrammingResponseSchema =
   CondensedChannelProgrammingSchema.extend({
     lineup: z.array(CondensedChannelProgramWithNoOriginalSchema),
-    programs: z.record(ContentProgramSchema),
+    programs: z.record(z.string(), ContentProgramSchema),
   });
 
 export const JellyfinGetLibraryItemsQuerySchema = z.object({

--- a/types/src/api/plexSearch.ts
+++ b/types/src/api/plexSearch.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const PlexFilterValueNodeSchema = z.object({
   type: z.literal('value'),

--- a/types/src/emby/index.ts
+++ b/types/src/emby/index.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 
 export const EmbyCollectionType = z.enum([
   'unknown',
@@ -155,7 +155,7 @@ export type EmbyItemSortBy = z.infer<typeof EmbyItemSortBy>;
 const EmbyMediaUrl = z
   .object({ Url: z.string(), Name: z.string() })
   .partial()
-  .passthrough();
+  .loose();
 
 export type EmbyNameIdPair = z.infer<typeof EmbyNameIdPairSchema>;
 export const EmbyNameIdPairSchema = z.object({
@@ -166,7 +166,7 @@ export const EmbyNameIdPairSchema = z.object({
 export const EmbyNameLongIdPair = z
   .object({ Name: z.string(), Id: z.number().int() })
   .partial()
-  .passthrough();
+  .loose();
 
 const EmbyMarkerType = z.enum([
   'Chapter',
@@ -186,7 +186,7 @@ export const EmbyChapterInfoSchema = z
     ChapterIndex: z.number().int(),
   })
   .partial()
-  .passthrough();
+  .loose();
 
 const ExtendedVideoTypes = z.enum([
   'None',
@@ -278,7 +278,7 @@ export const EmbyMediaStreamSchema = z
     SubtitleLocationType: SubtitleLocationType,
   })
   .partial()
-  .passthrough();
+  .loose();
 
 const EmbyMediaSourceType = z.enum(['Default', 'Grouping', 'Placeholder']);
 
@@ -331,7 +331,7 @@ export const EmbyMediaSourceInfoSchema = z
     Formats: z.array(z.string()),
     Bitrate: z.number().int().nullable(),
     Timestamp: TransportStreamTimestamp,
-    RequiredHttpHeaders: z.record(z.string()),
+    RequiredHttpHeaders: z.record(z.string(), z.string()),
     DirectStreamUrl: z.string(),
     AddApiKeyToDirectStreamUrl: z.boolean(),
     TranscodingUrl: z.string(),
@@ -345,7 +345,7 @@ export const EmbyMediaSourceInfoSchema = z
     ServerId: z.string(),
   })
   .partial()
-  .passthrough();
+  .loose();
 
 export type EmbyItem = z.infer<typeof EmbyItemSchema>;
 
@@ -360,7 +360,7 @@ export const EmbyItemSchema = z
     Prefix: z.string(),
     TunerName: z.string(),
     PlaylistItemId: z.string(),
-    DateCreated: z.string().datetime({ offset: true }).nullable(),
+    DateCreated: z.iso.datetime({ offset: true }).nullable(),
     ExtraType: z.string(),
     SortIndexNumber: z.number().int().nullable(),
     SortParentIndexNumber: z.number().int().nullable(),
@@ -389,7 +389,7 @@ export const EmbyItemSchema = z
     Video3DFormat: EmbyVideo3DFormat,
     PremiereDate: z.string().datetime({ offset: true }).nullable(),
     ExternalUrls: z.array(
-      z.object({ Name: z.string(), Url: z.string() }).partial().passthrough(),
+      z.object({ Name: z.string(), Url: z.string() }).partial().loose(),
     ),
     MediaSources: z.array(EmbyMediaSourceInfoSchema),
     CriticRating: z.number().nullable(),
@@ -417,7 +417,7 @@ export const EmbyItemSchema = z
     IndexNumberEnd: z.number().int().nullable(),
     ParentIndexNumber: z.number().int().nullable(),
     RemoteTrailers: z.array(EmbyMediaUrl),
-    ProviderIds: z.record(z.string()),
+    ProviderIds: z.record(z.string(), z.string()),
     IsFolder: z.boolean().nullable(),
     ParentId: z.string(),
     Type: EmbyItemKind,
@@ -431,7 +431,7 @@ export const EmbyItemSchema = z
           PrimaryImageTag: z.string(),
         })
         .partial()
-        .passthrough(),
+        .loose(),
     ),
     Studios: z.array(EmbyNameLongIdPair),
     GenreItems: z.array(EmbyNameLongIdPair),
@@ -455,7 +455,7 @@ export const EmbyItemSchema = z
         ServerId: z.string(),
       })
       .partial()
-      .passthrough(),
+      .loose(),
     RecursiveItemCount: z.number().int().nullable(),
     ChildCount: z.number().int().nullable(),
     SeasonCount: z.number().int().nullable(),
@@ -492,7 +492,7 @@ export const EmbyItemSchema = z
     SeasonName: z.string(),
     MediaStreams: z.array(EmbyMediaStreamSchema),
     PartCount: z.number().int().nullable(),
-    ImageTags: z.record(z.string()),
+    ImageTags: z.record(z.string(), z.string()),
     BackdropImageTags: z.array(z.string()),
     ParentLogoImageTag: z.string(),
     SeriesStudio: z.string(),
@@ -666,7 +666,7 @@ export const EmbyUserSchema = z
     ]),
   })
   .partial()
-  .passthrough();
+  .loose();
 
 const EmbySessionInfoSchema = z
   .object({

--- a/types/src/jellyfin/index.ts
+++ b/types/src/jellyfin/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // Some of this is generated from the Jellyfin 10.9.7 OpenAPI Schema
 
@@ -280,10 +280,10 @@ export const JellyfinMediaStream = z.object({
 });
 
 export const JellyfinImageBlurHashes = z.object({
-  Backdrop: z.record(z.string()).nullable().optional(),
-  Primary: z.record(z.string()).nullable().optional(),
-  Logo: z.record(z.string()).nullable().optional(),
-  Thumb: z.record(z.string()).nullable().optional(),
+  Backdrop: z.record(z.string(), z.string()).nullable().optional(),
+  Primary: z.record(z.string(), z.string()).nullable().optional(),
+  Logo: z.record(z.string(), z.string()).nullable().optional(),
+  Thumb: z.record(z.string(), z.string()).nullable().optional(),
 });
 
 export const JellyfinJoinItem = z.object({
@@ -613,7 +613,7 @@ const MediaSourceInfo = z
     Bitrate: z.number().int().nullable().optional(),
     // Timestamp: TransportStreamTimestamp.nullable().optional(),
     RequiredHttpHeaders: z
-      .record(z.string().nullable().optional())
+      .record(z.string(), z.string().nullable().optional())
       .nullable()
       .optional(),
     TranscodingUrl: z.string().nullable().optional(),
@@ -680,7 +680,10 @@ export const JellyfinItem = z.object({
   IndexNumberEnd: z.number().int().nullable().optional(),
   ParentIndexNumber: z.number().int().nullable().optional(),
   // RemoteTrailers: z.array(MediaUrl).nullable().optional(),
-  ProviderIds: z.record(z.string().nullable().optional()).nullable().optional(),
+  ProviderIds: z
+    .record(z.string(), z.string().nullable().optional())
+    .nullable()
+    .optional(),
   IsHD: z.boolean().nullable().optional(),
   IsFolder: z.boolean().nullable().optional(),
   ParentId: z.string().nullable().optional(),
@@ -720,7 +723,7 @@ export const JellyfinItem = z.object({
   VideoType: VideoType.nullable().optional(),
   PartCount: z.number().int().nullable().optional(),
   MediaSourceCount: z.number().int().nullable().optional(),
-  ImageTags: z.record(z.string()).nullable().optional(),
+  ImageTags: z.record(z.string(), z.string()).nullable().optional(),
   BackdropImageTags: z.array(z.string()).nullable().optional(),
   ScreenshotImageTags: z.array(z.string()).nullable().optional(),
   ParentLogoImageTag: z.string().nullable().optional(),
@@ -729,19 +732,19 @@ export const JellyfinItem = z.object({
   SeriesThumbImageTag: z.string().nullable().optional(),
   ImageBlurHashes: z
     .object({
-      Primary: z.record(z.string()),
-      Art: z.record(z.string()),
-      Backdrop: z.record(z.string()),
-      Banner: z.record(z.string()),
-      Logo: z.record(z.string()),
-      Thumb: z.record(z.string()),
-      Disc: z.record(z.string()),
-      Box: z.record(z.string()),
-      Screenshot: z.record(z.string()),
-      Menu: z.record(z.string()),
-      Chapter: z.record(z.string()),
-      BoxRear: z.record(z.string()),
-      Profile: z.record(z.string()),
+      Primary: z.record(z.string(), z.string()),
+      Art: z.record(z.string(), z.string()),
+      Backdrop: z.record(z.string(), z.string()),
+      Banner: z.record(z.string(), z.string()),
+      Logo: z.record(z.string(), z.string()),
+      Thumb: z.record(z.string(), z.string()),
+      Disc: z.record(z.string(), z.string()),
+      Box: z.record(z.string(), z.string()),
+      Screenshot: z.record(z.string(), z.string()),
+      Menu: z.record(z.string(), z.string()),
+      Chapter: z.record(z.string(), z.string()),
+      BoxRear: z.record(z.string(), z.string()),
+      Profile: z.record(z.string(), z.string()),
     })
     .partial()
     // .passthrough()

--- a/types/src/misc.ts
+++ b/types/src/misc.ts
@@ -1,4 +1,4 @@
-import type z from 'zod';
+import type z from 'zod/v4';
 import type { ExternalId } from './Program.js';
 import type {
   HealthCheckSchema,

--- a/types/src/plex/index.ts
+++ b/types/src/plex/index.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import type { FindChild } from '../util.js';
 export * from './dvr.js';
 
@@ -138,7 +138,7 @@ const basePlexGrandchildCollectionSchema = basePlexChildCollectionSchema.extend(
   },
 );
 
-const makePlexLibraryCollectionsSchema = <T extends z.AnyZodObject>(
+const makePlexLibraryCollectionsSchema = <T extends z.ZodObject>(
   metadata: T,
 ) => {
   return basePlexLibrarySchema.extend({
@@ -956,5 +956,5 @@ export const PlexMediaContainerResponseSchema = z.object({
 });
 
 export const PlexGenericMediaContainerResponseSchema = z.object({
-  MediaContainer: z.record(z.any()),
+  MediaContainer: z.record(z.string(), z.any()),
 });

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import type { TupleToUnion } from '../util.js';
 import { ResolutionSchema } from './miscSchemas.js';
 import {
@@ -106,7 +106,7 @@ export type ChannelConcatStreamMode = TupleToUnion<
 export const ChannelConcatStreamModeSchema = z.enum(ChannelConcatStreamModes);
 
 export const StreamConnectionDetailsSchema = z.object({
-  ip: z.string().ip(),
+  ip: z.ipv4().or(z.ipv6()),
   userAgent: z.string().optional(),
   lastHeartbeat: z.number().nonnegative().optional(),
 });

--- a/types/src/schemas/customShowsSchema.ts
+++ b/types/src/schemas/customShowsSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   ContentProgramSchema,
   CustomProgramSchema,

--- a/types/src/schemas/eventSchema.ts
+++ b/types/src/schemas/eventSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   ChannelConcatStreamModes,
   ChannelStreamModes,

--- a/types/src/schemas/fillerSchema.ts
+++ b/types/src/schemas/fillerSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   ContentProgramSchema,
   CustomProgramSchema,

--- a/types/src/schemas/guideApiSchemas.ts
+++ b/types/src/schemas/guideApiSchemas.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import { ChannelIconSchema } from './index.js';
 import {
   ContentProgramSchema,

--- a/types/src/schemas/miscSchemas.ts
+++ b/types/src/schemas/miscSchemas.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 
 export const ResolutionSchema = z.object({
   widthPx: z.number(),

--- a/types/src/schemas/programmingSchema.ts
+++ b/types/src/schemas/programmingSchema.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import {
   DynamicContentConfigSchema,
   LineupScheduleSchema,
@@ -231,7 +231,7 @@ export const CondensedChannelProgrammingSchema = z.object({
   name: z.string().optional(),
   number: z.number().optional(),
   totalPrograms: z.number(),
-  programs: z.record(ContentProgramSchema),
+  programs: z.record(z.string(), ContentProgramSchema),
   lineup: z.array(CondensedChannelProgramSchema),
   startTimeOffsets,
   schedule: LineupScheduleSchema.optional(),

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import { type Tag, type TupleToUnion } from '../util.js';
 import { ScheduleSchema } from './utilSchemas.js';
 

--- a/types/src/schemas/subtitleSchema.ts
+++ b/types/src/schemas/subtitleSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const SubtitleFilterSchema = z.enum([
   'none',

--- a/types/src/schemas/tasksSchema.ts
+++ b/types/src/schemas/tasksSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const TaskSchema = z.object({
   id: z.string(),

--- a/types/src/schemas/themeSchema.ts
+++ b/types/src/schemas/themeSchema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const ThemeSchema = z.object({
   darkMode: z.boolean().optional(),

--- a/types/src/schemas/transcodeConfigSchemas.ts
+++ b/types/src/schemas/transcodeConfigSchemas.ts
@@ -1,4 +1,4 @@
-import z from 'zod';
+import z from 'zod/v4';
 import { TupleToUnion } from '../util.js';
 import { ResolutionSchema } from './miscSchemas.js';
 import {

--- a/types/src/schemas/util.ts
+++ b/types/src/schemas/util.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // We don't use the built-in Zod brand() because we want to use
 // our custom branding type.
@@ -10,12 +10,12 @@ export function tagSchema<TagType, T extends z.ZodTypeAny>(
   return schema as any;
 }
 
-export function isValidZodLiteralUnion<T extends z.ZodLiteral<unknown>>(
+export function isValidZodLiteralUnion<T extends z.ZodLiteral>(
   literals: T[],
 ): literals is [T, T, ...T[]] {
   return literals.length >= 2;
 }
-export function constructZodLiteralUnionType<T extends z.ZodLiteral<unknown>>(
+export function constructZodLiteralUnionType<T extends z.ZodLiteral>(
   literals: T[],
 ) {
   if (!isValidZodLiteralUnion(literals)) {

--- a/types/src/schemas/utilSchemas.ts
+++ b/types/src/schemas/utilSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { type TupleToUnion } from '../util.js';
 import { constructZodLiteralUnionType } from './util.js';
 

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "@tunarr/shared": "workspace:*",
     "@tunarr/types": "workspace:*",
     "@uidotdev/usehooks": "^2.4.1",
-    "@zodios/core": "^10.9.6",
+    "@tunarr/zodios-core": "^11.0.2",
     "@zodios/plugins": "^10.6.0",
     "axios": "^1.6.0",
     "bowser": "^2.11.0",
@@ -55,7 +55,7 @@
     "ts-pattern": "^5.4.0",
     "usehooks-ts": "^2.14.0",
     "uuid": "^9.0.1",
-    "zod": "^3.23.8",
+    "zod": "^3.25.20",
     "zustand": "^4.4.6"
   },
   "devDependencies": {

--- a/web/src/components/channel_config/ChannelProgrammingConfig.tsx
+++ b/web/src/components/channel_config/ChannelProgrammingConfig.tsx
@@ -25,12 +25,12 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import { ZodiosError } from '@zodios/core';
+import { ZodiosError } from '@tunarr/zodios-core';
 import dayjs, { type Dayjs } from 'dayjs';
 import { chain, findIndex, head, isUndefined, map, reject } from 'lodash-es';
 import { useSnackbar } from 'notistack';
 import { useCallback, useMemo, useState } from 'react';
-import { ZodError } from 'zod';
+import { ZodError } from 'zod/v4';
 import type { CalendarState } from '../slot_scheduler/ProgramCalendarView.tsx';
 import { ProgramCalendarView } from '../slot_scheduler/ProgramCalendarView.tsx';
 import { ProgramDayCalendarView } from '../slot_scheduler/ProgramDayCalendarView.tsx';

--- a/web/src/external/api.ts
+++ b/web/src/external/api.ts
@@ -31,10 +31,10 @@ import {
   makeApi,
   makeErrors,
   parametersBuilder,
-} from '@zodios/core';
+} from '@tunarr/zodios-core';
 import { isEmpty } from 'lodash-es';
 import querystring from 'query-string';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { embyEndpoints } from './embyApi.ts';
 import { getFfmpegInfoEndpoint } from './ffmpegApi.ts';
 import { jellyfinEndpoints } from './jellyfinApi.ts';
@@ -151,7 +151,7 @@ export const api = makeApi([
   {
     method: 'get',
     path: '/api/sessions',
-    response: z.record(z.array(ChannelSessionsResponseSchema)),
+    response: z.record(z.string(), z.array(ChannelSessionsResponseSchema)),
     alias: 'getAllChannelSessions',
   },
   {
@@ -187,7 +187,7 @@ export const api = makeApi([
     parameters: parametersBuilder()
       .addBody(BatchLookupExternalProgrammingSchema)
       .build(),
-    response: z.record(ContentProgramSchema),
+    response: z.record(z.string(), ContentProgramSchema),
   },
   {
     method: 'get',

--- a/web/src/external/embyApi.ts
+++ b/web/src/external/embyApi.ts
@@ -3,8 +3,8 @@ import {
   EmbyItemSortBy,
   EmbyLibraryItemsResponse,
 } from '@tunarr/types/emby';
-import { makeEndpoint, parametersBuilder } from '@zodios/core';
-import { z } from 'zod';
+import { makeEndpoint, parametersBuilder } from '@tunarr/zodios-core';
+import { z } from 'zod/v4';
 
 export const embyEndpoints = [
   makeEndpoint({

--- a/web/src/external/ffmpegApi.ts
+++ b/web/src/external/ffmpegApi.ts
@@ -1,5 +1,5 @@
 import { FfmpegInfoResponse } from '@tunarr/types/api';
-import { makeEndpoint } from '@zodios/core';
+import { makeEndpoint } from '@tunarr/zodios-core';
 
 export const getFfmpegInfoEndpoint = makeEndpoint({
   method: 'get',

--- a/web/src/external/jellyfinApi.ts
+++ b/web/src/external/jellyfinApi.ts
@@ -3,8 +3,8 @@ import {
   JellyfinItemSortBy,
   JellyfinLibraryItemsResponse,
 } from '@tunarr/types/jellyfin';
-import { makeEndpoint, parametersBuilder } from '@zodios/core';
-import { z } from 'zod';
+import { makeEndpoint, parametersBuilder } from '@tunarr/zodios-core';
+import { z } from 'zod/v4';
 
 export const jellyfinEndpoints = [
   makeEndpoint({

--- a/web/src/external/settingsApi.ts
+++ b/web/src/external/settingsApi.ts
@@ -16,8 +16,8 @@ import {
   TranscodeConfigSchema,
   XmlTvSettingsSchema,
 } from '@tunarr/types/schemas';
-import { makeEndpoint, parametersBuilder } from '@zodios/core';
-import { z } from 'zod';
+import { makeEndpoint, parametersBuilder } from '@tunarr/zodios-core';
+import { z } from 'zod/v4';
 
 const getMediaSourcesEndpoint = makeEndpoint({
   method: 'get',
@@ -162,7 +162,7 @@ const systemHealthChecks = makeEndpoint({
   method: 'get',
   path: '/api/system/health',
   alias: 'getSystemHealth',
-  response: z.record(HealthCheckSchema),
+  response: z.record(z.string(), HealthCheckSchema),
 });
 
 const runSystemFixer = makeEndpoint({

--- a/web/src/hooks/useCreateChannel.ts
+++ b/web/src/hooks/useCreateChannel.ts
@@ -1,8 +1,8 @@
 import type { UseMutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Channel, CreateChannelRequest } from '@tunarr/types';
-import { ZodiosError } from '@zodios/core';
-import { z } from 'zod';
+import { ZodiosError } from '@tunarr/zodios-core';
+import { z } from 'zod/v4';
 import { useTunarrApi } from './useTunarrApi.ts';
 
 export const useCreateChannel = (

--- a/web/src/hooks/useCustomShows.ts
+++ b/web/src/hooks/useCustomShows.ts
@@ -7,7 +7,6 @@ import {
 } from '@tanstack/react-query';
 import { type CustomProgram, type CustomShow } from '@tunarr/types';
 import { type ApiClient } from '../external/api.ts';
-import { type ZodiosAliasReturnType } from '../types/index.ts';
 import { makeQueryOptions } from './useQueryHelpers.ts';
 import { useTunarrApi } from './useTunarrApi.ts';
 
@@ -34,18 +33,12 @@ export const useCustomShows = <TOut = CustomShow[]>(
 };
 
 export const customShowQuery = (apiClient: ApiClient, id: string) => ({
-  queryKey: ['custom-shows', id] as DataTag<
-    ['custom-shows', string],
-    ZodiosAliasReturnType<'getCustomShow'>
-  >,
+  queryKey: ['custom-shows', id],
   queryFn: () => apiClient.getCustomShow({ params: { id } }),
 });
 
 export const customShowProgramsQuery = (apiClient: ApiClient, id: string) => ({
-  queryKey: ['custom-shows', id, 'programs'] as DataTag<
-    ['custom-shows', string, 'programs'],
-    ZodiosAliasReturnType<'getCustomShowPrograms'>
-  >,
+  queryKey: ['custom-shows', id, 'programs'],
   queryFn: () => apiClient.getCustomShowPrograms({ params: { id } }),
 });
 

--- a/web/src/hooks/useUpdateChannel.ts
+++ b/web/src/hooks/useUpdateChannel.ts
@@ -1,8 +1,8 @@
 import type { UseMutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Channel, SaveableChannel } from '@tunarr/types';
-import { ZodiosError } from '@zodios/core';
-import { z } from 'zod';
+import { ZodiosError } from '@tunarr/zodios-core';
+import { z } from 'zod/v4';
 import { useTunarrApi } from './useTunarrApi';
 
 export const useUpdateChannel = (

--- a/web/src/hooks/useUpdateLineup.ts
+++ b/web/src/hooks/useUpdateLineup.ts
@@ -3,7 +3,7 @@ import type { UseMutationOptions } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { CondensedChannelProgramming } from '@tunarr/types';
 import type { UpdateChannelProgrammingRequest } from '@tunarr/types/api';
-import { ZodiosError } from '@zodios/core';
+import { ZodiosError } from '@tunarr/zodios-core';
 import { useTunarrApi } from './useTunarrApi';
 
 type MutateArgs = {

--- a/web/src/routes/channels/new.tsx
+++ b/web/src/routes/channels/new.tsx
@@ -8,7 +8,7 @@ import { Channel } from '@tunarr/types';
 import dayjs from 'dayjs';
 import { find, first, maxBy } from 'lodash-es';
 import { v4 } from 'uuid';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 function defaultNewChannel(num: number, transcodeConfigId: string): Channel {
   return {

--- a/web/src/routes/channels_/$channelId/edit/index.tsx
+++ b/web/src/routes/channels_/$channelId/edit/index.tsx
@@ -3,7 +3,7 @@ import EditChannelPage from '@/pages/channels/EditChannelPage';
 import { safeSetCurrentChannel } from '@/store/channelEditor/actions';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import { isUndefined } from 'lodash-es';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // TODO: Share this schema between new and edit routes
 const editChannelParamsSchema = z.object({

--- a/web/src/routes/channels_/$channelId/programming/add.tsx
+++ b/web/src/routes/channels_/$channelId/programming/add.tsx
@@ -7,7 +7,7 @@ import { addMediaToCurrentChannel } from '@/store/channelEditor/actions';
 import { setPlexFilter } from '@/store/programmingSelector/actions';
 import { createFileRoute } from '@tanstack/react-router';
 import { useCallback } from 'react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { ProgrammingSelectionContext } from '../../../../context/ProgrammingSelectionContext.ts';
 
 const channelProgrammingSchema = z.object({

--- a/web/src/routes/channels_/$channelId/watch.tsx
+++ b/web/src/routes/channels_/$channelId/watch.tsx
@@ -1,7 +1,7 @@
 import { channelQuery } from '@/hooks/useChannels';
 import ChannelWatchPage from '@/pages/watch/ChannelWatchPage';
 import { createFileRoute } from '@tanstack/react-router';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const watchPageSearchSchema = z.object({
   noAutoPlay: z.coerce

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -11,12 +11,12 @@ import {
   type Program,
   type RedirectProgram,
 } from '@tunarr/types';
-import { type ApiOf } from '@zodios/core';
+import { type ApiOf } from '@tunarr/zodios-core';
 import {
   type ZodiosAliases,
   type ZodiosQueryParamsByAlias,
   type ZodiosResponseByAlias,
-} from '@zodios/core/lib/zodios.types';
+} from '@tunarr/zodios-core/lib/zodios.types';
 import type { MarkRequired } from 'ts-essentials';
 import { type ApiClient } from '../external/api.ts';
 import type { EnrichedEmbyItem } from '../helpers/embyUtil.ts';


### PR DESCRIPTION
Upgrades to Zod v4 which should bring a lot of niceties, including built-in support for generating JSON schema, really nice performance improvements for both dev side and parsing side, a lot of great new features + better errors.

Since some libraries we use that integrate with Zod are / were lagging behind or abandoned, I had to fork and upgrade them or just pull their logic into Tunarr and upgrade there. 