### PR TITLE
feat(backend): add support for Tunarr worker thread pools

### DIFF
--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -38,6 +38,7 @@ import {
 } from './globals.js';
 import { ServerContext, ServerRequestContext } from './ServerContext.js';
 import { GlobalScheduler, scheduleJobs } from './services/Scheduler.ts';
+import { TunarrWorkerPool } from './services/TunarrWorkerPool.ts';
 import { initPersistentStreamCache } from './stream/ChannelCache.js';
 import { UpdateXmlTvTask } from './tasks/UpdateXmlTvTask.js';
 import { TUNARR_ENV_VARS } from './util/env.ts';
@@ -507,6 +508,13 @@ export class Server {
               session.sessionType,
             );
           }
+        }
+
+        this.logger.debug('Shutting down all workers');
+        try {
+          await container.get(TunarrWorkerPool).shutdown();
+        } catch (e) {
+          this.logger.error(e, 'Error shutting down workers');
         }
 
         this.serverContext.eventService.close();

--- a/server/src/cli/GenerateOpenApiCommand.ts
+++ b/server/src/cli/GenerateOpenApiCommand.ts
@@ -10,7 +10,7 @@ import { getTunarrVersion } from '../util/version.ts';
 import { type ServerArgsType } from './RunServerCommand.ts';
 import { type GlobalArgsType } from './types.ts';
 
-type GenerateOpenApiCommandArgs = ServerArgsType & {
+export type GenerateOpenApiCommandArgs = ServerArgsType & {
   apiVersion: string;
 };
 

--- a/server/src/cli/StartWorkerCommand.ts
+++ b/server/src/cli/StartWorkerCommand.ts
@@ -1,0 +1,28 @@
+import { isMainThread, parentPort } from 'node:worker_threads';
+import type { CommandModule } from 'yargs';
+import { container } from '../container.ts';
+import { TunarrWorker } from '../services/TunarrWorker.ts';
+import type { GenerateOpenApiCommandArgs } from './GenerateOpenApiCommand.ts';
+import type { GlobalArgsType } from './types.ts';
+
+export const StartWorkerCommand: CommandModule<
+  GlobalArgsType,
+  GenerateOpenApiCommandArgs
+> = {
+  command: 'start-worker',
+  describe: 'Starts a Tunarr worker (internal use only)',
+  // eslint-disable-next-line @typescript-eslint/require-await
+  handler: async () => {
+    if (isMainThread) {
+      console.error('This module is only meant to be run as a worker thread.');
+      process.exit(1);
+    }
+
+    if (!parentPort) {
+      console.error('No parent port.');
+      process.exit(1);
+    }
+
+    container.get<TunarrWorker>(TunarrWorker).start();
+  },
+};

--- a/server/src/cli/commands.ts
+++ b/server/src/cli/commands.ts
@@ -1,8 +1,10 @@
 import { GenerateOpenApiCommand } from './GenerateOpenApiCommand.ts';
 import { RunServerCommand } from './RunServerCommand.ts';
+import { StartWorkerCommand } from './StartWorkerCommand.ts';
 import { databaseCommands } from './database/databaseCommands.ts';
 import { LegacyMigrateCommand } from './legacyMigrateCommand.ts';
 import { RunFixerCommand } from './runFixerCommand.ts';
+import { schedulingCommands } from './scheduling/schedulingCommands.ts';
 import { settingsCommands } from './settings/settingsCommands.ts';
 
 export const commands = [
@@ -12,4 +14,6 @@ export const commands = [
   RunServerCommand,
   databaseCommands,
   GenerateOpenApiCommand,
+  schedulingCommands,
+  StartWorkerCommand,
 ];

--- a/server/src/cli/scheduling/ScheduleTimeSlotsCommand.ts
+++ b/server/src/cli/scheduling/ScheduleTimeSlotsCommand.ts
@@ -1,0 +1,67 @@
+import { scheduleTimeSlots } from '@tunarr/shared';
+import { TimeSlotScheduleSchema } from '@tunarr/types/api';
+import { performance } from 'node:perf_hooks';
+import { isMainThread, parentPort, workerData } from 'node:worker_threads';
+import type { CommandModule } from 'yargs';
+import { container } from '../../container.ts';
+import type { IChannelDB } from '../../db/interfaces/IChannelDB.ts';
+import { KEYS } from '../../types/inject.ts';
+
+type ScheduleTimeSlotsCommandArgs = {
+  config: unknown;
+};
+
+export const ScheduleTimeSlotsCommand: CommandModule<
+  ScheduleTimeSlotsCommandArgs,
+  ScheduleTimeSlotsCommandArgs
+> = {
+  command: 'time-slots',
+  // describe: 'Update Tunarr settings directly.',
+  builder: (yargs) =>
+    yargs.usage('$0 schedule time-slots ').option('config', {
+      type: 'string',
+      coerce(arg: string) {
+        return JSON.parse(arg) as unknown;
+      },
+      requiresArg: false,
+    }),
+  // .option('pretty', {
+  //   type: 'boolean',
+  //   default: false,
+  //   desc: 'Print settings JSON with spacing',
+  // })
+  // .option('settings', {
+  //   type: 'string',
+  // })
+  // .example([
+  //   [
+  //     '$0 settings update --settings.ffmpeg.ffmpegExecutablePath="/usr/bin/ffmpeg"',
+  //     'Update FFmpeg executable path',
+  //   ],
+  // ]),
+  handler: async (args) => {
+    performance.mark('handler-start');
+    console.log(args.config);
+    if (!isMainThread) {
+      console.log(workerData);
+      const schedule = TimeSlotScheduleSchema.parse(workerData);
+      const channelDB = container.get<IChannelDB>(KEYS.ChannelDB);
+      const channel = await channelDB.getChannel(1);
+      if (!channel) {
+        throw new Error('');
+      }
+
+      const lineup = await channelDB.loadAndMaterializeLineup(channel.uuid);
+      const result = await scheduleTimeSlots(schedule, lineup?.programs ?? []);
+      console.log(result);
+      parentPort?.postMessage(result);
+    }
+    performance.mark('handler-end');
+    const { duration } = performance.measure(
+      'handler',
+      'handler-start',
+      'handler-end',
+    );
+    console.log(`took ${duration}`);
+  },
+};

--- a/server/src/cli/scheduling/schedulingCommands.ts
+++ b/server/src/cli/scheduling/schedulingCommands.ts
@@ -1,0 +1,9 @@
+import type { CommandModule } from 'yargs';
+import { ScheduleTimeSlotsCommand } from './ScheduleTimeSlotsCommand.ts';
+
+export const schedulingCommands: CommandModule = {
+  command: 'schedule <command>',
+  describe: 'Generate schedules',
+  builder: (yargs) => yargs.command(ScheduleTimeSlotsCommand), //.command(SettingsUpdateCommand),
+  handler: () => {},
+};

--- a/server/src/db/interfaces/IChannelDB.ts
+++ b/server/src/db/interfaces/IChannelDB.ts
@@ -14,6 +14,7 @@ import type {
 import type { ChannelAndLineup } from '@/types/internal.js';
 import type { MarkNullable, Maybe, Nullable } from '@/types/util.js';
 import type {
+  ChannelProgramming,
   CondensedChannelProgramming,
   SaveableChannel,
 } from '@tunarr/types';
@@ -124,6 +125,12 @@ export interface IChannelDB {
   getChannelSubtitlePreferences(
     id: string,
   ): Promise<ChannelSubtitlePreferences[]>;
+
+  loadAndMaterializeLineup(
+    channelId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ChannelProgramming | null>;
 }
 export type UpdateChannelLineupRequest = MarkOptional<
   MarkNullable<

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -74,8 +74,12 @@ yargs(hideBin(process.argv))
     desc: 'Forces a migration from a legacy dizquetv database. Useful for development and debugging. NOTE: This WILL override any settings you have!',
     default: false,
   })
+  .option('hide_banner', {
+    type: 'boolean',
+    default: false,
+  })
   .middleware([
-    () => printBanner(),
+    ({ hide_banner }) => (hide_banner ? void 0 : printBanner()),
     (opts) => setGlobalOptions(opts),
     () => bootstrapTunarr(),
   ])

--- a/server/src/interfaces/IWorkerPool.ts
+++ b/server/src/interfaces/IWorkerPool.ts
@@ -1,0 +1,19 @@
+import type { StrictOmit } from 'ts-essentials';
+import type z from 'zod/v4';
+import type {
+  WorkerRequest,
+  WorkerRequestToResponse,
+} from '../types/worker_schemas.ts';
+
+export interface IWorkerPool {
+  start(): void;
+  shutdown(timeout: number): Promise<void>;
+  allReady(): Promise<void>;
+  queueTask<
+    Req extends StrictOmit<WorkerRequest, 'requestId'>,
+    Out = z.infer<(typeof WorkerRequestToResponse)[Req['type']]>,
+  >(
+    request: Req,
+    timeout?: number,
+  ): Promise<Out>;
+}

--- a/server/src/services/StartupService.ts
+++ b/server/src/services/StartupService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from 'inversify';
 import { KEYS } from '../types/inject.ts';
 import type { Logger } from '../util/logging/LoggerFactory.ts';
 import { SystemDevicesService } from './SystemDevicesService.ts';
+import { TunarrWorkerPool } from './TunarrWorkerPool.ts';
 
 @injectable()
 export class StartupService {
@@ -11,6 +12,8 @@ export class StartupService {
     @inject(KEYS.Logger) private logger: Logger,
     @inject(SystemDevicesService)
     private systemDevicesService: SystemDevicesService,
+    @inject(TunarrWorkerPool)
+    private tunarrWorkerPool: TunarrWorkerPool,
   ) {}
 
   async runStartupServices() {
@@ -23,6 +26,12 @@ export class StartupService {
           'Error when running startup services! The system might not function normally.',
         );
       }
+
+      this.tunarrWorkerPool.start();
     }
+  }
+
+  waitForCompletion() {
+    return Promise.all([this.tunarrWorkerPool.allReady()]);
   }
 }

--- a/server/src/services/TimeSlotSchedulerService.ts
+++ b/server/src/services/TimeSlotSchedulerService.ts
@@ -1,0 +1,27 @@
+import { scheduleTimeSlots } from '@tunarr/shared';
+import { TimeSlotSchedule } from '@tunarr/types/api';
+import { inject, injectable } from 'inversify';
+import { isNumber } from 'lodash-es';
+import { IChannelDB } from '../db/interfaces/IChannelDB.ts';
+import { KEYS } from '../types/inject.ts';
+
+@injectable()
+export class TimeSlotSchedulerService {
+  constructor(@inject(KEYS.ChannelDB) private channelDB: IChannelDB) {}
+
+  async schedule(channelId: string | number, request: TimeSlotSchedule) {
+    if (isNumber(channelId)) {
+      channelId = (await this.channelDB.getChannel(channelId, false))!.uuid;
+    }
+    const channelAndLineup =
+      await this.channelDB.loadAndMaterializeLineup(channelId);
+    if (!channelAndLineup) {
+      throw new Error('');
+    }
+
+    const programs = channelAndLineup.programs;
+
+    // TODO: Load other stuff that isn't part of the channel.
+    return scheduleTimeSlots(request, programs);
+  }
+}

--- a/server/src/services/TunarrSubprocessService.ts
+++ b/server/src/services/TunarrSubprocessService.ts
@@ -1,0 +1,30 @@
+import { Worker, type WorkerOptions } from 'node:worker_threads';
+import { isDev } from '../util/index.ts';
+
+export class TunarrSubprocessService {
+  static createWorker(opts: WorkerOptions = {}) {
+    return new TsWorker(process.argv[1], {
+      ...opts,
+      argv: ['--hide_banner', 'start-worker'],
+    });
+  }
+}
+
+class TsWorker extends Worker {
+  constructor(filename: string, options: WorkerOptions = {}) {
+    if (isDev) {
+      options.workerData ??= {};
+      // options.workerData.__ts_worker_filename = filename.toString();
+      // super(new URL('./worker.mjs', import.meta.url), options);
+      super(
+        `import('tsx/esm/api').then(({ register }) => { register(); import('${new URL(filename, import.meta.url).toString()}') })`,
+        {
+          ...options,
+          eval: true,
+        },
+      );
+    } else {
+      super(new URL(filename, import.meta.url), options);
+    }
+  }
+}

--- a/server/src/services/TunarrWorker.ts
+++ b/server/src/services/TunarrWorker.ts
@@ -1,0 +1,104 @@
+import { inject, injectable } from 'inversify';
+import PQueue from 'p-queue';
+import { parentPort } from 'worker_threads';
+import { KEYS } from '../types/inject.ts';
+import { Result } from '../types/result.ts';
+import {
+  WorkerReply,
+  WorkerRequest,
+  WorkerScheduleTimeSlotsRequest,
+  WorkerSuccessReply,
+  WorkerTimeSlotScheduleReply,
+  type WorkerEvent,
+} from '../types/worker_schemas.ts';
+import { Logger } from '../util/logging/LoggerFactory.ts';
+import { TimeSlotSchedulerService } from './TimeSlotSchedulerService.ts';
+
+@injectable()
+export class TunarrWorker {
+  #queue: PQueue;
+
+  constructor(
+    @inject(KEYS.Logger) private logger: Logger,
+    @inject(TimeSlotSchedulerService)
+    private timeSlotSchedulerService: TimeSlotSchedulerService,
+  ) {
+    // TODO: Make this configurable
+    this.#queue = new PQueue({
+      concurrency: 2,
+    });
+  }
+
+  start() {
+    this.logger.info('Tunarr worker started');
+    parentPort?.postMessage({
+      type: 'event',
+      eventType: 'started',
+      message: 'Worker successfully started!',
+    } satisfies WorkerEvent);
+
+    parentPort?.on('message', (message) => {
+      const parsed = WorkerRequest.safeParse(message);
+      if (parsed.error) {
+        this.logger.error(parsed.error, 'Error parsing worker request message');
+        return;
+      }
+
+      this.#queue
+        .add(async () => {
+          const requestId = parsed.data.requestId;
+
+          switch (parsed.data.type) {
+            case 'status':
+              this.sendSuccessReply(requestId, {
+                type: 'status',
+                status: 'healthy',
+              });
+              break;
+            case 'time-slots':
+              await this.handleTimeSlots(parsed.data);
+              break;
+            case 'restart':
+              process.exit(parsed.data.code ?? 1);
+          }
+        })
+        .catch(console.error);
+    });
+  }
+
+  private async handleTimeSlots(req: WorkerScheduleTimeSlotsRequest) {
+    const result = await Result.attemptAsync(() =>
+      this.timeSlotSchedulerService.schedule(req.channelId, req.schedule),
+    );
+    if (result.isFailure()) {
+      this.sendReply({
+        type: 'error',
+        requestId: req.requestId,
+        message: result.error.message,
+      });
+      return;
+    }
+
+    this.sendSuccessReply(req.requestId, {
+      programs: result.get().programs,
+      startTime: result.get().startTime,
+      // requestId: req.requestId,
+      type: 'time-slots',
+    } satisfies WorkerTimeSlotScheduleReply);
+  }
+
+  private sendSuccessReply(
+    requestId: string,
+    data: WorkerSuccessReply['data'],
+  ) {
+    this.sendReply({
+      type: 'success',
+      data,
+      requestId,
+    });
+  }
+
+  private sendReply(reply: WorkerReply) {
+    parentPort?.postMessage(reply);
+  }
+}

--- a/server/src/services/TunarrWorkerPool.ts
+++ b/server/src/services/TunarrWorkerPool.ts
@@ -1,0 +1,311 @@
+import { Mutex } from 'async-mutex';
+import retry from 'async-retry';
+import { inject, injectable } from 'inversify';
+import { reject } from 'lodash-es';
+import { cpus } from 'node:os';
+import { Worker } from 'node:worker_threads';
+import { StrictOmit } from 'ts-essentials';
+import { match, P } from 'ts-pattern';
+import { v4 } from 'uuid';
+import z from 'zod/v4';
+import { IWorkerPool } from '../interfaces/IWorkerPool.ts';
+import { KEYS } from '../types/inject.ts';
+import {
+  WorkerMessage,
+  WorkerRequest,
+  WorkerRequestToResponse,
+} from '../types/worker_schemas.ts';
+import { getNumericEnvVar } from '../util/env.ts';
+import { timeoutPromise } from '../util/index.ts';
+import { Logger } from '../util/logging/LoggerFactory.ts';
+import { TunarrSubprocessService } from './TunarrSubprocessService.ts';
+
+const MAX_WORKERS = 8;
+
+const cpuCount = cpus().length;
+
+const envVarSetting = getNumericEnvVar('TUNARR_NUM_WORKERS');
+
+const numWorkers = envVarSetting ?? Math.min(cpuCount, MAX_WORKERS);
+
+interface PooledWorker {
+  worker: Worker;
+  ready: boolean;
+}
+
+export class Future<T> implements Promise<T> {
+  #promise: Promise<T>;
+  #resolve: (v: T | PromiseLike<T>) => void;
+  #reject: (reason?: unknown) => void;
+  #state: 'pending' | 'fulfilled' | 'rejected' = 'pending';
+  #value: T | undefined;
+  #err: unknown;
+
+  constructor() {
+    this.#promise = new Promise<T>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+
+    this.#promise.then(
+      (v) => {
+        this.#state = 'fulfilled';
+        this.#value = v;
+      },
+      (err) => {
+        this.#state = 'rejected';
+        this.#err = err;
+      },
+    );
+  }
+
+  [Symbol.toStringTag]: string;
+
+  resolve(value: T | PromiseLike<T>) {
+    if (this.#state === 'pending') {
+      this.#resolve(value);
+    } else {
+      throw new Error(
+        'Resolving already fulfilled future with state ' + this.#state,
+      );
+    }
+  }
+
+  reject(e: unknown) {
+    if (this.#state === 'pending') {
+      this.#reject(e);
+    } else {
+      throw new Error(
+        'Rejecting already fulfilled future with state ' + this.#state,
+      );
+    }
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.#promise.then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<T | TResult> {
+    return this.#promise.catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<T> {
+    return this.#promise.finally(onfinally);
+  }
+
+  get promise() {
+    return this.#promise;
+  }
+
+  get state() {
+    return this.#state;
+  }
+
+  get value() {
+    return this.#value;
+  }
+
+  get error() {
+    return this.#err;
+  }
+}
+
+type State = 'pending' | 'started' | 'terminating';
+
+@injectable()
+export class TunarrWorkerPool implements IWorkerPool {
+  #mu = new Mutex();
+  #state: State = 'pending';
+  #pool: PooledWorker[] = Array<PooledWorker>(numWorkers);
+  #last = 0;
+  #listeners = new Map<string, Future<unknown>>();
+  #outstandingByIndex = new Map<number, string[]>();
+  #startPromises: Promise<boolean>[] = [];
+
+  constructor(@inject(KEYS.Logger) private logger: Logger) {}
+
+  start() {
+    if (this.#state !== 'pending') {
+      return;
+    }
+    this.#state = 'pending';
+    this.logger.info('Starting worker pool...');
+    for (let i = 0; i < numWorkers; i++) {
+      this.#startPromises.push(this.setupWorker(i));
+    }
+    Promise.all(this.#startPromises)
+      .then(() => {
+        this.logger.debug(
+          'Worker pool successfully started %d workers',
+          numWorkers,
+        );
+        this.#state = 'started';
+      })
+      .catch(console.error);
+  }
+
+  async shutdown(timeout: number = 5_000) {
+    if (this.#state === 'terminating') {
+      return;
+    }
+    this.#state = 'terminating';
+    this.logger.info('Attempting graceful shutdown of all workers');
+    const shutdownPromises = this.#pool.map(({ worker }) => {
+      if (worker) {
+        return worker.terminate();
+      }
+      return Promise.resolve();
+    });
+    return timeoutPromise(
+      Promise.all(shutdownPromises).then(() => {}),
+      timeout,
+    ).then(() => {
+      this.#state = 'pending';
+    });
+  }
+
+  async allReady() {
+    await Promise.all(this.#startPromises);
+    return;
+  }
+
+  async queueTask<
+    Req extends StrictOmit<WorkerRequest, 'requestId'>,
+    Out = z.infer<(typeof WorkerRequestToResponse)[Req['type']]>,
+  >(request: Req, timeout: number = 60_000): Promise<Out> {
+    const requestId = v4();
+    const reqWithId: WorkerRequest = { ...request, requestId };
+    const fut = new Future<Out>();
+    await retry(async () => {
+      return this.#mu.runExclusive(() => {
+        const idx = this.#last;
+        const { ready, worker } = this.#pool[idx];
+        this.#last = (this.#last + 1) % this.#pool.length;
+        if (ready) {
+          this.#listeners.set(reqWithId.requestId, fut);
+          this.#outstandingByIndex.set(
+            idx,
+            this.#outstandingByIndex.get(idx)?.concat([requestId]) ?? [
+              requestId,
+            ],
+          );
+          worker.postMessage(reqWithId);
+          return;
+        } else {
+          throw new Error(`Worker at ${idx} is not ready yet`);
+        }
+      });
+    });
+
+    return timeoutPromise(fut.promise, timeout);
+  }
+
+  private async setupWorker(idx: number): Promise<boolean> {
+    if (this.#state === 'terminating') {
+      this.logger.trace('Not starting worker because pool is terminating.');
+      return Promise.resolve(false);
+    }
+
+    this.logger.info(`Starting worker ${idx}`);
+    const worker = TunarrSubprocessService.createWorker();
+
+    this.#pool[idx] = {
+      worker,
+      ready: false,
+    };
+
+    const fut = new Future<void>();
+    let started = false;
+
+    worker.on('message', (message) => {
+      const parsed = WorkerMessage.safeParse(message);
+      if (parsed.error) {
+        this.logger.warn(
+          'Worker responded with broken reply: %s',
+          parsed.error.message,
+        );
+        return;
+      }
+
+      match(parsed.data)
+        .with({ type: 'event', eventType: 'started' }, () => {
+          // We should only ever get one of these
+          this.logger.debug('Worker %d is ready', idx);
+          started = true;
+          fut.resolve();
+          this.#pool[idx].ready = true;
+        })
+        .with({ type: P.union('success', 'error') }, (reply) => {
+          const fut = this.#listeners.get(reply.requestId);
+          if (fut) {
+            this.#listeners.delete(reply.requestId);
+            this.#outstandingByIndex.set(
+              idx,
+              reject(
+                this.#outstandingByIndex.get(idx),
+                (id) => id === reply.requestId,
+              ),
+            );
+            if (reply.type === 'success') {
+              fut.resolve(reply);
+            } else {
+              fut.reject(new Error(reply.message));
+            }
+          } else {
+            this.logger.error(
+              'No listener found for request ID: %s',
+              reply.requestId,
+            );
+          }
+        })
+        .exhaustive();
+    });
+
+    worker.on('error', (err) => {
+      this.logger.error(err, 'Worker %d errored out', idx);
+      if (!started) {
+        fut.reject(err);
+      }
+
+      const outstandingListeners = this.#outstandingByIndex.get(idx) ?? [];
+      for (const outstanding of outstandingListeners) {
+        this.#listeners.get(outstanding)?.reject(err);
+      }
+
+      this.#outstandingByIndex.set(idx, []);
+    });
+
+    worker.on('exit', (code) => {
+      this.#startPromises[idx]
+        .then(() => this.setupWorker(idx))
+        .catch(() => this.setupWorker(idx));
+
+      const outstandingListeners = this.#outstandingByIndex.get(idx) ?? [];
+      for (const outstanding of outstandingListeners) {
+        const fut = this.#listeners.get(outstanding);
+        if (fut?.state === 'pending') {
+          fut.reject(new Error('Worker exited'));
+        }
+      }
+      this.#outstandingByIndex.set(idx, []);
+
+      if (!started && fut.state === 'pending' && code !== 0) {
+        fut.reject(new Error('Worker exited with code ' + code));
+      }
+      this.logger.warn(
+        'Worker %d exited (code = %d).%s',
+        idx,
+        code,
+        this.#state === 'started' ? ' Restarting.' : '',
+      );
+    });
+
+    await fut;
+    return true;
+  }
+}

--- a/server/src/types/worker_schemas.ts
+++ b/server/src/types/worker_schemas.ts
@@ -1,0 +1,98 @@
+import { TimeSlotScheduleSchema } from '@tunarr/types/api';
+import { ChannelProgramSchema } from '@tunarr/types/schemas';
+import { z } from 'zod/v4';
+
+export const BaseWorkerRequest = z.object({
+  requestId: z.uuid(),
+});
+
+export const WorkerRestartRequest = BaseWorkerRequest.extend({
+  type: z.literal('restart'),
+  code: z.number().optional(),
+});
+
+export const WorkerStatusRequest = BaseWorkerRequest.extend({
+  type: z.literal('status'),
+});
+
+export const WorkerScheduleTimeSlotsRequest = BaseWorkerRequest.extend({
+  type: z.literal('time-slots'),
+  channelId: z.uuid().or(z.number()),
+  schedule: TimeSlotScheduleSchema,
+});
+
+export type WorkerScheduleTimeSlotsRequest = z.infer<
+  typeof WorkerScheduleTimeSlotsRequest
+>;
+
+export const WorkerRequest = z.discriminatedUnion('type', [
+  WorkerRestartRequest,
+  WorkerStatusRequest,
+  WorkerScheduleTimeSlotsRequest,
+]);
+
+export type WorkerRequest = z.infer<typeof WorkerRequest>;
+
+export const WorkerStartedEvent = z.object({
+  type: 'started',
+});
+
+export const WorkerEvent = z.object({
+  type: z.literal('event'),
+  eventType: z.enum(['started']),
+  message: z.string().optional(),
+});
+
+export type WorkerEvent = z.infer<typeof WorkerEvent>;
+
+export const WorkerErrorReply = z.object({
+  type: z.literal('error'),
+  message: z.string(),
+  requestId: z.string(),
+});
+
+export const WorkerStatusReply = z.object({
+  type: z.literal('status'),
+  status: z.enum(['healthy']),
+});
+
+export const WorkerTimeSlotScheduleReply = z.object({
+  type: z.literal('time-slots'),
+  programs: ChannelProgramSchema.array(),
+  startTime: z.number(),
+});
+
+export type WorkerTimeSlotScheduleReply = z.infer<
+  typeof WorkerTimeSlotScheduleReply
+>;
+
+export type WorkerStatusReply = z.infer<typeof WorkerStatusReply>;
+
+export const WorkerSuccessReply = z.object({
+  type: z.literal('success'),
+  requestId: z.string(),
+  data: z.discriminatedUnion('type', [
+    WorkerStatusReply,
+    WorkerTimeSlotScheduleReply,
+  ]),
+});
+
+export type WorkerSuccessReply = z.infer<typeof WorkerSuccessReply>;
+
+export const WorkerReply = z.discriminatedUnion('type', [
+  WorkerErrorReply,
+  WorkerSuccessReply,
+]);
+
+export type WorkerReply = z.infer<typeof WorkerReply>;
+
+export const WorkerMessage = z.discriminatedUnion('type', [
+  WorkerEvent,
+  WorkerReply,
+]);
+
+export const WorkerRequestToResponse = {
+  status: WorkerStatusReply,
+  restart: z.void(),
+  'time-slots': WorkerTimeSlotScheduleReply,
+} as const;

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -246,6 +246,19 @@ export const wait = (ms?: number | Duration) => {
   return new Promise((resolve) => setTimeout(resolve, ms ?? 0));
 };
 
+export function timeoutPromise<T>(
+  promise: Promise<T>,
+  ms: number | Duration,
+): Promise<T> {
+  ms = dayjs.isDuration(ms) ? +ms : ms;
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
 type NativeFuncOrApply<In, Out> = ((input: In) => Out) | Func<In, Out>;
 
 export async function asyncFlow<T>(

--- a/server/turbo.json
+++ b/server/turbo.json
@@ -13,7 +13,7 @@
       "outputs": ["temp/metadata.json"]
     },
     "bundle": {
-      "inputs": ["./scripts/bundle-old.ts"],
+      "inputs": ["./scripts/bundle-old.ts", "./src/**"],
       "dependsOn": ["^build", "^bundle"],
       "outputs": ["dist/**"]
     },
@@ -22,7 +22,7 @@
     },
     "make-bin": {
       "dependsOn": ["bundle"],
-      "outputs": ["dist/bin/**"]
+      "outputs": ["bin/**"]
     },
     "lint-staged": {},
     "lint": {


### PR DESCRIPTION
This will allow us to run CPU intensive commands away from the main
server event loop, which could improve stream quality and allow us to
ditch erroneous setTimeout calls to flush the event loop. We will
eventually move all scheduling operations onto the server because they
are much more flexible.