### PR TITLE
feat(scheduling): support for flex kinds in time slots

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 import dotenv from '@dotenvx/dotenvx';
-dotenv.config({ debug: true });
+dotenv.config({ debug: true, ignore: ['MISSING_ENV_FILE'] });
 
 import { bootstrapTunarr } from '@/bootstrap.js';
 import { setGlobalOptions } from '@/globals.js';

--- a/server/src/services/scheduling/FillerProgramIterator.ts
+++ b/server/src/services/scheduling/FillerProgramIterator.ts
@@ -1,0 +1,123 @@
+import type { ChannelProgram, FillerProgram } from '@tunarr/types';
+import type { FillerProgrammingSlot } from '@tunarr/types/api';
+import { findIndex, isNil, last, maxBy, sortBy, sum } from 'lodash-es';
+import type { Random } from 'random-js';
+import type { NonEmptyArray } from 'ts-essentials';
+import { match } from 'ts-pattern';
+import type {
+  IterationState,
+  ProgramIterator,
+  WeightedProgram,
+} from './ProgramIterator.ts';
+
+export class FillerProgramIterator implements ProgramIterator {
+  private weightedPrograms: NonEmptyArray<WeightedProgram>;
+  private lastSeenTimestampById = new Map<string, number>();
+  private weightsById = new Map<string, number>();
+
+  constructor(
+    programs: NonEmptyArray<FillerProgram>,
+    private slotDef: FillerProgrammingSlot,
+    private random: Random,
+    private decayFactor: number = slotDef.decayFactor,
+    private resetRate: number = slotDef.recoveryFactor,
+  ) {
+    const maxDuration = maxBy(programs, (p) => p.duration)!.duration;
+    const rawWeights = match([
+      this.slotDef.order,
+      this.slotDef.durationWeighting,
+    ])
+      .with(['shuffle_prefer_short', 'linear'], () =>
+        programs.map((p) => maxDuration - p.duration + 1),
+      )
+      .with(['shuffle_prefer_short', 'log'], () =>
+        programs.map((p) => Math.log(1 / p.duration)),
+      )
+      .with(['shuffle_prefer_long', 'linear'], () =>
+        programs.map((p) => p.duration),
+      )
+      .with(['shuffle_prefer_long', 'log'], () =>
+        programs.map((p) => Math.log(p.duration)),
+      )
+      .otherwise(() => {
+        throw new Error('Invalid slot configuration');
+      });
+
+    const weightSum = sum(rawWeights);
+    const normalizedWeights = rawWeights.map((weight) => weight / weightSum);
+    programs.forEach((p, idx) => {
+      this.weightsById.set(p.id, normalizedWeights[idx]);
+    });
+    // TODO: Precalculate slices because we know all of the relevant
+    // slot lengths at creation time. Then we don't have to calculate
+    // the correct slices each time.
+    this.weightedPrograms = sortBy(programs, (p) => p.duration).map(
+      (p, i) =>
+        ({
+          program: p,
+          currentWeight: normalizedWeights[i],
+          originalWeight: normalizedWeights[i],
+        }) satisfies WeightedProgram,
+    ) as NonEmptyArray<WeightedProgram>;
+  }
+
+  current(state: IterationState): ChannelProgram | null {
+    const idx = findIndex(
+      this.weightedPrograms,
+      ({ program }) => program.duration > state.slotDuration,
+    );
+    if (idx === -1) {
+      // No programs are the right duration.
+      return null;
+    }
+    const endIdx = idx === 0 ? this.weightedPrograms.length - 1 : idx - 1;
+
+    const programsToConsider = this.weightedPrograms
+      .slice(0, endIdx)
+      .filter(({ program }) => {
+        const lastSeen = this.lastSeenTimestampById.get(program.id);
+        if (
+          !isNil(lastSeen) &&
+          state.timeCursor - lastSeen < state.slotDuration
+        ) {
+          return false;
+        }
+        return true;
+      });
+
+    let sumWeight = 0;
+    const cumulativeWeights: number[] = [];
+    for (const { currentWeight } of programsToConsider) {
+      sumWeight += currentWeight;
+      cumulativeWeights.push(sumWeight);
+    }
+
+    const targetWeight = this.random.real(0, sumWeight, false);
+    for (let i = 0; i < cumulativeWeights.length; i++) {
+      const program = programsToConsider[i];
+      if (targetWeight < cumulativeWeights[i]) {
+        this.lastSeenTimestampById.set(program.program.id, state.timeCursor);
+        program.currentWeight *= this.decayFactor;
+        return program.program;
+      }
+    }
+
+    return last(programsToConsider)?.program ?? null;
+  }
+
+  next(): void {
+    for (const program of this.weightedPrograms) {
+      program.currentWeight = Math.min(
+        program.originalWeight,
+        program.currentWeight +
+          (program.originalWeight - program.currentWeight) * this.resetRate,
+      );
+    }
+  }
+
+  reset(): void {
+    for (const program of this.weightedPrograms) {
+      program.currentWeight = program.originalWeight;
+    }
+  }
+}

--- a/server/src/services/scheduling/FlexProgramIterator.ts
+++ b/server/src/services/scheduling/FlexProgramIterator.ts
@@ -1,0 +1,16 @@
+import type { ChannelProgram, FlexProgram } from '@tunarr/types';
+import type { IterationState } from './ProgramIterator.ts';
+import { StaticProgramIterator } from './StaticProgramIterator.ts';
+
+export class FlexProgramIterator extends StaticProgramIterator {
+  constructor(flexProgram: FlexProgram) {
+    super(flexProgram);
+  }
+
+  current({ slotDuration }: IterationState): ChannelProgram | null {
+    return {
+      ...this.program,
+      duration: slotDuration,
+    };
+  }
+}

--- a/server/src/services/scheduling/ProgramChunkedShuffle.ts
+++ b/server/src/services/scheduling/ProgramChunkedShuffle.ts
@@ -1,0 +1,35 @@
+import { seq } from '@tunarr/shared/util';
+import type { ChannelProgram } from '@tunarr/types';
+import { nth, orderBy } from 'lodash-es';
+import type { ProgramIterator } from './ProgramIterator.ts';
+import { random } from './RandomSlotsService.ts';
+
+export class ProgramChunkedShuffle<ProgramType extends ChannelProgram>
+  implements ProgramIterator
+{
+  #programs: ProgramType[];
+  #position: number = 0;
+
+  constructor(
+    programs: ProgramType[],
+    orderer: (program: ProgramType) => string | number,
+    asc: boolean = true,
+  ) {
+    this.#programs = seq.rotateArray(
+      orderBy(programs, orderer, [asc ? 'asc' : 'desc']),
+      random.integer(0, programs.length),
+    );
+  }
+
+  current(): ProgramType | null {
+    return nth(this.#programs, this.#position) ?? null;
+  }
+
+  next(): void {
+    this.#position = (this.#position + 1) % this.#programs.length;
+  }
+
+  reset(): void {
+    this.#position = 0;
+  }
+}

--- a/server/src/services/scheduling/ProgramIterator.ts
+++ b/server/src/services/scheduling/ProgramIterator.ts
@@ -1,31 +1,13 @@
-import { seq } from '@tunarr/shared/util';
 import type {
   ChannelProgram,
   ContentProgram,
   FillerProgram,
-  FlexProgram,
 } from '@tunarr/types';
 import type { BaseSlot, FillerProgrammingSlot } from '@tunarr/types/api';
 import dayjs from 'dayjs';
-import {
-  findIndex,
-  isNil,
-  last,
-  maxBy,
-  nth,
-  orderBy,
-  shuffle,
-  slice,
-  sortBy,
-  sum,
-} from 'lodash-es';
-import type { Random } from 'random-js';
-import type { NonEmptyArray } from 'ts-essentials';
-import { match } from 'ts-pattern';
-import { random } from './RandomSlotsService.js';
 import type { SlotIteratorKey } from './slotSchedulerUtil.js';
 
-type IterationState = {
+export type IterationState = {
   slotDuration: number; // ms
   timeCursor: number; // ms since epoch
 };
@@ -36,246 +18,11 @@ export interface ProgramIterator {
   reset(): void;
 }
 
-/**
- * A {@link ProgramIterator} that returns a single program repeatedly.
- */
-export class StaticProgramIterator implements ProgramIterator {
-  constructor(protected program: ChannelProgram) {}
-
-  current(_state: IterationState): ChannelProgram | null {
-    return this.program;
-  }
-
-  next(): void {}
-
-  reset(): void {}
-}
-
-export class FlexProgramIterator extends StaticProgramIterator {
-  constructor(flexProgram: FlexProgram) {
-    super(flexProgram);
-  }
-
-  current({ slotDuration }: IterationState): ChannelProgram | null {
-    return {
-      ...this.program,
-      duration: slotDuration,
-    };
-  }
-}
-
-export class ProgramShuffler implements ProgramIterator {
-  #programs: ChannelProgram[];
-  #position: number = 0;
-
-  constructor(
-    programs: ChannelProgram[],
-    private random: Random,
-  ) {
-    this.#programs = shuffle(programs);
-  }
-
-  current() {
-    return nth(this.#programs, this.#position) ?? null;
-  }
-
-  next() {
-    this.#position++;
-    if (this.#position >= this.#programs.length) {
-      const mid = Math.floor(this.#programs.length / 2);
-      this.#programs = [
-        ...slice(this.#programs, 0, mid),
-        ...slice(this.#programs, mid),
-      ];
-      this.#position = 0;
-    }
-  }
-
-  reset(): void {
-    this.#programs = this.random.shuffle(this.#programs);
-    this.#position = 0;
-  }
-}
-
-export class ProgramChunkedShuffle<ProgramType extends ChannelProgram>
-  implements ProgramIterator
-{
-  #programs: ProgramType[];
-  #position: number = 0;
-
-  constructor(
-    programs: ProgramType[],
-    orderer: (program: ProgramType) => string | number,
-    asc: boolean = true,
-  ) {
-    this.#programs = seq.rotateArray(
-      orderBy(programs, orderer, [asc ? 'asc' : 'desc']),
-      random.integer(0, programs.length),
-    );
-  }
-
-  current(): ProgramType | null {
-    return nth(this.#programs, this.#position) ?? null;
-  }
-
-  next(): void {
-    this.#position = (this.#position + 1) % this.#programs.length;
-  }
-
-  reset(): void {
-    this.#position = 0;
-  }
-}
-
-/**
- * A {@link ProgramIterator} that handles {@link ContentProgram}s by iterating
- * them in a particular order. By default, the {@link getProgramOrder} ordering
- * is used.
- */
-export class ProgramOrdereredIterator<ProgramType extends ChannelProgram>
-  implements ProgramIterator
-{
-  #programs: ProgramType[];
-  #position: number = 0;
-
-  constructor(
-    programs: ProgramType[],
-    orderer: (program: ProgramType) => string | number,
-    asc: boolean = true,
-  ) {
-    this.#programs = orderBy(programs, orderer, [asc ? 'asc' : 'desc']);
-  }
-
-  current(): ChannelProgram | null {
-    return nth(this.#programs, this.#position) ?? null;
-  }
-
-  next(): void {
-    this.#position = (this.#position + 1) % this.#programs.length;
-  }
-
-  reset(): void {
-    this.#position = 0;
-  }
-}
-
-type WeightedProgram = {
+export type WeightedProgram = {
   program: FillerProgram;
   originalWeight: number;
   currentWeight: number;
 };
-
-export class FillerProgramIterator implements ProgramIterator {
-  private weightedPrograms: NonEmptyArray<WeightedProgram>;
-  private lastSeenTimestampById = new Map<string, number>();
-  private weightsById = new Map<string, number>();
-
-  constructor(
-    programs: NonEmptyArray<FillerProgram>,
-    private slotDef: FillerProgrammingSlot,
-    private random: Random,
-    private decayFactor: number = slotDef.decayFactor,
-    private resetRate: number = slotDef.recoveryFactor,
-  ) {
-    const maxDuration = maxBy(programs, (p) => p.duration)!.duration;
-    const rawWeights = match([
-      this.slotDef.order,
-      this.slotDef.durationWeighting,
-    ])
-      .with(['shuffle_prefer_short', 'linear'], () =>
-        programs.map((p) => maxDuration - p.duration + 1),
-      )
-      .with(['shuffle_prefer_short', 'log'], () =>
-        programs.map((p) => Math.log(1 / p.duration)),
-      )
-      .with(['shuffle_prefer_long', 'linear'], () =>
-        programs.map((p) => p.duration),
-      )
-      .with(['shuffle_prefer_long', 'log'], () =>
-        programs.map((p) => Math.log(p.duration)),
-      )
-      .otherwise(() => {
-        throw new Error('Invalid slot configuration');
-      });
-
-    const weightSum = sum(rawWeights);
-    const normalizedWeights = rawWeights.map((weight) => weight / weightSum);
-    programs.forEach((p, idx) => {
-      this.weightsById.set(p.id, normalizedWeights[idx]);
-    });
-    // TODO: Precalculate slices because we know all of the relevant
-    // slot lengths at creation time. Then we don't have to calculate
-    // the correct slices each time.
-    this.weightedPrograms = sortBy(programs, (p) => p.duration).map(
-      (p, i) =>
-        ({
-          program: p,
-          currentWeight: normalizedWeights[i],
-          originalWeight: normalizedWeights[i],
-        }) satisfies WeightedProgram,
-    ) as NonEmptyArray<WeightedProgram>;
-  }
-
-  current(state: IterationState): ChannelProgram | null {
-    const idx = findIndex(
-      this.weightedPrograms,
-      ({ program }) => program.duration > state.slotDuration,
-    );
-    if (idx === 0) {
-      // No programs are the right duration.
-      return null;
-    }
-    const endIdx = idx === -1 ? this.weightedPrograms.length - 1 : idx - 1;
-
-    const programsToConsider = this.weightedPrograms
-      .slice(0, endIdx)
-      .filter(({ program }) => {
-        const lastSeen = this.lastSeenTimestampById.get(program.id);
-        if (
-          !isNil(lastSeen) &&
-          state.timeCursor - lastSeen < state.slotDuration
-        ) {
-          return false;
-        }
-        return true;
-      });
-
-    let sumWeight = 0;
-    const cumulativeWeights: number[] = [];
-    for (const { currentWeight } of programsToConsider) {
-      sumWeight += currentWeight;
-      cumulativeWeights.push(sumWeight);
-    }
-
-    const targetWeight = this.random.real(0, sumWeight, false);
-    for (let i = 0; i < cumulativeWeights.length; i++) {
-      const program = programsToConsider[i];
-      if (targetWeight < cumulativeWeights[i]) {
-        this.lastSeenTimestampById.set(program.program.id, state.timeCursor);
-        program.currentWeight *= this.decayFactor;
-        return program.program;
-      }
-    }
-
-    return last(programsToConsider)?.program ?? null;
-  }
-
-  next(): void {
-    for (const program of this.weightedPrograms) {
-      program.currentWeight = Math.min(
-        program.originalWeight,
-        program.currentWeight +
-          (program.originalWeight - program.currentWeight) * this.resetRate,
-      );
-    }
-  }
-
-  reset(): void {
-    for (const program of this.weightedPrograms) {
-      program.currentWeight = program.originalWeight;
-    }
-  }
-}
 
 function programOrdererNext(program: ContentProgram) {
   switch (program.subtype) {
@@ -349,34 +96,9 @@ export function slotIteratorKey<T extends BaseSlot>(slot: T): SlotIteratorKey {
   }
 }
 
-export function getNextProgramForSlot<T extends BaseSlot>(
-  slot: T,
-  iterators: Record<SlotIteratorKey, ProgramIterator>,
-  state: IterationState,
-): ChannelProgram | null {
-  switch (slot.type) {
-    case 'movie':
-    case 'show':
-    case 'redirect':
-    case 'custom-show':
-    case 'filler':
-    case 'flex':
-      return iterators[slotIteratorKey(slot)].current(state);
-  }
-}
-
-export function advanceIterator<T extends BaseSlot>(
-  slot: T,
-  iterators: Record<SlotIteratorKey, ProgramIterator>,
-) {
-  switch (slot.type) {
-    case 'movie':
-    case 'show':
-    case 'redirect':
-    case 'custom-show':
-    case 'filler':
-    case 'flex':
-      iterators[slotIteratorKey(slot)].next();
-      return;
-  }
+export function fillerSlotIteratorKey(
+  fillerListId: string,
+  order: FillerProgrammingSlot['order'],
+): SlotIteratorKey {
+  return `filler_${fillerListId}_${order}`;
 }

--- a/server/src/services/scheduling/ProgramOrdereredIterator.ts
+++ b/server/src/services/scheduling/ProgramOrdereredIterator.ts
@@ -1,0 +1,36 @@
+import type { ChannelProgram } from '@tunarr/types';
+import { nth, orderBy } from 'lodash-es';
+import type { ProgramIterator } from './ProgramIterator.ts';
+
+/**
+ * A {@link ProgramIterator} that handles {@link ContentProgram}s by iterating
+ * them in a particular order. By default, the {@link getProgramOrder} ordering
+ * is used.
+ */
+
+export class ProgramOrdereredIterator<ProgramType extends ChannelProgram>
+  implements ProgramIterator
+{
+  #programs: ProgramType[];
+  #position: number = 0;
+
+  constructor(
+    programs: ProgramType[],
+    orderer: (program: ProgramType) => string | number,
+    asc: boolean = true,
+  ) {
+    this.#programs = orderBy(programs, orderer, [asc ? 'asc' : 'desc']);
+  }
+
+  current(): ChannelProgram | null {
+    return nth(this.#programs, this.#position) ?? null;
+  }
+
+  next(): void {
+    this.#position = (this.#position + 1) % this.#programs.length;
+  }
+
+  reset(): void {
+    this.#position = 0;
+  }
+}

--- a/server/src/services/scheduling/ProgramShuffler.ts
+++ b/server/src/services/scheduling/ProgramShuffler.ts
@@ -1,0 +1,37 @@
+import type { ChannelProgram } from '@tunarr/types';
+import { nth, shuffle, slice } from 'lodash-es';
+import type { Random } from 'random-js';
+import type { ProgramIterator } from './ProgramIterator.ts';
+
+export class ProgramShuffler implements ProgramIterator {
+  #programs: ChannelProgram[];
+  #position: number = 0;
+
+  constructor(
+    programs: ChannelProgram[],
+    private random: Random,
+  ) {
+    this.#programs = shuffle(programs);
+  }
+
+  current() {
+    return nth(this.#programs, this.#position) ?? null;
+  }
+
+  next() {
+    this.#position++;
+    if (this.#position >= this.#programs.length) {
+      const mid = Math.floor(this.#programs.length / 2);
+      this.#programs = [
+        ...slice(this.#programs, 0, mid),
+        ...slice(this.#programs, mid),
+      ];
+      this.#position = 0;
+    }
+  }
+
+  reset(): void {
+    this.#programs = this.random.shuffle(this.#programs);
+    this.#position = 0;
+  }
+}

--- a/server/src/services/scheduling/RandomSlotImpl.ts
+++ b/server/src/services/scheduling/RandomSlotImpl.ts
@@ -1,0 +1,38 @@
+import type { RandomSlot, RandomSlotDurationSpec } from '@tunarr/types/api';
+import type { Random } from 'random-js';
+import type { FillerProgramIterator } from './FillerProgramIterator.ts';
+import type { ProgramIterator } from './ProgramIterator.js';
+import { SlotImpl } from './SlotImpl.js';
+
+export class RandomSlotImpl extends SlotImpl<RandomSlot> {
+  constructor(
+    slot: RandomSlot,
+    iterator: ProgramIterator,
+    random: Random,
+    fillerIteratorsByListId: Record<string, FillerProgramIterator> = {},
+  ) {
+    super(slot, iterator, random, fillerIteratorsByListId);
+  }
+
+  get cooldownMs() {
+    return this.slot.cooldownMs;
+  }
+
+  get weight() {
+    return this.slot.weight;
+  }
+
+  get durationSpec(): RandomSlotDurationSpec {
+    return this.slot.durationSpec;
+  }
+
+  set durationSpec(spec: RandomSlotDurationSpec) {
+    this.slot.durationSpec = spec;
+  }
+
+  get durationMs() {
+    return this.slot.durationSpec.type === 'fixed'
+      ? this.slot.durationSpec.durationMs
+      : null;
+  }
+}

--- a/server/src/services/scheduling/SlotImpl.ts
+++ b/server/src/services/scheduling/SlotImpl.ts
@@ -1,0 +1,84 @@
+import type { ChannelProgram } from '@tunarr/types';
+import type { BaseSlot, SlotFillerTypes } from '@tunarr/types/api';
+import { isEmpty, some } from 'lodash-es';
+import type { Random } from 'random-js';
+import type { FillerProgramIterator } from './FillerProgramIterator.ts';
+import type { IterationState, ProgramIterator } from './ProgramIterator.js';
+import { slotMayHaveFiller } from './slotSchedulerUtil.js';
+
+export abstract class SlotImpl<SlotType extends BaseSlot> {
+  protected fillerIteratorsByType: Record<
+    SlotFillerTypes,
+    FillerProgramIterator[]
+  > = {
+    head: [],
+    post: [],
+    pre: [],
+    tail: [],
+    fallback: [],
+  };
+
+  constructor(
+    protected slot: SlotType,
+    private iterator: ProgramIterator,
+    private random: Random,
+    private fillerIteratorsByListId: Record<string, FillerProgramIterator> = {},
+  ) {
+    if (slotMayHaveFiller(this.slot) && this.slot.filler) {
+      for (const filler of this.slot.filler) {
+        if (!this.fillerIteratorsByListId[filler.fillerListId]) {
+          continue;
+        }
+
+        const it = this.fillerIteratorsByListId[filler.fillerListId];
+
+        for (const type of filler.types) {
+          if (this.fillerIteratorsByType[type]) {
+            this.fillerIteratorsByType[type].push(it);
+          } else {
+            this.fillerIteratorsByType[type] = [it];
+          }
+        }
+      }
+    }
+  }
+
+  getNextProgram(state: IterationState): ChannelProgram | null {
+    return this.iterator.current(state);
+  }
+
+  advanceIterator(): void {
+    return this.iterator.next();
+  }
+
+  getFillerOfType(
+    type: SlotFillerTypes,
+    state: IterationState,
+  ): ChannelProgram | null {
+    const its = this.fillerIteratorsByType?.[type];
+    if (!its || isEmpty(its)) {
+      return null;
+    }
+
+    // Random pick right now
+    const it = this.random.pick(its);
+    const filler = it.current(state);
+    if (filler) {
+      it.next();
+    }
+    return filler;
+  }
+
+  hasFillerOfType(type: SlotFillerTypes) {
+    const its = this.fillerIteratorsByType?.[type];
+    return !isEmpty(its);
+  }
+
+  hasAnyFillerSettings() {
+    return some(this.fillerIteratorsByType, (v) => !isEmpty(v));
+  }
+
+  get type() {
+    return this.slot.type;
+  }
+}

--- a/server/src/services/scheduling/StaticProgramIterator.ts
+++ b/server/src/services/scheduling/StaticProgramIterator.ts
@@ -1,0 +1,18 @@
+import type { ChannelProgram } from '@tunarr/types';
+import type { IterationState, ProgramIterator } from './ProgramIterator.ts';
+
+/**
+ * A {@link ProgramIterator} that returns a single program repeatedly.
+ */
+
+export class StaticProgramIterator implements ProgramIterator {
+  constructor(protected program: ChannelProgram) {}
+
+  current(_state: IterationState): ChannelProgram | null {
+    return this.program;
+  }
+
+  next(): void {}
+
+  reset(): void {}
+}

--- a/server/src/services/scheduling/TimeSlotImpl.ts
+++ b/server/src/services/scheduling/TimeSlotImpl.ts
@@ -1,0 +1,20 @@
+import type { TimeSlot } from '@tunarr/types/api';
+import type { Random } from 'random-js';
+import type { FillerProgramIterator } from './FillerProgramIterator.ts';
+import type { ProgramIterator } from './ProgramIterator.js';
+import { SlotImpl } from './SlotImpl.js';
+
+export class TimeSlotImpl extends SlotImpl<TimeSlot> {
+  constructor(
+    slot: TimeSlot,
+    iterator: ProgramIterator,
+    random: Random,
+    fillerIteratorsByListId: Record<string, FillerProgramIterator> = {},
+  ) {
+    super(slot, iterator, random, fillerIteratorsByListId);
+  }
+
+  get startTime() {
+    return this.slot.startTime;
+  }
+}

--- a/server/src/services/scheduling/TimeSlotSchedulerService.ts
+++ b/server/src/services/scheduling/TimeSlotSchedulerService.ts
@@ -133,6 +133,19 @@ export class TimeSlotSchedulerService {
 
     // Here's the big one - find shows that are included in the schedule but
     // not currently saved to the channel.
+    const slotFiller = slots.flatMap((slot) => {
+      switch (slot.type) {
+        case 'filler':
+        case 'flex':
+        case 'redirect':
+          return [];
+        case 'movie':
+        case 'show':
+        case 'custom-show':
+          return slot.filler?.map(({ fillerListId }) => fillerListId) ?? [];
+      }
+    });
+
     const slottedFillerLists = reduce(
       slots,
       (acc, curr) => {
@@ -143,6 +156,8 @@ export class TimeSlotSchedulerService {
       },
       new Set<string>(),
     );
+
+    slotFiller.forEach((id) => slottedFillerLists.add(id));
 
     const missing = difference([...slottedFillerLists], fillerListIds);
 

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -162,14 +162,6 @@ export function groupByAndMapAsync<
   );
 }
 
-// export async function forEachAsync<T>(arr: Nilable<ArrayLike<T> | object | string>) {
-//   if (isNil(arr)) {
-//     return;
-//   }
-
-//   for (const c of)
-// }
-
 type mapAsyncSeq2Opts = {
   ms?: number;
   parallelism?: number;
@@ -392,6 +384,16 @@ export async function attempt<T>(f: () => T | PromiseLike<T>): Promise<Try<T>> {
 
     throw e; // Unhandled
   }
+}
+
+export function retrySimple<T>(f: () => Nilable<T>, times: number): Nilable<T> {
+  for (let i = 0; i < times; i++) {
+    const res = f();
+    if (res) {
+      return res;
+    }
+  }
+  return;
 }
 
 function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {

--- a/shared/src/util/seq.ts
+++ b/shared/src/util/seq.ts
@@ -6,6 +6,7 @@ import {
   isNil,
   sortBy,
 } from 'lodash-es';
+import type { NonEmptyArray } from 'ts-essentials';
 
 export function intersperse<T>(arr: T[], v: T, makeLast: boolean = false): T[] {
   return flatMap(arr, (x, i) => (i === 0 && !makeLast ? [x] : [x, v]));
@@ -104,6 +105,10 @@ export function collectMapValues<ValueType, ReturnType>(
   return results;
 }
 
+export function groupBy<T, Key extends string | number | symbol>(
+  arr: NonEmptyArray<T>,
+  f: (t: T) => Key,
+): Record<Key, NonEmptyArray<T>>;
 export function groupBy<T, Key extends string | number | symbol>(
   arr: T[] | null | undefined,
   f: (t: T) => Key,

--- a/types/src/api/Scheduling.ts
+++ b/types/src/api/Scheduling.ts
@@ -20,12 +20,34 @@ const BaseSlotOrdering = z.object({
   direction: z.enum(['asc', 'desc']).default('asc'),
 });
 
+export const SlotFillerTypes = z.enum([
+  'head',
+  'pre',
+  'post',
+  'tail',
+  'fallback',
+]);
+
+export type SlotFillerTypes = z.infer<typeof SlotFillerTypes>;
+
+export const SlotFiller = z.object({
+  types: z.array(SlotFillerTypes).nonempty(),
+  fillerListId: z.uuid(),
+});
+
+export type SlotFiller = z.infer<typeof SlotFiller>;
+
+const Slot = z.object({
+  filler: z.array(SlotFiller).optional(),
+});
+
 //
 // Base slots
 //
 const MovieProgrammingSlotSchema = z.object({
   type: z.literal('movie'),
   ...BaseSlotOrdering.shape,
+  ...Slot.shape,
 });
 
 export type BaseMovieProgrammingSlot = z.infer<
@@ -36,6 +58,7 @@ const ShowProgrammingSlotSchema = z.object({
   type: z.literal('show'),
   showId: z.string(),
   ...BaseSlotOrdering.shape,
+  ...Slot.shape,
 });
 
 export type BaseShowProgrammingSlot = z.infer<typeof ShowProgrammingSlotSchema>;
@@ -56,7 +79,12 @@ const CustomShowProgrammingSlotSchema = z.object({
   type: z.literal('custom-show'),
   customShowId: z.uuid(),
   ...BaseSlotOrdering.shape,
+  ...Slot.shape,
 });
+
+export type BaseCustomShowProgrammingSlot = z.infer<
+  typeof CustomShowProgrammingSlotSchema
+>;
 
 const FillerProgrammingSlotSchema = z.object({
   type: z.literal('filler'),
@@ -88,15 +116,21 @@ const BaseTimeSlot = z.object({
   startTime: z.number(), // Offset from midnight in millis
 });
 
-export const MovieProgrammingTimeSlotSchema = MovieProgrammingSlotSchema.extend(
-  BaseTimeSlot.shape,
-);
-export const ShowProgrammingTimeSlotSchema = ShowProgrammingSlotSchema.extend(
-  BaseTimeSlot.shape,
-);
-export const FlexProgrammingTimeSlotSchema = FlexProgrammingSlotSchema.extend(
-  BaseTimeSlot.shape,
-);
+export const MovieProgrammingTimeSlotSchema = z.object({
+  ...BaseTimeSlot.shape,
+  ...MovieProgrammingSlotSchema.shape,
+});
+
+export const ShowProgrammingTimeSlotSchema = z.object({
+  ...BaseTimeSlot.shape,
+  ...ShowProgrammingSlotSchema.shape,
+});
+
+export const FlexProgrammingTimeSlotSchema = z.object({
+  ...BaseTimeSlot.shape,
+  ...FlexProgrammingSlotSchema.shape,
+});
+
 export const RedirectProgrammingTimeSlotSchema =
   RedirectProgrammingSlotSchema.extend(BaseTimeSlot.shape);
 export const CustomShowProgrammingTimeSlotSchema =
@@ -183,6 +217,8 @@ export const RandomSlotDurationSpec = z.discriminatedUnion('type', [
   RandomSlotDynamicDurationspecSchema,
 ]);
 
+export type RandomSlotDurationSpec = z.infer<typeof RandomSlotDurationSpec>;
+
 const BaseRandomSlotSchema = z.object({
   order: SlotProgrammingOrderSchema,
   direction: z.enum(['asc', 'desc']).default('asc'),
@@ -200,11 +236,13 @@ const BaseRandomSlotSchema = z.object({
 });
 
 export const MovieProgrammingRandomSlotSchema = z.object({
+  ...Slot.shape,
   ...BaseRandomSlotSchema.shape,
   type: z.literal('movie'),
 });
 
 export const ShowProgrammingRandomSlotSchema = z.object({
+  ...Slot.shape,
   ...BaseRandomSlotSchema.shape,
   ...ShowProgrammingSlotSchema.shape,
 });
@@ -220,6 +258,7 @@ export const RedirectProgrammingRandomSlotSchema = z.object({
 });
 
 export const CustomShowProgrammingRandomSchema = z.object({
+  ...Slot.shape,
   ...BaseRandomSlotSchema.shape,
   ...CustomShowProgrammingSlotSchema.shape,
 });

--- a/web/src/components/slot_scheduler/AddTimeSlotButton.tsx
+++ b/web/src/components/slot_scheduler/AddTimeSlotButton.tsx
@@ -41,8 +41,6 @@ export const AddTimeSlotButton = ({
     });
   }, [currentPeriod, dayOffset, slots]);
 
-  console.log(dayOffset, relevantSlots);
-
   const optionsByType = useMemo(() => {
     return groupBy(programOptions, (opt) => opt.type) as Dictionary<
       ProgramOption[],

--- a/web/src/components/slot_scheduler/EditRandomSlotDialogContent.tsx
+++ b/web/src/components/slot_scheduler/EditRandomSlotDialogContent.tsx
@@ -10,6 +10,8 @@ import {
   DialogContent,
   Slider,
   Stack,
+  Tab,
+  Tabs,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -21,7 +23,10 @@ import dayjs from 'dayjs';
 import { isNil, map } from 'lodash-es';
 import React, { useCallback, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { useFillerLists } from '../../hooks/useFillerLists.ts';
+import { TabPanel } from '../TabPanel.tsx';
 import { EditSlotProgrammingForm } from './EditSlotProgrammingForm.tsx';
+import { SlotFillerDialogPanel } from './SlotFillerDialogPanel.tsx';
 
 type EditRandomSlotDialogContentProps = {
   slot: RandomSlot;
@@ -48,6 +53,8 @@ export const EditRandomSlotDialogContent = ({
   });
   const { control, getValues, setValue, watch } = formMethods;
   const [durationSpec, programType] = watch(['durationSpec', 'type']);
+  const [tab, setTab] = useState(0);
+  const { data: fillerLists } = useFillerLists();
 
   // const [programming, slotDuration] = watch([`programming`, 'durationMs']);
   const [weightValue, setWeightValue] = useState(getValues('weight'));
@@ -119,141 +126,159 @@ export const EditRandomSlotDialogContent = ({
             gap: '1rem',
           }}
         >
-          <Stack gap={2} useFlexGap>
-            <Stack direction="row" gap={1}>
-              {(programType === 'custom-show' ||
-                programType === 'movie' ||
-                programType === 'show' ||
-                programType === 'filler') && (
-                <Box>
+          <Tabs
+            value={tab}
+            onChange={(_, tab: number) => setTab(tab)}
+            sx={{ borderBottom: 1, borderColor: 'divider' }}
+          >
+            <Tab label="Programming" />
+            <Tab
+              label="Filler"
+              disabled={programType === 'flex' || fillerLists.length === 0}
+            />
+          </Tabs>
+          <TabPanel value={tab} index={0}>
+            <Stack gap={2} useFlexGap>
+              <Stack direction="row" gap={1}>
+                {(programType === 'custom-show' ||
+                  programType === 'movie' ||
+                  programType === 'show' ||
+                  programType === 'filler') && (
+                  <Box>
+                    <Controller
+                      control={control}
+                      name="durationSpec.type"
+                      render={({ field }) => (
+                        <ToggleButtonGroup
+                          color="primary"
+                          exclusive
+                          aria-label="Platform"
+                          {...field}
+                        >
+                          <ToggleButton value="fixed">Fixed</ToggleButton>
+                          <ToggleButton value="dynamic">Dynamic</ToggleButton>
+                        </ToggleButtonGroup>
+                      )}
+                    />
+                  </Box>
+                )}
+                {durationSpec.type === 'dynamic' && (
+                  <NumericFormControllerText
+                    control={control}
+                    TextFieldProps={{
+                      label: 'Program Count',
+                      fullWidth: true,
+                      helperText: '',
+                    }}
+                    rules={{
+                      min: 1,
+                    }}
+                    defaultValue={1}
+                    name="durationSpec.programCount"
+                  />
+                )}
+                {durationSpec.type === 'fixed' && (
                   <Controller
                     control={control}
-                    name="durationSpec.type"
-                    render={({ field }) => (
-                      <ToggleButtonGroup
-                        color="primary"
-                        exclusive
-                        aria-label="Platform"
-                        {...field}
-                      >
-                        <ToggleButton value="fixed">Fixed</ToggleButton>
-                        <ToggleButton value="dynamic">Dynamic</ToggleButton>
-                      </ToggleButtonGroup>
-                    )}
+                    name="durationSpec.durationMs"
+                    rules={{
+                      min: 1,
+                    }}
+                    render={({ field, fieldState: { error } }) => {
+                      return (
+                        <TimeField
+                          format="H[h] m[m] s[s]"
+                          {...field}
+                          value={dayjs().startOf('day').add(field.value)}
+                          onChange={(value) =>
+                            updateSlotTime(value, field.onChange)
+                          }
+                          label="Duration"
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: !isNil(error),
+                              helperText: betterHumanize(
+                                dayjs.duration(field.value),
+                                { exact: true, style: 'full' },
+                              ),
+                            },
+                          }}
+                        />
+                      );
+                    }}
                   />
-                </Box>
-              )}
-              {durationSpec.type === 'dynamic' && (
-                <NumericFormControllerText
-                  control={control}
-                  TextFieldProps={{
-                    label: 'Program Count',
-                    fullWidth: true,
-                    helperText: '',
-                  }}
-                  rules={{
-                    min: 1,
-                  }}
-                  defaultValue={1}
-                  name="durationSpec.programCount"
-                />
-              )}
-              {durationSpec.type === 'fixed' && (
-                <Controller
-                  control={control}
-                  name="durationSpec.durationMs"
-                  rules={{
-                    min: 1,
-                  }}
-                  render={({ field, fieldState: { error } }) => {
-                    return (
-                      <TimeField
-                        format="H[h] m[m] s[s]"
-                        {...field}
-                        value={dayjs().startOf('day').add(field.value)}
-                        onChange={(value) =>
-                          updateSlotTime(value, field.onChange)
-                        }
-                        label="Duration"
-                        slotProps={{
-                          textField: {
-                            fullWidth: true,
-                            error: !isNil(error),
-                            helperText: betterHumanize(
-                              dayjs.duration(field.value),
-                              { exact: true, style: 'full' },
-                            ),
-                          },
-                        }}
-                      />
-                    );
-                  }}
-                />
-              )}
-              {distribution !== 'none' && (
-                <Controller
-                  control={control}
-                  name="cooldownMs"
-                  render={({ field, fieldState: { error } }) => {
-                    return (
-                      <TimeField
-                        format="H[h] m[m] s[s]"
-                        {...field}
-                        value={dayjs().startOf('day').add(field.value)}
-                        onChange={(value) =>
-                          updateSlotTime(value, field.onChange)
-                        }
-                        label="Cooldown"
-                        slotProps={{
-                          textField: {
-                            fullWidth: true,
-                            error: !isNil(error),
-                            helperText: betterHumanize(
-                              dayjs.duration(field.value),
-                              { exact: true, style: 'full' },
-                            ),
-                          },
-                        }}
-                      />
-                    );
-                  }}
-                />
+                )}
+                {distribution !== 'none' && (
+                  <Controller
+                    control={control}
+                    name="cooldownMs"
+                    render={({ field, fieldState: { error } }) => {
+                      return (
+                        <TimeField
+                          format="H[h] m[m] s[s]"
+                          {...field}
+                          value={dayjs().startOf('day').add(field.value)}
+                          onChange={(value) =>
+                            updateSlotTime(value, field.onChange)
+                          }
+                          label="Cooldown"
+                          slotProps={{
+                            textField: {
+                              fullWidth: true,
+                              error: !isNil(error),
+                              helperText: betterHumanize(
+                                dayjs.duration(field.value),
+                                { exact: true, style: 'full' },
+                              ),
+                            },
+                          }}
+                        />
+                      );
+                    }}
+                  />
+                )}
+              </Stack>
+              <FormProvider {...formMethods}>
+                <EditSlotProgrammingForm programOptions={programOptions} />
+              </FormProvider>
+              {distribution === 'weighted' && (
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Slider
+                    min={0}
+                    max={100}
+                    value={weightValue}
+                    step={0.1}
+                    onChange={handleWeightChange}
+                    onChangeCommitted={setFormWeightValue}
+                    sx={{
+                      width: '90%',
+                      '& .MuiSlider-thumb': {
+                        transition: 'left 0.1s',
+                      },
+                      '& .MuiSlider-thumb.MuiSlider-active': {
+                        transition: 'left 0s',
+                      },
+                      '& .MuiSlider-track': {
+                        transition: 'width 0.1s',
+                      },
+                    }}
+                  />
+                  <TextField
+                    type="number"
+                    label="Weight %"
+                    value={weightValue}
+                    disabled
+                  />
+                </Stack>
               )}
             </Stack>
+          </TabPanel>
+          <TabPanel value={tab} index={1}>
             <FormProvider {...formMethods}>
-              <EditSlotProgrammingForm programOptions={programOptions} />
+              <SlotFillerDialogPanel />
             </FormProvider>
-            {distribution === 'weighted' && (
-              <Stack direction="row" spacing={2} alignItems="center">
-                <Slider
-                  min={0}
-                  max={100}
-                  value={weightValue}
-                  step={0.1}
-                  onChange={handleWeightChange}
-                  onChangeCommitted={setFormWeightValue}
-                  sx={{
-                    width: '90%',
-                    '& .MuiSlider-thumb': {
-                      transition: 'left 0.1s',
-                    },
-                    '& .MuiSlider-thumb.MuiSlider-active': {
-                      transition: 'left 0s',
-                    },
-                    '& .MuiSlider-track': {
-                      transition: 'width 0.1s',
-                    },
-                  }}
-                />
-                <TextField
-                  type="number"
-                  label="Weight %"
-                  value={weightValue}
-                  disabled
-                />
-              </Stack>
-            )}
-          </Stack>
+          </TabPanel>
         </Box>
       </DialogContent>
       <DialogActions>

--- a/web/src/components/slot_scheduler/RandomSlotTable.tsx
+++ b/web/src/components/slot_scheduler/RandomSlotTable.tsx
@@ -449,7 +449,7 @@ export const RandomSlotTable = () => {
         <MaterialReactTable table={table} />
       </Box>
       <Dialog
-        maxWidth="sm"
+        maxWidth="md"
         open={!!currentEditingSlot}
         fullWidth
         onClose={() => setCurrentEditingSlot(null)}

--- a/web/src/components/slot_scheduler/SlotFillerDialogPanel.tsx
+++ b/web/src/components/slot_scheduler/SlotFillerDialogPanel.tsx
@@ -1,0 +1,152 @@
+import {
+  Add,
+  Delete,
+  FirstPage,
+  LastPage,
+  LowPriority,
+  Repeat,
+} from '@mui/icons-material';
+import {
+  Autocomplete,
+  Button,
+  IconButton,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@mui/material';
+import { seq } from '@tunarr/shared/util';
+import type { BaseSlot } from '@tunarr/types/api';
+import { find, isEmpty, some } from 'lodash-es';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+import { useFillerLists } from '../../hooks/useFillerLists.ts';
+
+export const SlotFillerDialogPanel = () => {
+  const { control, watch } = useFormContext<BaseSlot>();
+  const fillerFields = useFieldArray({ control, name: 'filler' });
+  const { data: fillerLists } = useFillerLists();
+
+  const [chosenFillerLists, setChosenFillerLists] = useState<string[]>([]);
+
+  // Insanely stupid hack we have to do in order to re-render on nested value
+  // set.
+  useEffect(() => {
+    const { unsubscribe } = watch((value, info) => {
+      if (
+        value.type &&
+        (value.type === 'movie' ||
+          value.type === 'custom-show' ||
+          value.type === 'show') &&
+        info.name?.startsWith('filler')
+      ) {
+        const fillerListIds = seq.collect(
+          value.filler,
+          (filler) => filler?.fillerListId,
+        );
+        console.log(fillerListIds);
+        setChosenFillerLists(fillerListIds);
+      }
+    });
+    return () => unsubscribe();
+  }, [watch]);
+
+  const fillerListOptions = useMemo(() => {
+    if (chosenFillerLists.length <= 1) {
+      return fillerLists;
+    }
+
+    return fillerLists.filter(
+      (list) => !some(chosenFillerLists, (field) => field === list.id),
+    );
+  }, [chosenFillerLists, fillerLists]);
+
+  const handleAddNewFillerList = useCallback(() => {
+    const unselected = fillerLists.find(
+      (list) => !some(chosenFillerLists, (field) => field === list.id),
+    );
+    if (!unselected) {
+      return;
+    }
+
+    fillerFields.append({
+      types: ['pre'],
+      fillerListId: unselected.id,
+    });
+  }, [fillerLists, fillerFields, chosenFillerLists]);
+
+  if (fillerLists.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Button
+        startIcon={<Add />}
+        variant="outlined"
+        disabled={isEmpty(fillerListOptions)}
+        onClick={handleAddNewFillerList}
+      >
+        Add filler
+      </Button>
+      {fillerFields.fields.map((fillerField, idx) => (
+        <Stack direction="row" spacing={2} key={fillerField.id}>
+          <Controller
+            control={control}
+            name={`filler.${idx}.fillerListId` as const}
+            rules={{ required: true }}
+            render={({ field }) => (
+              <Autocomplete
+                fullWidth
+                disableClearable={true}
+                options={fillerListOptions}
+                getOptionKey={(list) => list.id}
+                getOptionLabel={(list) => list.name}
+                value={find(fillerLists, { id: field.value })}
+                onChange={(_, list) => field.onChange(list?.id)}
+                renderInput={(params) => (
+                  <TextField {...params} label="Filler List" />
+                )}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name={`filler.${idx}.types`}
+            rules={{ validate: { nonempty: (v) => v.length > 0 } }}
+            render={({ field }) => (
+              <ToggleButtonGroup
+                key={fillerField.id}
+                value={field.value}
+                onChange={(_, formats) => field.onChange(formats)}
+              >
+                <ToggleButton value="head">
+                  <FirstPage />
+                  Head
+                </ToggleButton>
+                <ToggleButton value={'pre'}>
+                  <LowPriority
+                    sx={{ rotate: '180deg', transform: 'scale(-1, 1)', mr: 1 }}
+                  />{' '}
+                  Pre
+                </ToggleButton>
+                <ToggleButton value="post">
+                  <LowPriority sx={{ mr: 1 }} /> Post
+                </ToggleButton>
+                <ToggleButton value="tail">
+                  <LastPage sx={{ mr: 1 }} /> Tail
+                </ToggleButton>
+                <ToggleButton value="fallback">
+                  <Repeat /> Fallback
+                </ToggleButton>
+              </ToggleButtonGroup>
+            )}
+          />
+          <IconButton onClick={() => fillerFields.remove(idx)} disableRipple>
+            <Delete />{' '}
+          </IconButton>
+        </Stack>
+      ))}
+    </Stack>
+  );
+};

--- a/web/src/components/slot_scheduler/TimeSlotTable.tsx
+++ b/web/src/components/slot_scheduler/TimeSlotTable.tsx
@@ -257,12 +257,10 @@ export const TimeSlotTable = () => {
             case 'show':
             case 'custom-show':
             case 'filler':
-              return capitalize(
-                originalRow.order
-                  .split('_')
-                  .map((x) => capitalize(x))
-                  .join(' '),
-              );
+              return originalRow.order
+                .split('_')
+                .map((x) => capitalize(x))
+                .join(' ');
           }
         },
         id: 'programOrder',
@@ -375,7 +373,7 @@ export const TimeSlotTable = () => {
       )}
       <MaterialReactTable table={table} />
       <Dialog
-        maxWidth="sm"
+        maxWidth="md"
         open={!!currentEditingSlot}
         fullWidth
         onClose={() => setCurrentEditingSlot(null)}

--- a/web/src/hooks/useFillerLists.ts
+++ b/web/src/hooks/useFillerLists.ts
@@ -12,6 +12,7 @@ export const fillerListsQuery = (apiClient: ApiClient) =>
   queryOptions({
     queryKey: ['fillers'],
     queryFn: () => apiClient.getFillerLists(),
+    staleTime: 1000 * 60 * 5,
   });
 
 export const useFillerLists = (


### PR DESCRIPTION
* Support for assigning a filler "type" to a given slot in both time slots and slot editor
* Supported types are "head" (before all programs in a lot), "pre" (before each program in a slot), "post" (after each program in a slot), "tail" (after all programs in a slot) and "fallback" (used to fill any additional time)
* Each slot can have multiple filler lists, each assigned to multiple "types". Lists are equally weighted
* For dynamic duration slots (in slot editor), configured filler will always be chosen
* For fixed duration slots (in slot editor or time slots), configured filler is best effort, given the remaining time in a slot after scheduling actual content.