### PR TITLE
fix(streaming): remove some limits on thread counts

### DIFF
--- a/server/src/ffmpeg/builder/constants.ts
+++ b/server/src/ffmpeg/builder/constants.ts
@@ -38,6 +38,7 @@ export const OutputFormatTypes = {
   Mp4: 'mp4',
   Hls: 'hls',
   Nut: 'nut',
+  Dash: 'dash',
 } as const;
 
 export type OutputLocation = Lowercase<keyof typeof OutputLocation>;


### PR DESCRIPTION
thread option here only applies to decoding, as currently implemented. we shouldn't override the count when encoding with hardware 