### PR TITLE
feat: add genres endpoint and integrate genre selection in the ui for…

### DIFF
--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -359,6 +359,26 @@ export class JellyfinApiClient extends BaseApiClient {
     return `${this.options.url}/web/#/details?id=${id}`;
   }
 
+  async getGenres(
+    parentId?: string,
+    includeItemTypes?: string
+  ): Promise<QueryResult<string>> {
+    const genresResult = await this.doGet<string>({
+      url: `/Genres`,
+      params: {
+        ...(parentId ? { parentId } : {}),
+        includeItemTypes,
+        recursive: 'true',
+      },
+    });
+
+    if (isError(genresResult)) {
+      return this.makeErrorResult('generic_request_error');
+    }
+
+    return this.makeSuccessResult(genresResult);
+  }
+
   async recordPlaybackStart(itemId: string, deviceId: string) {
     return this.doPost({
       url: '/Sessions/Playing',

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -366,13 +366,14 @@ export class JellyfinApiClient extends BaseApiClient {
     const genresResult = await this.doGet<string>({
       url: `/Genres`,
       params: {
-        ...(parentId ? { parentId } : {}),
+        parentId,
+        userId: this.options.userId,
         includeItemTypes,
         recursive: 'true',
       },
     });
 
-    if (isError(genresResult)) {
+    if (genresResult instanceof Error) {
       return this.makeErrorResult('generic_request_error');
     }
 

--- a/types/src/jellyfin/index.ts
+++ b/types/src/jellyfin/index.ts
@@ -859,6 +859,16 @@ export type JellyfinLibraryItemsResponse = z.infer<
   typeof JellyfinLibraryItemsResponse
 >;
 
+export const JellyfinGenresResponse = z.object({
+  Items: z.array(JellyfinItem),
+  TotalRecordCount: z.number(),
+  StartIndex: z.number().nullable().optional(),
+});
+
+export type JellyfinGenresResponse = z.infer<
+  typeof JellyfinGenresResponse
+>;
+
 const JellyfinSessionInfo = z
   .object({
     // PlayState: PlayerStateInfo.nullable().optional(),

--- a/types/src/jellyfin/index.ts
+++ b/types/src/jellyfin/index.ts
@@ -859,15 +859,8 @@ export type JellyfinLibraryItemsResponse = z.infer<
   typeof JellyfinLibraryItemsResponse
 >;
 
-export const JellyfinGenresResponse = z.object({
-  Items: z.array(JellyfinItem),
-  TotalRecordCount: z.number(),
-  StartIndex: z.number().nullable().optional(),
-});
-
-export type JellyfinGenresResponse = z.infer<
-  typeof JellyfinGenresResponse
->;
+export const JellyfinGenresResponse = JellyfinLibraryItemsResponse;
+export type JellyfinGenresResponse = JellyfinLibraryItemsResponse;
 
 const JellyfinSessionInfo = z
   .object({

--- a/web/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web/src/components/channel_config/ProgrammingSelector.tsx
@@ -1,4 +1,5 @@
 import { useJellyfinGenres, useJellyfinUserLibraries } from '@/hooks/jellyfin/useJellyfinApi.ts';
+import type { JellyfinGenresResponse, JellyfinItem } from '@tunarr/types/jellyfin';
 import { useKnownMedia } from '@/store/programmingSelector/selectors.ts';
 import {
   Alert,
@@ -107,7 +108,7 @@ export const ProgrammingSelector = ({
     selectedServer?.id ?? tag(''),
     selectedJellyfinLibrary?.Id ?? '',
     selectedServer?.type === Jellyfin && !!selectedJellyfinLibrary,
-  );
+  ) as { data?: JellyfinGenresResponse };
 
   useEffect(() => {
     const server =
@@ -451,26 +452,10 @@ export const ProgrammingSelector = ({
     }
   };
 
-  /**
-   * Helper function to extract genre name from different API response formats
-   * Jellyfin API can return genres as objects with 'Name' property or as strings
-   */
-  const extractGenreName = (genre: unknown): string => {
-    // Handle object format: { Name: "Action" }
-    if (genre && typeof genre === 'object' && genre !== null && 'Name' in genre) {
-      return String((genre as { Name: unknown }).Name);
-    }
-    // Handle string format: "Action"
-    if (genre != null) {
-      return String(genre);
-    }
-    return '';
-  };
+  const extractGenreName = (genre: JellyfinItem): string => genre.Name ?? '';
 
   const renderGenreChoices = () => {
-    // Handle both API response formats: { Items: [...] } or direct array
-    const genreList = jellyfinGenres?.Items ?? jellyfinGenres ?? [];
-
+    const genreList = jellyfinGenres?.Items ?? [];
     return (
       <FormControl size="small" sx={{ minWidth: { sm: 200 } }}>
         <InputLabel>Genre</InputLabel>
@@ -479,17 +464,16 @@ export const ProgrammingSelector = ({
           value={selectedGenre ?? ''}
           onChange={(e) => {
             const value = e.target.value;
-            // Clear genre filter if "All Genres" is selected
             setProgrammingGenre(value === '' ? undefined : value);
           }}
         >
           <MenuItem value="">
             <em>All Genres</em>
           </MenuItem>
-          {map(genreList, (genre, idx) => {
+          {genreList.map((genre) => {
             const genreValue = extractGenreName(genre);
             return (
-              <MenuItem key={genreValue || idx} value={genreValue}>
+              <MenuItem key={genre.Id} value={genreValue}>
                 {capitalize(genreValue)}
               </MenuItem>
             );

--- a/web/src/components/channel_config/jellyfin/JellyfinProgrammingSelector.tsx
+++ b/web/src/components/channel_config/jellyfin/JellyfinProgrammingSelector.tsx
@@ -15,10 +15,12 @@ enum TabValues {
 
 type Props = {
   toggleOrSetSelectedProgramsDrawer: (open: boolean) => void;
+  selectedGenre?: string;
 };
 
 export function JellyfinProgrammingSelector({
   toggleOrSetSelectedProgramsDrawer,
+  selectedGenre,
 }: Props) {
   const selectedServer = useCurrentMediaSource(Jellyfin)!;
   const selectedLibrary = useCurrentMediaSourceView(Jellyfin)!;
@@ -48,6 +50,7 @@ export function JellyfinProgrammingSelector({
           parentContext={[]}
           selectedLibrary={selectedLibrary}
           selectedServer={selectedServer}
+          genres={selectedGenre ? [selectedGenre] : []}
         />
       </Box>
     </>

--- a/web/src/external/jellyfinApi.ts
+++ b/web/src/external/jellyfinApi.ts
@@ -2,6 +2,7 @@ import {
   JellyfinItemKind,
   JellyfinItemSortBy,
   JellyfinLibraryItemsResponse,
+  JellyfinGenresResponse
 } from '@tunarr/types/jellyfin';
 import { makeEndpoint, parametersBuilder } from '@tunarr/zodios-core';
 import { z } from 'zod/v4';
@@ -47,5 +48,15 @@ export const jellyfinEndpoints = [
       .build(),
     response: JellyfinLibraryItemsResponse,
     alias: 'getJellyfinItems',
+  }),
+  makeEndpoint({
+    method: 'get',
+    path: '/api/jellyfin/:mediaSourceId/libraries/:libraryId/genres',
+    parameters: parametersBuilder()
+      .addPath('mediaSourceId', z.string())
+      .addPath('libraryId', z.string())
+      .build(),
+    response: JellyfinGenresResponse,
+    alias: 'getJellyfinGenres',
   }),
 ] as const;

--- a/web/src/hooks/jellyfin/useJellyfinApi.ts
+++ b/web/src/hooks/jellyfin/useJellyfinApi.ts
@@ -27,6 +27,22 @@ export const useJellyfinUserLibraries = (
   });
 };
 
+export const useJellyfinGenres = (
+  mediaSourceId: MediaSourceId,
+  libraryId: string,
+  enabled: boolean = true,
+) => {
+  const apiClient = useTunarrApi();
+
+  return useQuery({
+    queryKey: ['jellyfin', mediaSourceId, 'libraries', libraryId, 'genres'],
+    queryFn: () =>
+      apiClient.getJellyfinGenres({ params: { mediaSourceId, libraryId } }),
+    enabled:
+      isNonEmptyString(mediaSourceId) && isNonEmptyString(libraryId) && enabled
+  });
+};
+
 export const useJellyfinLibraryItems = (
   mediaSourceId: MediaSourceId,
   parentId: string,

--- a/web/src/hooks/jellyfin/useJellyfinApi.ts
+++ b/web/src/hooks/jellyfin/useJellyfinApi.ts
@@ -39,7 +39,8 @@ export const useJellyfinGenres = (
     queryFn: () =>
       apiClient.getJellyfinGenres({ params: { mediaSourceId, libraryId } }),
     enabled:
-      isNonEmptyString(mediaSourceId) && isNonEmptyString(libraryId) && enabled
+      isNonEmptyString(mediaSourceId) && isNonEmptyString(libraryId) && enabled,
+    staleTime: 900_000, // 15 minutes
   });
 };
 

--- a/web/src/store/programmingSelector/actions.ts
+++ b/web/src/store/programmingSelector/actions.ts
@@ -51,6 +51,11 @@ export const setProgrammingListLibrary = (library: MediaSourceView) =>
     state.currentMediaSourceView = library;
   });
 
+export const setProgrammingGenre = (genre?: string) =>
+  useStore.setState((state) => {
+    state.currentMediaGenre = genre;
+  });
+
 export const setPlexProgrammingListLibrarySubview = (
   subview?: 'collections' | 'playlists',
 ) =>

--- a/web/src/store/programmingSelector/store.ts
+++ b/web/src/store/programmingSelector/store.ts
@@ -90,6 +90,8 @@ export type MediaSourceView =
 
 type TypedItem<T, Type> = TypedKey<T, Type, 'item'>;
 
+export type MediaGenre = TypedItem<string, Jellyfin | Plex | Emby>;
+
 export type MediaItems =
   | TypedItem<PlexLibrarySection | PlexMedia, Plex>
   | TypedItem<JellyfinItem, Jellyfin>
@@ -105,6 +107,7 @@ export type ContentHierarchyMap = Record<
 export interface ProgrammingListingsState {
   currentMediaSource?: MediaSourceSettings;
   currentMediaSourceView?: MediaSourceView;
+  currentMediaGenre?: string;
   // Tracks the parent-child mappings of library items
   contentHierarchyByServer: ContentHierarchyMap;
   // Holds the actual metadata for items, including directories (i.e. Plex libraries)


### PR DESCRIPTION
… jellyfin programming

Add ability to filter programming items on a Jellyfin library by genre on the Add Media screen
<img width="875" height="153" alt="Snag_6c9b257" src="https://github.com/user-attachments/assets/daf927a9-1548-4cea-b6fa-f288681360a1" />
<img width="887" height="207" alt="Snag_6c9bfc5" src="https://github.com/user-attachments/assets/38bfa6c3-9386-4bb2-a84c-d53239f3dae0" />
