### PR TITLE
Copy openapi docs to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY types ./types
 COPY web ./web
 COPY patches ./patches
 COPY CHANGELOG.md CHANGELOG.md
+COPY tunarr-openapi.json tunarr-openapi.json
 
 # Dev container
 FROM ffmpeg-base AS dev
@@ -64,6 +65,7 @@ COPY ./web web
 COPY ./shared shared
 COPY ./types types
 COPY ./scripts scripts
+COPY ./patches patches
 COPY README.md README.md
 COPY package.json package.json
 COPY pnpm-lock.yaml pnpm-lock.yaml


### PR DESCRIPTION
I got excited for some of the new updates, but it looks like [docker builds are failing due to missing files](https://github.com/chrisbenincasa/tunarr/actions/runs/17133789683/job/48605017461#step:10:932). 

Copying the openapi spec into the container and patches dir between stages seemed to fix the build on my local 