### PR TITLE
Add new channel options button across channel pages

### DIFF
--- a/web/src/components/channels/ChannelOptionsButton.tsx
+++ b/web/src/components/channels/ChannelOptionsButton.tsx
@@ -1,0 +1,59 @@
+import type { channelListOptions } from '@/types/index.ts';
+import { Settings } from '@mui/icons-material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { Button } from '@mui/material';
+import type { Channel } from '@tunarr/types';
+import { isNull } from 'lodash-es';
+import { useState } from 'react';
+import { ChannelOptionsMenu } from './ChannelOptionsMenu.tsx';
+
+type Props = {
+  channel: Channel;
+  hideItems?: channelListOptions[];
+};
+
+export const ChannelOptionsButton = ({ channel, hideItems }: Props) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [channelMenu, setChannelMenu] = useState<Channel>();
+  const open = !isNull(anchorEl);
+
+  const handleClick = (
+    event: React.MouseEvent<HTMLElement>,
+    channel: Channel,
+  ) => {
+    console.log(channel);
+    setAnchorEl(event.currentTarget);
+    setChannelMenu(channel);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        startIcon={<Settings />}
+        aria-controls={open ? 'channel-nav-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        disableRipple
+        disableElevation
+        onClick={(event) => handleClick(event, channel)}
+        endIcon={<KeyboardArrowDownIcon />}
+      >
+        Options
+      </Button>
+      {channelMenu && (
+        <ChannelOptionsMenu
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          row={channelMenu}
+          hideItems={hideItems}
+        />
+      )}
+    </>
+  );
+};

--- a/web/src/components/channels/ChannelOptionsMenu.tsx
+++ b/web/src/components/channels/ChannelOptionsMenu.tsx
@@ -1,3 +1,4 @@
+import type { channelListOptions } from '@/types/index.ts';
 import {
   ContentCopy,
   CopyAll,
@@ -27,12 +28,10 @@ type Props = {
   anchorEl: PopoverAnchorEl;
   open: boolean;
   onClose: (e?: SyntheticEvent) => void;
-  hideItems?: ListItem[];
+  hideItems?: channelListOptions[];
 };
 
-type ListItem = 'edit' | 'duplicate' | 'delete';
-
-export const ChannelsTableOptionsMenu = ({
+export const ChannelOptionsMenu = ({
   row,
   anchorEl,
   open,
@@ -108,18 +107,20 @@ export const ChannelsTableOptionsMenu = ({
           </MenuItem>
         ) : null}
 
-        <MenuItem
-          to={`/channels/${channelId}/programming`}
-          component={Link}
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-        >
-          <ListItemIcon>
-            <Edit />
-          </ListItemIcon>
-          <ListItemText>Modify Programming</ListItemText>
-        </MenuItem>
+        {!hideItems?.includes('programming') ? (
+          <MenuItem
+            to={`/channels/${channelId}/programming`}
+            component={Link}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <ListItemIcon>
+              <Edit />
+            </ListItemIcon>
+            <ListItemText>Modify Programming</ListItemText>
+          </MenuItem>
+        ) : null}
 
         <MenuItem
           onClick={(e) => {
@@ -162,18 +163,21 @@ export const ChannelsTableOptionsMenu = ({
           </ListItemIcon>
           <ListItemText>Copy Channel ID</ListItemText>
         </MenuItem>
-        <MenuItem
-          component={Link}
-          to={`/channels/${channelId}/watch`}
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-        >
-          <ListItemIcon>
-            <Tv />
-          </ListItemIcon>
-          <ListItemText>Watch Channel</ListItemText>
-        </MenuItem>
+
+        {!hideItems?.includes('watch') ? (
+          <MenuItem
+            component={Link}
+            to={`/channels/${channelId}/watch`}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <ListItemIcon>
+              <Tv />
+            </ListItemIcon>
+            <ListItemText>Watch Channel</ListItemText>
+          </MenuItem>
+        ) : null}
         <MenuItem
           onClick={(e) => {
             e.stopPropagation();

--- a/web/src/components/guide/TvGuide.tsx
+++ b/web/src/components/guide/TvGuide.tsx
@@ -27,7 +27,7 @@ import type { Maybe } from '../../types/util.ts';
 import ProgramDetailsDialog from '../ProgramDetailsDialog';
 import TunarrLogo from '../TunarrLogo';
 import PaddedPaper from '../base/PaddedPaper';
-import { ChannelsTableOptionsMenu } from '../channels/ChannelsTableOptionsMenu.tsx';
+import { ChannelOptionsMenu } from '../channels/ChannelOptionsMenu.tsx';
 import { TvGuideGridChild } from './TvGuideGridChild.tsx';
 import { TvGuideItem } from './TvGuideItem.tsx';
 
@@ -159,7 +159,7 @@ export function TvGuide({ channelId, start, end, showStealth = true }: Props) {
 
   const renderChannelMenu = () => {
     return channelMenu ? (
-      <ChannelsTableOptionsMenu
+      <ChannelOptionsMenu
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}

--- a/web/src/pages/channels/ChannelProgrammingPage.tsx
+++ b/web/src/pages/channels/ChannelProgrammingPage.tsx
@@ -1,16 +1,8 @@
 import Breadcrumbs from '@/components/Breadcrumbs.tsx';
+import { ChannelOptionsButton } from '@/components/channels/ChannelOptionsButton.tsx';
 import { useChannelAndProgramming } from '@/hooks/useChannelLineup.ts';
 import { Route } from '@/routes/channels_/$channelId/programming/index.tsx';
-import Edit from '@mui/icons-material/Edit';
-import {
-  Alert,
-  Box,
-  Button,
-  Link,
-  Paper,
-  Stack,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, Link, Paper, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { ChannelProgrammingConfig } from '../../components/channel_config/ChannelProgrammingConfig.tsx';
@@ -44,14 +36,10 @@ export default function ChannelProgrammingPage() {
           {channel.name}
         </Typography>
         <Box>
-          <Button
-            component={RouterLink}
-            to="../edit"
-            variant="outlined"
-            startIcon={<Edit />}
-          >
-            Edit
-          </Button>
+          <ChannelOptionsButton
+            channel={channel}
+            hideItems={['programming', 'duplicate', 'delete']}
+          />
         </Box>
       </Stack>
       {schedule && (

--- a/web/src/pages/channels/ChannelSummaryPage.tsx
+++ b/web/src/pages/channels/ChannelSummaryPage.tsx
@@ -1,15 +1,12 @@
-import { AddToQueue, Settings } from '@mui/icons-material';
+import { ChannelOptionsButton } from '@/components/channels/ChannelOptionsButton.tsx';
 import {
   Box,
-  IconButton,
   LinearProgress,
   Stack,
-  Tooltip,
   Typography,
   useTheme,
 } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { Link } from '@tanstack/react-router';
 import { Suspense } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
 import { ChannelNowPlayingCard } from '../../components/channels/ChannelNowPlayingCard.tsx';
@@ -47,16 +44,10 @@ export const ChannelSummaryPage = () => {
         </Box>
       </Stack>
       <Stack direction="row" spacing={1} justifyContent="right">
-        <Tooltip title="Edit" placement="top">
-          <IconButton component={Link} from={Route.fullPath} to="./edit">
-            <Settings />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Add Programming" placement="top">
-          <IconButton component={Link} from={Route.fullPath} to="./programming">
-            <AddToQueue />
-          </IconButton>
-        </Tooltip>
+        <ChannelOptionsButton
+          channel={channel}
+          hideItems={['duplicate', 'delete']}
+        />
       </Stack>
       <Box sx={{ width: '100%' }}>
         <Suspense fallback={<LinearProgress />}>

--- a/web/src/pages/channels/ChannelsPage.tsx
+++ b/web/src/pages/channels/ChannelsPage.tsx
@@ -5,7 +5,7 @@ import {
   setChannelTableColumnModel,
 } from '@/store/settings/actions.ts';
 import type { Maybe } from '@/types/util.ts';
-import { Check, Close, MoreVert, Settings } from '@mui/icons-material';
+import { Check, Close, Edit, MoreVert } from '@mui/icons-material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import type { BoxProps } from '@mui/material';
 import {
@@ -47,8 +47,8 @@ import pluralize from 'pluralize';
 import React, { useEffect, useMemo, useState } from 'react';
 import TunarrLogo from '../../components/TunarrLogo.tsx';
 import NoChannelsCreated from '../../components/channel_config/NoChannelsCreated.tsx';
+import { ChannelOptionsMenu } from '../../components/channels/ChannelOptionsMenu.tsx';
 import { ChannelSessionsDialog } from '../../components/channels/ChannelSessionsDialog.tsx';
-import { ChannelsTableOptionsMenu } from '../../components/channels/ChannelsTableOptionsMenu.tsx';
 import { deleteApiChannelsByIdMutation } from '../../generated/@tanstack/react-query.gen.ts';
 import { isNonEmptyString } from '../../helpers/util.ts';
 import { useChannelsSuspense } from '../../hooks/useChannels.ts';
@@ -222,7 +222,7 @@ export default function ChannelsPage() {
 
   const renderChannelMenu = (row: ChannelRow) => {
     return (
-      <ChannelsTableOptionsMenu
+      <ChannelOptionsMenu
         anchorEl={anchorEl}
         onClose={() => handleChannelMenuClose()}
         open={channelMenuOpen === row.id}
@@ -247,7 +247,7 @@ export default function ChannelsPage() {
               component={RouterLink}
               onClick={(e) => e.stopPropagation()}
             >
-              <Settings />
+              <Edit />
             </IconButton>
           </Tooltip>
         )}

--- a/web/src/pages/channels/EditChannelPage.tsx
+++ b/web/src/pages/channels/EditChannelPage.tsx
@@ -1,12 +1,11 @@
 import type { EditChannelTabs } from '@/components/channel_config/EditChannelTabPanel.tsx';
+import { ChannelOptionsButton } from '@/components/channels/ChannelOptionsButton.tsx';
+import { useChannelSuspense } from '@/hooks/useChannels.ts';
+import { Route } from '@/routes/channels_/$channelId/edit/index.tsx';
+import { Box, Stack } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
 import { EditChannelForm } from '../../components/channel_config/EditChannelForm.tsx';
-import { Route } from '@/routes/channels_/$channelId/edit/index.tsx';
-import { useChannelSuspense } from '@/hooks/useChannels.ts';
-import Edit from '@mui/icons-material/Edit';
-import { Link } from '@tanstack/react-router';
-import { Stack, Box, Button } from '@mui/material';
 
 type Props = {
   initialTab?: EditChannelTabs;
@@ -25,14 +24,10 @@ export default function EditChannelPage({ initialTab }: Props) {
             {channel.name}
           </Typography>
           <Box>
-            <Button
-              component={Link}
-              to="../programming"
-              variant="outlined"
-              startIcon={<Edit />}
-            >
-              Programming
-            </Button>
+            <ChannelOptionsButton
+              channel={channel}
+              hideItems={['edit', 'duplicate', 'delete']}
+            />
           </Box>
         </Stack>
         <EditChannelForm

--- a/web/src/pages/watch/ChannelWatchPage.tsx
+++ b/web/src/pages/watch/ChannelWatchPage.tsx
@@ -1,11 +1,13 @@
+import { ChannelOptionsButton } from '@/components/channels/ChannelOptionsButton.tsx';
 import { useChannelSuspense } from '@/hooks/useChannels.ts';
+import { Route } from '@/routes/channels_/$channelId/watch.tsx';
+import { Stack } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs.tsx';
 import Video from '../../components/Video.tsx';
 import { TvGuide } from '../../components/guide/TvGuide.tsx';
 import { roundCurrentTime } from '../../helpers/util.ts';
-import { Route } from '@/routes/channels_/$channelId/watch.tsx';
 
 export default function ChannelWatchPage() {
   const { channelId } = Route.useParams();
@@ -20,9 +22,15 @@ export default function ChannelWatchPage() {
     channel && (
       <div>
         <Breadcrumbs />
-        <Typography variant="h4" sx={{ mb: 2 }}>
-          "{channel.name}" Live
-        </Typography>
+        <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+          <Typography variant="h4" sx={{ mb: 2, width: '100%' }}>
+            "{channel.name}" Live
+          </Typography>
+          <ChannelOptionsButton
+            channel={channel}
+            hideItems={['duplicate', 'delete', 'watch']}
+          />
+        </Stack>
         <Video channelId={channel.id} />
         <TvGuide channelId={channel.id} start={start} end={end} />
       </div>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -136,3 +136,10 @@ export type Prettify<Type> = Type extends Function
       },
       Type
     >;
+
+export type channelListOptions =
+  | 'edit'
+  | 'duplicate'
+  | 'delete'
+  | 'programming'
+  | 'watch';


### PR DESCRIPTION
Goal of this PR is to create a unified UX pattern for accessing channel options (copy ids, edit, programming, watch) across channel pages.  

This PR resolves https://github.com/chrisbenincasa/tunarr/issues/746

Updates:
- Created ChannelOptionsButton component that accesses the now renamed ChannelOptionsMenu
  - Now that we have this component we can adjust/tweak/improve the UX for this and have it propagate across the channel pages
- Created prop `hideItems` on ChannelOptionsButton with the type channelListOptions to allow us to control which options we list on which pages
- Added the options drop down to Edit, Add Programming, Channel Summary
- Removed some existing buttons to try and create consistency across channel pages on where these could be accessed
- Updated the 'edit' icon on Channels pages for consistency, it was using the "Settings" icon which we use elsewhere to indicate settings/options instead of edit.

Screenshots:

Channel Programming:
<img width="1431" height="657" alt="image" src="https://github.com/user-attachments/assets/43927cf2-e16f-46c5-9607-db6aca3db1a3" />

Channel Summary Page:
<img width="1424" height="859" alt="image" src="https://github.com/user-attachments/assets/f2027966-181d-43db-8eea-a8d08d9153ec" />

Watch Page:
<img width="1421" height="771" alt="image" src="https://github.com/user-attachments/assets/4a55a5ed-da65-46ba-913c-1029d9058849" />

Channels:
<img width="1429" height="753" alt="image" src="https://github.com/user-attachments/assets/d0046285-a4d6-4d76-9534-4340df4fc191" />

