### PR TITLE
fix: force 8-bit H.264 output to prevent High 10 profile playback issues

### DIFF
--- a/server/src/ffmpeg/builder/encoder/Libx264Encoder.ts
+++ b/server/src/ffmpeg/builder/encoder/Libx264Encoder.ts
@@ -15,6 +15,10 @@ export class Libx264Encoder extends VideoEncoder {
 
   options(): string[] {
     const opts = [...super.options()];
+    // Force 8-bit output (yuv420p) to ensure compatibility with most players/devices.
+    // Without this, libx264 may output 10-bit H.264 (High 10 profile) which many
+    // hardware decoders cannot handle.
+    opts.push('-pix_fmt', 'yuv420p');
     if (isNonEmptyString(this.videoPreset)) {
       opts.push('-profile:v', this.videoPreset);
     }


### PR DESCRIPTION
## Problem

When transcoding 10-bit HEVC sources to H.264, libx264 preserves the 10-bit depth and outputs H.264 High 10 profile. This causes playback failures on most devices/players (including Plex) because hardware decoders rarely support 10-bit H.264.

## Solution

Add `-pix_fmt yuv420p` to the ffmpeg transcode command when using libx264, forcing 8-bit output regardless of source bit depth.

## Before
```
Stream: h264 (High 10), yuv420p10le
```

## After
```
Stream: h264 (High), yuv420p
```

## Testing
- Tested with 10-bit HEVC sources from Plex library
- Confirmed output is now 8-bit H.264 via ffprobe
- Plex Live TV now plays channels that previously failed