### PR TITLE
fix: add missing build dependency for meilisearch install

### DIFF
--- a/server/turbo.json
+++ b/server/turbo.json
@@ -1,41 +1,74 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
     "build": {},
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     },
     "bundle": {
-      "inputs": ["./scripts/bundle.ts", "./src/**"],
-      "dependsOn": ["^build", "@tunarr/web#bundle"],
-      "outputs": ["dist/**"]
+      "inputs": [
+        "./scripts/bundle.ts",
+        "./src/**"
+      ],
+      "dependsOn": [
+        "^build",
+        "@tunarr/web#bundle"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "build-dev": {
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     },
     "make-bin": {
       "cache": false,
-      "dependsOn": ["@tunarr/web#bundle", "bundle"],
-      "outputs": ["bin/**"]
+      "dependsOn": [
+        "@tunarr/web#bundle",
+        "bundle"
+      ],
+      "outputs": [
+        "bin/**"
+      ]
     },
     "lint-staged": {},
     "lint": {
-      "dependsOn": ["lint-staged"]
+      "dependsOn": [
+        "lint-staged"
+      ]
     },
     "install-meilisearch": {
-      "inputs": ["./scripts/download-meilisearch.ts"],
+      "inputs": [
+        "./scripts/download-meilisearch.ts"
+      ],
+      "dependsOn": [
+        "@tunarr/shared#build"
+      ],
       "cache": false
     },
     "dev": {
-      "dependsOn": ["install-meilisearch", "@tunarr/shared#build"],
+      "dependsOn": [
+        "install-meilisearch",
+        "@tunarr/shared#build"
+      ],
       "persistent": true,
       "cache": false,
       "interruptible": true
     },
     "generate-openapi": {
-      "inputs": ["./src/**"],
-      "dependsOn": ["^build"]
+      "inputs": [
+        "./src/**"
+      ],
+      "dependsOn": [
+        "^build"
+      ]
     }
   }
 }


### PR DESCRIPTION
When running dev build instructions from README.md, I encountered errors when running `pnpm turbo dev`.

The install-meilisearch script imports from @tunarr/shared, but the task was missing this dependency in the Turbo graph. This caused a race condition where the script would attempt to run before the shared package was built.

This change adds `@tunarr/shared#build` to the `dependsOn` array for `install-meilisearch` to ensure the correct build order.