### PR TITLE
fix: populate subtitle language metadata from ffprobe

### DIFF
--- a/server/src/services/scanner/FileSystemScanner.ts
+++ b/server/src/services/scanner/FileSystemScanner.ts
@@ -194,7 +194,8 @@ export abstract class FileSystemScanner {
           index: subtitleStream.index ?? 0,
           default: true,
           // forced: true,
-          languageCodeISO6392: subtitleStream.languageCodeISO6392,
+          languageCodeISO6392:
+            subtitleStream.languageCodeISO6392 ?? subtitleStream.language,
           // programVersionId: versionId,
           profile: null,
           pixelFormat: null,

--- a/server/src/stream/FfprobeStreamDetails.ts
+++ b/server/src/stream/FfprobeStreamDetails.ts
@@ -126,6 +126,8 @@ export class FfprobeStreamDetails
       ),
       (stream) => {
         const lang = stream.tags?.['language'];
+        const validLang =
+          lang && LanguageService.isValidLanguageCode(lang) ? lang : undefined;
         return {
           type: 'embedded',
           codec: stream.codec_name,
@@ -133,10 +135,10 @@ export class FfprobeStreamDetails
           default: stream.disposition?.default === 1,
           forced: stream.disposition?.forced === 1,
           sdh: stream.disposition?.hearing_impaired === 1,
-          language:
-            lang && LanguageService.isValidLanguageCode(lang)
-              ? lang
-              : undefined,
+          language: validLang,
+          languageCodeISO6392: validLang
+            ? LanguageService.getAlpha3TCode(validLang)
+            : undefined,
         } satisfies SubtitleStreamDetails;
       },
     );


### PR DESCRIPTION
- Add languageCodeISO6392 field to subtitle stream details in FfprobeStreamDetails
- Add fallback to language field in FileSystemScanner when ISO code is missing

Previously, subtitle streams were missing the languageCodeISO6392 field which prevented subtitle language preferences from working correctly.