### PR TITLE
feat: enable direct burning of embedded text subtitles

### DIFF
--- a/server/src/ffmpeg/SubtitleStreamPicker.ts
+++ b/server/src/ffmpeg/SubtitleStreamPicker.ts
@@ -114,18 +114,9 @@ export class SubtitleStreamPicker {
           continue;
         }
 
-        // TODO: check if embedded text based are extracted and continue searching
-        // for a fallback if they are not.
-        if (!isImageBasedSubtitle(stream.codec) && stream.type === 'embedded') {
-          const streamWithUpdatedPath =
-            await this.getSubtitleDetailsWithExtractedPath(lineupItem, stream);
-          if (streamWithUpdatedPath) {
-            return streamWithUpdatedPath;
-          }
-
-          continue;
-        }
-
+        // For embedded text-based subtitles, we can burn them directly from
+        // the source file using ffmpeg's subtitles filter with stream index.
+        // No pre-extraction is required.
         return stream;
       }
     }

--- a/server/src/ffmpeg/builder/filter/SubtitleFilter.ts
+++ b/server/src/ffmpeg/builder/filter/SubtitleFilter.ts
@@ -1,5 +1,6 @@
 import { head } from 'lodash-es';
 import { isWindows } from '../../../util/index.ts';
+import { EmbeddedSubtitleStream } from '../MediaStream.ts';
 import type { SubtitlesInputSource } from '../input/SubtitlesInputSource.ts';
 import type { FrameState } from '../state/FrameState.ts';
 import { FrameDataLocation } from '../types.ts';
@@ -30,6 +31,11 @@ export class SubtitleFilter extends FilterOption {
       .replaceAll('[', '\\[')
       .replaceAll(']', '\\]')
       .replaceAll(':', '\\:');
+
+    // For embedded subtitles, use the stream index selector
+    if (stream instanceof EmbeddedSubtitleStream) {
+      return `subtitles=${path}:si=${stream.index}`;
+    }
 
     return `subtitles=${path}`;
   }


### PR DESCRIPTION
- Remove pre-extraction requirement for text-based embedded subtitles
- Add stream index support to SubtitleFilter using subtitles=path:si=index syntax

This allows embedded text-based subtitles (like subrip) to be burned directly into the video stream without requiring pre-extraction to cache files.