### PR TITLE
Add endpoint to search by external id

### DIFF
--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -52,6 +52,8 @@ import Migration1763749592_AddProgramState from './db/Migration1763749592_AddPro
 import Migration1764022266_AddCreditGroupingIndex from './db/Migration1764022266_AddCreditGroupingIndex.ts';
 import Migration1764022464_AddArtworkIndexes from './db/Migration1764022464_AddArtworkIndexes.ts';
 import Migration1767300603_AddExternalCollections from './db/Migration1767300603_AddExternalCollections.ts';
+import Migration1768713600_AddExternalIdSearchIndexes from './db/Migration1768713600_AddExternalIdSearchIndexes.ts';
+
 import { makeKyselyMigrationFromSqlFile } from './db/util.ts';
 
 export const LegacyMigrationNameToNewMigrationName = [
@@ -183,6 +185,7 @@ export class DirectMigrationProvider implements MigrationProvider {
           migration1767374284: makeKyselyMigrationFromSqlFile(
             './sql/0036_smooth_vanisher.sql',
           ),
+          migration1768713600: Migration1768713600_AddExternalIdSearchIndexes,
         },
         wrapWithTransaction,
       ),

--- a/server/src/migration/db/Migration1768713600_AddExternalIdSearchIndexes.ts
+++ b/server/src/migration/db/Migration1768713600_AddExternalIdSearchIndexes.ts
@@ -1,0 +1,19 @@
+import type { Kysely } from 'kysely';
+import { applyDrizzleMigrationExpression } from './util.ts';
+import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+
+const expr = String.raw`
+CREATE INDEX IF NOT EXISTS "program_external_id_external_key_idx"
+ON "program_external_id" ("external_key");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "program_grouping_external_id_external_key_idx"
+ON "program_grouping_external_id" ("external_key");--> statement-breakpoint
+`;
+
+export default {
+  async up(db: Kysely<unknown>) {
+    await applyDrizzleMigrationExpression(db, expr);
+  },
+  fullCopy: true,
+} satisfies TunarrDatabaseMigration;
+


### PR DESCRIPTION
Adds a new API endpoint to search Tunarr content by a raw external id (the `external_key` stored on external-id rows), without requiring the `{source_type}|{source_id}|{external_key}` composite format.

### What’s included

* **New endpoint:** `GET /programming/external-id/search`

  * Required query: `externalId=<raw id>`
  * Optional filters: `sourceType`, `mediaSourceId`, `externalSourceId`
  * Paging: `limit`, `offset`
  * Toggles: `includePrograms`, `includeGroupings` (both default true)
  * Response returns matching `programs` and/or `groupings` plus totals.

* **DB migration:** adds indexes to keep the lookup fast:

  * `program_external_id(external_key)`
  * `program_grouping_external_id(external_key)`
  * Uses `CREATE INDEX IF NOT EXISTS` and the existing migration util for consistency.

Paging is likely not needed in normal use-cases, but added because its technically possible. 

Haven't tested yet, just at a stopping point.