### PR TITLE
feat: re-implementation of the original filler picker

### DIFF
--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -6,6 +6,7 @@ import cors from '@fastify/cors';
 import fastifyMultipart from '@fastify/multipart';
 import fpStatic from '@fastify/static';
 import fastifySwagger from '@fastify/swagger';
+import glob from 'fast-glob';
 import fastify, { FastifySchema } from 'fastify';
 import fastifyGracefulShutdown from 'fastify-graceful-shutdown';
 import fp from 'fastify-plugin';
@@ -36,10 +37,12 @@ import { HdhrApiRouter } from './api/hdhrApi.js';
 import { apiRouter } from './api/index.js';
 import { streamApi } from './api/streamApi.js';
 import { videoApiRouter } from './api/videoApi.js';
+import { defaultHlsOptions } from './ffmpeg/builder/constants.ts';
 import { type ServerOptions, serverOptions } from './globals.js';
 import { IWorkerPool } from './interfaces/IWorkerPool.ts';
 import { ServerContext, ServerRequestContext } from './ServerContext.js';
-import { TUNARR_ENV_VARS } from './util/env.ts';
+import { Result } from './types/result.ts';
+import { getBooleanEnvVar, TUNARR_ENV_VARS } from './util/env.ts';
 import { filename, isDev, run, timeoutPromise } from './util/index.js';
 import { type Logger } from './util/logging/LoggerFactory.js';
 
@@ -62,6 +65,7 @@ export class Server {
       trustProxy: this.serverOptions.trustProxy,
     })
       .setValidatorCompiler(validatorCompiler)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       .setSerializerCompiler(serializerCompiler)
       .withTypeProvider<ZodTypeProvider>();
 
@@ -334,7 +338,7 @@ export class Server {
               await req.serverCtx.cacheImageService.clearCache();
               return res.status(200).send({ msg: 'Cache Image are Cleared' });
             } catch (error) {
-              this.logger.error('Error deleting cached images', error);
+              this.logger.error(error, 'Error deleting cached images');
               return res.status(500).send('error');
             }
           },
@@ -459,10 +463,10 @@ export class Server {
         level: 'warning',
       });
     } catch (e) {
-      this.logger.debug(e, 'Error sending shutdown signal to frontend');
+      this.logger.warn(e, 'Error sending shutdown signal to frontend');
     }
 
-    this.logger.debug('Canceling all active scans');
+    this.logger.info('Canceling all active scans');
     this.serverContext.mediaSourceScanCoordinator.cancelAll();
 
     try {
@@ -477,13 +481,13 @@ export class Server {
     this.serverContext.searchService.stop();
 
     try {
-      this.logger.debug('Pausing all on-demand channels');
+      this.logger.info('Pausing all on-demand channels');
       await this.serverContext.onDemandChannelService.pauseAllChannels();
     } catch (e) {
       this.logger.error(e, 'Error pausing on-demand channels');
     }
 
-    this.logger.debug('Shutting down all sessions');
+    this.logger.info('Shutting down all sessions');
     for (const session of values(
       this.serverContext.sessionManager.allSessions(),
     )) {
@@ -499,17 +503,31 @@ export class Server {
       }
     }
 
-    this.logger.debug('Shutting down all workers');
-    try {
-      await container.get<IWorkerPool>(KEYS.WorkerPool).shutdown(5_000);
-    } catch (e) {
-      this.logger.error(e, 'Error shutting down workers');
+    // TODO: This is a bug because in theory
+    // sessions can override this. But for the most part,
+    // it works
+    const baseStreamsDir = path.join(
+      serverOptions().databaseDirectory,
+      defaultHlsOptions.segmentBaseDirectory,
+    );
+    const transcodeDirs = await glob(path.join(`${baseStreamsDir}/*`));
+    await Promise.all(
+      transcodeDirs.map((dir) => Result.attemptAsync(() => fs.rmdir(dir))),
+    );
+
+    if (getBooleanEnvVar(TUNARR_ENV_VARS.USE_WORKER_POOL_ENV_VAR, false)) {
+      this.logger.info('Shutting down all workers');
+      try {
+        await container.get<IWorkerPool>(KEYS.WorkerPool).shutdown(5_000);
+      } catch (e) {
+        this.logger.error(e, 'Error shutting down workers');
+      }
     }
 
     this.serverContext.eventService.close();
 
     try {
-      this.logger.debug('Waiting for pending jobs to complete!');
+      this.logger.info('Waiting for pending jobs to complete!');
       await Promise.race([
         schedule.gracefulShutdown(),
         new Promise<boolean>((resolve) => {

--- a/server/src/container.ts
+++ b/server/src/container.ts
@@ -60,6 +60,7 @@ import { FixerRunner } from './tasks/fixers/FixerRunner.ts';
 import { ChildProcessHelper } from './util/ChildProcessHelper.ts';
 import { Timer } from './util/Timer.ts';
 import { getBooleanEnvVar, USE_WORKER_POOL_ENV_VAR } from './util/env.ts';
+import type { LoggingDefinition } from './util/logging/loggingDef.ts';
 
 const container = new Container({ autoBindInjectable: true });
 
@@ -88,9 +89,13 @@ const RootModule = new ContainerModule((bind) => {
   bind<Logger>(KEYS.Logger).toDynamicValue((ctx) => {
     const impl =
       ctx.currentRequest.parentRequest?.bindings?.[0]?.implementationType;
+    const loggingDef = impl
+      ? (Reflect.get(impl, 'tunarr:log_def') as LoggingDefinition)
+      : null;
     return LoggerFactory.child({
       className: impl ? (Reflect.get(impl, 'name') as string) : 'Unknown',
       worker: isMainThread ? undefined : true,
+      category: loggingDef?.category,
     });
   });
 

--- a/server/src/db/schema/ProgramPlayHistory.ts
+++ b/server/src/db/schema/ProgramPlayHistory.ts
@@ -28,6 +28,7 @@ export const ProgramPlayHistory = sqliteTable(
     index('program_play_history_program_uuid_index').on(table.programUuid),
     index('program_play_history_channel_uuid_index').on(
       table.channelUuid,
+      table.programUuid,
       table.fillerListId,
     ),
     index('program_play_history_played_at_index').on(table.playedAt),

--- a/server/src/ffmpeg/builder/constants.ts
+++ b/server/src/ffmpeg/builder/constants.ts
@@ -149,3 +149,5 @@ export type OutputFormat =
   | MpegDashOutputFormat
   | Mp4OutputFormat
   | MpegTsOutputFormat;
+export const OneDayMillis = 7 * 24 * 60 * 60 * 1000;
+export const FiveMinutesMillis = 5 * 60 * 60 * 1000;

--- a/server/src/ffmpeg/builder/filter/nvidia/HardwareUploadCudaFilter.ts
+++ b/server/src/ffmpeg/builder/filter/nvidia/HardwareUploadCudaFilter.ts
@@ -23,7 +23,6 @@ export class HardwareUploadCudaFilter extends FilterOption {
       return '';
     } else {
       let fmtPart = '';
-      console.log(this.currentState);
       if (
         !this.currentState.pixelFormat ||
         this.currentState.pixelFormat.name === PixelFormats.Unknown

--- a/server/src/ffmpeg/builder/filter/nvidia/ScaleCudaFilter.ts
+++ b/server/src/ffmpeg/builder/filter/nvidia/ScaleCudaFilter.ts
@@ -111,7 +111,6 @@ export class ScaleCudaFilter extends FilterOption {
     const filters = [scale];
     if (this.currentState.frameDataLocation === FrameDataLocation.Software) {
       this.uploadFilter = new HardwareUploadCudaFilter(this.currentState);
-      console.log('apply upload filter');
       filters.unshift(this.uploadFilter.filter);
     }
 

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -189,6 +189,9 @@ export class DirectMigrationProvider implements MigrationProvider {
           migration1768876318: makeKyselyMigrationFromSqlFile(
             './sql/0038_boring_maginty.sql',
           ),
+          migration1769099084: makeKyselyMigrationFromSqlFile(
+            './sql/0039_famous_bloodscream.sql',
+          ),
         },
         wrapWithTransaction,
       ),

--- a/server/src/migration/db/sql/0039_famous_bloodscream.sql
+++ b/server/src/migration/db/sql/0039_famous_bloodscream.sql
@@ -1,0 +1,2 @@
+DROP INDEX `program_play_history_channel_uuid_index`;--> statement-breakpoint
+CREATE INDEX `program_play_history_channel_uuid_index` ON `program_play_history` (`channel_uuid`,`program_uuid`,`filler_list_id`);

--- a/server/src/migration/db/sql/meta/0039_snapshot.json
+++ b/server/src/migration/db/sql/meta/0039_snapshot.json
@@ -1,0 +1,3969 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2f93e2b8-1948-4048-a454-37317f4a54aa",
+  "prevId": "648527ff-84c3-477b-8891-677557950031",
+  "tables": {
+    "artwork": {
+      "name": "artwork",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_path": {
+          "name": "cache_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork_type": {
+          "name": "artwork_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blur_hash43": {
+          "name": "blur_hash43",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blur_hash64": {
+          "name": "blur_hash64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credit_id": {
+          "name": "credit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artwork_program_idx": {
+          "name": "artwork_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_grouping_idx": {
+          "name": "artwork_grouping_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_credit_idx": {
+          "name": "artwork_credit_idx",
+          "columns": [
+            "credit_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artwork_program_id_program_uuid_fk": {
+          "name": "artwork_program_id_program_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_grouping_id_program_grouping_uuid_fk": {
+          "name": "artwork_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_credit_id_credit_uuid_fk": {
+          "name": "artwork_credit_id_credit_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "credit",
+          "columnsFrom": [
+            "credit_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_image": {
+      "name": "cached_image",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel": {
+      "name": "channel",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_filler_overlay": {
+          "name": "disable_filler_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_repeat_cooldown": {
+          "name": "filler_repeat_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_title": {
+          "name": "group_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_flex_title": {
+          "name": "guide_flex_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_minimum_duration": {
+          "name": "guide_minimum_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offline": {
+          "name": "offline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "stream_mode": {
+          "name": "stream_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hls'"
+        },
+        "transcoding": {
+          "name": "transcoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_config_id": {
+          "name": "transcode_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitles_enabled": {
+          "name": "subtitles_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "channel_number_unique": {
+          "name": "channel_number_unique",
+          "columns": [
+            "number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_custom_show": {
+      "name": "channel_custom_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_custom_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_custom_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_custom_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_custom_show_program_uuid_program_uuid_fk": {
+          "name": "channel_custom_show_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_custom_show",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_custom_show_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_custom_show_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_filler_show": {
+      "name": "channel_filler_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_filler_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_filler_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_filler_show_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "channel_filler_show_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_filler_show_channel_uuid_filler_show_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "filler_show_uuid"
+          ],
+          "name": "channel_filler_show_channel_uuid_filler_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_programs": {
+      "name": "channel_programs",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_programs_channel_uuid_channel_uuid_fk": {
+          "name": "channel_programs_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_programs_program_uuid_program_uuid_fk": {
+          "name": "channel_programs_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_programs_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_programs_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credit": {
+      "name": "credit",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "credit_program_id_idx": {
+          "name": "credit_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "credit_grouping_id_idx": {
+          "name": "credit_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "credit_program_id_program_uuid_fk": {
+          "name": "credit_program_id_program_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_grouping_id_program_grouping_uuid_fk": {
+          "name": "credit_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show": {
+      "name": "custom_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_content": {
+      "name": "custom_show_content",
+      "columns": {
+        "content_uuid": {
+          "name": "content_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_show_uuid": {
+          "name": "custom_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_content_content_uuid_program_uuid_fk": {
+          "name": "custom_show_content_content_uuid_program_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "content_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_custom_show_uuid_custom_show_uuid_fk": {
+          "name": "custom_show_content_custom_show_uuid_custom_show_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_show_content_content_uuid_custom_show_uuid_pk": {
+          "columns": [
+            "content_uuid",
+            "custom_show_uuid"
+          ],
+          "name": "custom_show_content_content_uuid_custom_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collections": {
+      "name": "external_collections",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_media_source_id_external_key_idx": {
+          "name": "external_collection_media_source_id_external_key_idx",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collection_library_id_external_key_idx": {
+          "name": "external_collection_library_id_external_key_idx",
+          "columns": [
+            "library_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collections_mediaSourceId_externalKey_unique": {
+          "name": "external_collections_mediaSourceId_externalKey_unique",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "external_collections_media_source_id_media_source_uuid_fk": {
+          "name": "external_collections_media_source_id_media_source_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collections_library_id_media_source_library_uuid_fk": {
+          "name": "external_collections_library_id_media_source_library_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collection_programs": {
+      "name": "external_collection_programs",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_program_idx": {
+          "name": "external_collection_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "external_collection_programs_collection_id_external_collections_uuid_fk": {
+          "name": "external_collection_programs_collection_id_external_collections_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "external_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_program_id_program_uuid_fk": {
+          "name": "external_collection_programs_program_id_program_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_grouping_id_program_grouping_uuid_fk": {
+          "name": "external_collection_programs_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_collection_programs_collection_id_program_id_pk": {
+          "columns": [
+            "collection_id",
+            "program_id"
+          ],
+          "name": "external_collection_programs_collection_id_program_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show": {
+      "name": "filler_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show_content": {
+      "name": "filler_show_content",
+      "columns": {
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_content_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "filler_show_content_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filler_show_content_program_uuid_program_uuid_fk": {
+          "name": "filler_show_content_program_uuid_program_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filler_show_content_filler_show_uuid_program_uuid_pk": {
+          "columns": [
+            "filler_show_uuid",
+            "program_uuid"
+          ],
+          "name": "filler_show_content_filler_show_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre_entity": {
+      "name": "genre_entity",
+      "columns": {
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_entity_id_index": {
+          "name": "genre_entity_id_index",
+          "columns": [
+            "genre_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_program_id_index": {
+          "name": "genre_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_group_id_index": {
+          "name": "genre_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "genre_program_unique_idx": {
+          "name": "genre_program_unique_idx",
+          "columns": [
+            "genre_id",
+            "program_id"
+          ],
+          "isUnique": true
+        },
+        "genre_grouping_unique_idx": {
+          "name": "genre_grouping_unique_idx",
+          "columns": [
+            "genre_id",
+            "group_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "genre_entity_genre_id_genre_uuid_fk": {
+          "name": "genre_entity_genre_id_genre_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "genre",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_program_id_program_uuid_fk": {
+          "name": "genre_entity_program_id_program_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_group_id_program_grouping_uuid_fk": {
+          "name": "genre_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre": {
+      "name": "genre",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_name_idx": {
+          "name": "genre_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_folder": {
+      "name": "local_media_folder",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "local_media_folder_library_id_path_idx": {
+          "name": "local_media_folder_library_id_path_idx",
+          "columns": [
+            "library_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_path_idx": {
+          "name": "local_media_folder_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_canonical_id_id": {
+          "name": "local_media_folder_canonical_id_id",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "local_media_folder_library_id_media_source_library_uuid_fk": {
+          "name": "local_media_folder_library_id_media_source_library_uuid_fk",
+          "tableFrom": "local_media_folder",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_source_path": {
+      "name": "local_media_source_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_media_source_path_media_source_id_media_source_uuid_fk": {
+          "name": "local_media_source_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "local_media_source_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_source": {
+      "name": "media_source",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_identifier": {
+          "name": "client_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "send_channel_updates": {
+          "name": "send_channel_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_guide_updates": {
+          "name": "send_guide_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_source_type_check": {
+          "name": "media_source_type_check",
+          "value": "\"media_source\".\"type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "media_source_library": {
+      "name": "media_source_library",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_type_check": {
+          "name": "media_type_check",
+          "value": "\"media_source_library\".\"media_type\" in ('movies', 'shows', 'music_videos', 'other_videos', 'tracks')"
+        }
+      }
+    },
+    "media_source_library_replace_path": {
+      "name": "media_source_library_replace_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_path": {
+          "name": "server_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_replace_path_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_replace_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library_replace_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program": {
+      "name": "program",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_uuid": {
+          "name": "album_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode": {
+          "name": "episode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_icon": {
+          "name": "episode_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_source_path_id": {
+          "name": "local_media_source_path_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_external_key": {
+          "name": "grandparent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_air_date": {
+          "name": "original_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_external_key": {
+          "name": "parent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_file_path": {
+          "name": "plex_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_icon": {
+          "name": "season_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_uuid": {
+          "name": "season_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_title": {
+          "name": "show_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tv_show_uuid": {
+          "name": "tv_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {
+        "program_season_uuid_index": {
+          "name": "program_season_uuid_index",
+          "columns": [
+            "season_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_tv_show_uuid_index": {
+          "name": "program_tv_show_uuid_index",
+          "columns": [
+            "tv_show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_album_uuid_index": {
+          "name": "program_album_uuid_index",
+          "columns": [
+            "album_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_artist_uuid_index": {
+          "name": "program_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_media_source_id_index": {
+          "name": "program_media_source_id_index",
+          "columns": [
+            "media_source_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_library_id_index": {
+          "name": "program_media_library_id_index",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        },
+        "program_source_type_external_source_id_external_key_unique": {
+          "name": "program_source_type_external_source_id_external_key_unique",
+          "columns": [
+            "source_type",
+            "external_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_source_type_media_source_external_key_unique": {
+          "name": "program_source_type_media_source_external_key_unique",
+          "columns": [
+            "source_type",
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_canonical_id_index": {
+          "name": "program_canonical_id_index",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        },
+        "program_state_index": {
+          "name": "program_state_index",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_album_uuid_program_grouping_uuid_fk": {
+          "name": "program_album_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "album_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_media_source_id_media_source_uuid_fk": {
+          "name": "program_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_library_id_media_source_library_uuid_fk": {
+          "name": "program_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_local_media_source_path_id_local_media_source_path_uuid_fk": {
+          "name": "program_local_media_source_path_id_local_media_source_path_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_source_path",
+          "columnsFrom": [
+            "local_media_source_path_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_season_uuid_program_grouping_uuid_fk": {
+          "name": "program_season_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "season_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_tv_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_tv_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "tv_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "program_type_check": {
+          "name": "program_type_check",
+          "value": "\"program\".\"type\" in ('movie', 'episode', 'track', 'music_video', 'other_video')"
+        },
+        "program_source_type_check": {
+          "name": "program_source_type_check",
+          "value": "\"program\".\"source_type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "program_chapter": {
+      "name": "program_chapter",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chapter_type": {
+          "name": "chapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chapter'"
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_chapter_program_version_id_program_version_uuid_fk": {
+          "name": "program_chapter_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_chapter",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_external_id": {
+      "name": "program_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direct_file_path": {
+          "name": "direct_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_external_id_program_uuid_index": {
+          "name": "program_external_id_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_multiple_external_id": {
+          "name": "unique_program_multiple_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is not null"
+        },
+        "unique_program_single_external_id": {
+          "name": "unique_program_single_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is null"
+        },
+        "unique_program_multiple_external_id_media_source": {
+          "name": "unique_program_multiple_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is not null"
+        },
+        "unique_program_single_external_id_media_source": {
+          "name": "unique_program_single_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is null"
+        }
+      },
+      "foreignKeys": {
+        "program_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_external_id_program_uuid_program_uuid_fk": {
+          "name": "program_external_id_program_uuid_program_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type": {
+          "name": "source_type",
+          "value": "\"program_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_grouping": {
+      "name": "program_grouping",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_uuid": {
+          "name": "show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {
+        "program_grouping_show_uuid_index": {
+          "name": "program_grouping_show_uuid_index",
+          "columns": [
+            "show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_grouping_artist_uuid_index": {
+          "name": "program_grouping_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type_check": {
+          "name": "type_check",
+          "value": "\"program_grouping\".\"type\" in ('show', 'season', 'artist', 'album')"
+        }
+      }
+    },
+    "program_grouping_external_id": {
+      "name": "program_grouping_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_uuid": {
+          "name": "group_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_grouping_group_uuid_index": {
+          "name": "program_grouping_group_uuid_index",
+          "columns": [
+            "group_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_grouping_multiple_external_id_media_source": {
+          "name": "unique_program_grouping_multiple_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is not null`"
+        },
+        "unique_program_grouping_single_external_id_media_source": {
+          "name": "unique_program_grouping_single_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is null`"
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_external_id_group_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_external_id_group_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "program_grouping_external_id_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_external_id_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type_check": {
+          "name": "source_type_check",
+          "value": "\"program_grouping_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_media_file": {
+      "name": "program_media_file",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_media_file_program_version_idx": {
+          "name": "program_media_file_program_version_idx",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_file_folder_idx": {
+          "name": "program_media_file_folder_idx",
+          "columns": [
+            "local_media_folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_file_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_file_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_media_file_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_media_file_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_media_stream": {
+      "name": "program_media_stream",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_kind": {
+          "name": "stream_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pixel_format": {
+          "name": "pixel_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_range": {
+          "name": "color_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_transfer": {
+          "name": "color_transfer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_primaries": {
+          "name": "color_primaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bits_per_sample": {
+          "name": "bits_per_sample",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_id": {
+          "name": "index_program_version_id",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_stream_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_stream_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_stream",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_play_history": {
+      "name": "program_play_history",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_duration": {
+          "name": "played_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_list_id": {
+          "name": "filler_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_play_history_program_uuid_index": {
+          "name": "program_play_history_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_uuid_index": {
+          "name": "program_play_history_channel_uuid_index",
+          "columns": [
+            "channel_uuid",
+            "program_uuid",
+            "filler_list_id"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_played_at_index": {
+          "name": "program_play_history_played_at_index",
+          "columns": [
+            "played_at"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_played_at_index": {
+          "name": "program_play_history_channel_played_at_index",
+          "columns": [
+            "channel_uuid",
+            "played_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_play_history_program_uuid_program_uuid_fk": {
+          "name": "program_play_history_program_uuid_program_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_channel_uuid_channel_uuid_fk": {
+          "name": "program_play_history_channel_uuid_channel_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_filler_list_id_filler_show_uuid_fk": {
+          "name": "program_play_history_filler_list_id_filler_show_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_list_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_subtitles": {
+      "name": "program_subtitles",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle_type": {
+          "name": "subtitle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_index": {
+          "name": "stream_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sdh": {
+          "name": "sdh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_extracted": {
+          "name": "is_extracted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_subtitles_program_id_program_uuid_fk": {
+          "name": "program_subtitles_program_id_program_uuid_fk",
+          "tableFrom": "program_subtitles",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_version": {
+      "name": "program_version",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_aspect_ratio": {
+          "name": "sample_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_aspect_ratio": {
+          "name": "display_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_kind": {
+          "name": "scan_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_program_id": {
+          "name": "index_program_version_program_id",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_version_program_id_program_uuid_fk": {
+          "name": "program_version_program_id_program_uuid_fk",
+          "tableFrom": "program_version",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "smart_collection": {
+      "name": "smart_collection",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio": {
+      "name": "studio",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio_entity": {
+      "name": "studio_entity",
+      "columns": {
+        "studio_id": {
+          "name": "studio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "studio_entity_id_index": {
+          "name": "studio_entity_id_index",
+          "columns": [
+            "studio_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_program_id_index": {
+          "name": "studio_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_group_id_index": {
+          "name": "studio_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "studio_entity_studio_id_studio_uuid_fk": {
+          "name": "studio_entity_studio_id_studio_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "studio",
+          "columnsFrom": [
+            "studio_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_program_id_program_uuid_fk": {
+          "name": "studio_entity_program_id_program_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_group_id_program_grouping_uuid_fk": {
+          "name": "studio_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_subtitle_preferences": {
+      "name": "channel_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_priority_index": {
+          "name": "channel_priority_index",
+          "columns": [
+            "channel_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_subtitle_preferences_channel_id_channel_uuid_fk": {
+          "name": "channel_subtitle_preferences_channel_id_channel_uuid_fk",
+          "tableFrom": "channel_subtitle_preferences",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_subtitle_preferences": {
+      "name": "custom_show_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "custom_show_id": {
+          "name": "custom_show_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_show_priority_index": {
+          "name": "custom_show_priority_index",
+          "columns": [
+            "custom_show_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk": {
+          "name": "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk",
+          "tableFrom": "custom_show_subtitle_preferences",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_unique_tag_idx": {
+          "name": "tags_unique_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_relations": {
+      "name": "tag_relations",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_relations_program_id_idx": {
+          "name": "tag_relations_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "tag_relations_grouping_id_idx": {
+          "name": "tag_relations_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "tag_program_id_unique_idx": {
+          "name": "tag_program_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "program_id"
+          ],
+          "isUnique": true
+        },
+        "tag_grouping_id_unique_idx": {
+          "name": "tag_grouping_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "grouping_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tag_relations_tag_id_tags_uuid_fk": {
+          "name": "tag_relations_tag_id_tags_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_program_id_program_uuid_fk": {
+          "name": "tag_relations_program_id_program_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_grouping_id_program_grouping_uuid_fk": {
+          "name": "tag_relations_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcode_config": {
+      "name": "transcode_config",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_count": {
+          "name": "thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hardware_acceleration_mode": {
+          "name": "hardware_acceleration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vaapi_driver": {
+          "name": "vaapi_driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "vaapi_device": {
+          "name": "vaapi_device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_format": {
+          "name": "video_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_profile": {
+          "name": "video_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_preset": {
+          "name": "video_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_bit_depth": {
+          "name": "video_bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 8
+        },
+        "video_bit_rate": {
+          "name": "video_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_buffer_size": {
+          "name": "video_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_bit_rate": {
+          "name": "audio_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_buffer_size": {
+          "name": "audio_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_sample_rate": {
+          "name": "audio_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_volume_percent": {
+          "name": "audio_volume_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "normalize_frame_rate": {
+          "name": "normalize_frame_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deinterlace_video": {
+          "name": "deinterlace_video",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "disable_channel_overlay": {
+          "name": "disable_channel_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_screen": {
+          "name": "error_screen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pic'"
+        },
+        "error_screen_audio": {
+          "name": "error_screen_audio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'silent'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_decoder": {
+          "name": "disable_hardware_decoder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_encoding": {
+          "name": "disable_hardware_encoding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_filters": {
+          "name": "disable_hardware_filters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcode_config_hardware_accel_check": {
+          "name": "transcode_config_hardware_accel_check",
+          "value": "\"transcode_config\".\"hardware_acceleration_mode\" in ('none', 'cuda', 'vaapi', 'qsv', 'videotoolbox')"
+        },
+        "transcode_config_vaapi_driver_check": {
+          "name": "transcode_config_vaapi_driver_check",
+          "value": "\"transcode_config\".\"vaapi_driver\" in ('system', 'ihd', 'i965', 'radeonsi', 'nouveau')"
+        },
+        "transcode_config_video_format_check": {
+          "name": "transcode_config_video_format_check",
+          "value": "\"transcode_config\".\"video_format\" in ('h264', 'hevc', 'mpeg2video')"
+        },
+        "transcode_config_audio_format_check": {
+          "name": "transcode_config_audio_format_check",
+          "value": "\"transcode_config\".\"audio_format\" in ('aac', 'ac3', 'copy', 'mp3')"
+        },
+        "transcode_config_error_screen_check": {
+          "name": "transcode_config_error_screen_check",
+          "value": "\"transcode_config\".\"error_screen\" in ('static', 'pic', 'blank', 'testsrc', 'text', 'kill')"
+        },
+        "transcode_config_error_screen_audio_check": {
+          "name": "transcode_config_error_screen_audio_check",
+          "value": "\"transcode_config\".\"error_screen_audio\" in ('silent', 'sine', 'whitenoise')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/migration/db/sql/meta/_journal.json
+++ b/server/src/migration/db/sql/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1768876233969,
       "tag": "0038_boring_maginty",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1769031772309,
+      "tag": "0039_famous_bloodscream",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/services/FillerPicker.ts
+++ b/server/src/services/FillerPicker.ts
@@ -4,17 +4,23 @@ import type { Maybe } from '@/types/util.js';
 import { random } from '@/util/random.js';
 import constants from '@tunarr/shared/constants';
 import { inject, injectable } from 'inversify';
-import { isEmpty, isNil } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import type {
   ChannelFillerShowWithContent,
   ProgramWithRelations,
 } from '../db/schema/derivedTypes.js';
-import type { IFillerPicker } from './interfaces/IFillerPicker.ts';
-import { EmptyFillerPickResult } from './interfaces/IFillerPicker.ts';
-
-const DefaultFillerCooldownMillis = 30 * 60 * 1000;
-const OneDayMillis = 7 * 24 * 60 * 60 * 1000;
-const FiveMinutesMillis = 5 * 60 * 60 * 1000;
+import {
+  FiveMinutesMillis,
+  OneDayMillis,
+} from '../ffmpeg/builder/constants.ts';
+import type {
+  FillerPickResult,
+  IFillerPicker,
+} from './interfaces/IFillerPicker.ts';
+import {
+  DefaultFillerCooldownMillis,
+  EmptyFillerPickResult,
+} from './interfaces/IFillerPicker.ts';
 
 @injectable()
 export class FillerPicker implements IFillerPicker {
@@ -28,9 +34,9 @@ export class FillerPicker implements IFillerPicker {
     channel: Channel,
     fillers: ChannelFillerShowWithContent[],
     maxDuration: number,
-  ) {
+  ): Promise<FillerPickResult> {
     if (isEmpty(fillers)) {
-      return EmptyFillerPickResult;
+      return Promise.resolve(EmptyFillerPickResult);
     }
 
     let pick1: Maybe<ProgramWithRelations>;
@@ -104,11 +110,11 @@ export class FillerPicker implements IFillerPicker {
       }
     }
 
-    return {
-      fillerListId: fillerListId!,
-      filler: isNil(pick1) ? null : pick1,
+    return Promise.resolve({
+      fillerListId: fillerListId ?? null,
+      filler: pick1 ?? null,
       minimumWait,
-    };
+    });
   }
 }
 

--- a/server/src/services/MeilisearchService.ts
+++ b/server/src/services/MeilisearchService.ts
@@ -409,7 +409,6 @@ export class MeilisearchService implements ISearchService {
       if (this.started) {
         return;
       }
-
       const indexFolderExists = await fileExists(this.dbPath);
 
       // Check for update.

--- a/server/src/services/interfaces/IFillerPicker.ts
+++ b/server/src/services/interfaces/IFillerPicker.ts
@@ -22,5 +22,7 @@ export interface IFillerPicker {
     channel: Channel,
     fillers: ChannelFillerShowWithContent[],
     maxDuration: number,
-  ): FillerPickResult;
+    now?: number,
+  ): Promise<FillerPickResult>;
 }
+export const DefaultFillerCooldownMillis = 30 * 60 * 1000;

--- a/server/src/services/scheduling/FillerPickerV2.test.ts
+++ b/server/src/services/scheduling/FillerPickerV2.test.ts
@@ -1,0 +1,941 @@
+import { faker } from '@faker-js/faker';
+import dayjs from 'dayjs';
+import { v4 } from 'uuid';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProgramPlayHistoryDB } from '../../db/ProgramPlayHistoryDB.ts';
+import type { Channel } from '../../db/schema/Channel.ts';
+import type {
+  ChannelFillerShowWithContent,
+  ProgramWithRelations,
+} from '../../db/schema/derivedTypes.ts';
+import { type ProgramPlayHistoryOrm } from '../../db/schema/ProgramPlayHistory.ts';
+import { OneDayMillis } from '../../ffmpeg/builder/constants.ts';
+import {
+  DefaultFillerCooldownMillis,
+  EmptyFillerPickResult,
+} from '../interfaces/IFillerPicker.ts';
+import { FillerPickerV2 } from './FillerPickerV2.ts';
+
+// Mock the random module for deterministic tests
+vi.mock('../../util/random.ts', () => ({
+  random: {
+    bool: vi.fn(),
+    shuffle: vi.fn(<T>(arr: T[]) => arr),
+  },
+}));
+
+import { random } from '../../util/random.ts';
+
+describe('FillerPickerV2', () => {
+  let mockPlayHistoryDB: ProgramPlayHistoryDB;
+  let mockLogger: {
+    isLevelEnabled: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+    trace: ReturnType<typeof vi.fn>;
+  };
+  let picker: FillerPickerV2;
+  let mockChannel: Channel;
+
+  function createProgram(
+    overrides: Partial<ProgramWithRelations> = {},
+  ): ProgramWithRelations {
+    return {
+      uuid: v4(),
+      duration: 30000,
+      type: 'movie',
+      title: faker.lorem.words(3),
+      externalKey: faker.string.alphanumeric(10),
+      externalSourceId: 'plex',
+      sourceType: 'plex',
+      ...overrides,
+    } as ProgramWithRelations;
+  }
+
+  function createFiller(
+    overrides: Partial<ChannelFillerShowWithContent> = {},
+  ): ChannelFillerShowWithContent {
+    const fillerShowUuid = overrides.fillerShowUuid ?? v4();
+    return {
+      fillerShowUuid,
+      channelUuid: mockChannel.uuid,
+      weight: 100,
+      cooldown: 0,
+      fillerShow: {
+        uuid: fillerShowUuid,
+        name: faker.lorem.words(2),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      fillerContent: [createProgram()],
+      ...overrides,
+    } as ChannelFillerShowWithContent;
+  }
+
+  function createPlayHistory(
+    programUuid: string,
+    playedAt: Date,
+    fillerListId: string,
+  ): ProgramPlayHistoryOrm {
+    return {
+      uuid: v4(),
+      programUuid,
+      playedAt,
+      channelUuid: mockChannel.uuid,
+      playedDuration: 30000,
+      createdAt: new Date(),
+      fillerListId,
+    };
+  }
+
+  beforeEach(() => {
+    mockPlayHistoryDB = {
+      getFillerHistory: vi.fn().mockResolvedValue([]),
+    } as unknown as ProgramPlayHistoryDB;
+
+    mockLogger = {
+      isLevelEnabled: vi.fn().mockReturnValue(false),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    };
+
+    picker = new FillerPickerV2(mockPlayHistoryDB, mockLogger as never);
+
+    mockChannel = {
+      uuid: v4(),
+      fillerRepeatCooldown: DefaultFillerCooldownMillis, // 30 minutes
+      name: 'Test Channel',
+      number: 1,
+      duration: 0,
+      guideMinimumDuration: 30000,
+      icon: {},
+      offline: { mode: 'pic' },
+      startTime: Date.now(),
+      streamMode: 'hls',
+      transcodeConfigId: v4(),
+    } as Channel;
+
+    vi.clearAllMocks();
+  });
+
+  describe('edge cases', () => {
+    it('returns EmptyFillerPickResult when fillers array is empty', async () => {
+      const result = await picker.pickFiller(mockChannel, [], 60000);
+      expect(result).toEqual(EmptyFillerPickResult);
+    });
+
+    it('returns EmptyFillerPickResult when fillers is undefined-ish empty', async () => {
+      const result = await picker.pickFiller(mockChannel, [], 60000);
+      expect(result.filler).toBeNull();
+      expect(result.fillerListId).toBeNull();
+      expect(result.minimumWait).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('queries play history once for the channel (batched)', async () => {
+      const fillers = [createFiller(), createFiller()];
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      await picker.pickFiller(mockChannel, fillers, 60000);
+
+      // Now uses a single batched query instead of N+1 queries
+      expect(mockPlayHistoryDB.getFillerHistory).toHaveBeenCalledTimes(1);
+      expect(mockPlayHistoryDB.getFillerHistory).toHaveBeenCalledWith(
+        mockChannel.uuid,
+      );
+    });
+
+    it('uses default fillerRepeatCooldown when channel has none set', async () => {
+      const channelWithoutCooldown = {
+        ...mockChannel,
+        fillerRepeatCooldown: null,
+      } as Channel;
+
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller();
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Program played 20 minutes ago (within 30-minute default cooldown)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 20 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        channelWithoutCooldown,
+        [filler],
+        60000,
+        now,
+      );
+
+      // Program should be skipped due to default cooldown
+      expect(result.filler).toBeNull();
+    });
+  });
+
+  // ==========================================
+  // FILLER LIST SELECTION TESTS
+  // ==========================================
+
+  describe('filler list selection', () => {
+    it('selects filler when random.bool returns true and no cooldown', async () => {
+      const filler = createFiller({ weight: 50 });
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result.fillerListId).toBe(filler.fillerShowUuid);
+      expect(result.filler).toBeDefined();
+    });
+
+    it('does not select filler when random.bool returns false', async () => {
+      const filler = createFiller({ weight: 50 });
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result.filler).toBeNull();
+      expect(result.fillerListId).toBeNull();
+    });
+
+    it('skips filler list when still in cooldown period', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller({ cooldown: 60000 }); // 1 minute cooldown
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Played 30 seconds ago (still in cooldown)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 30000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000, now);
+
+      // Should not pick this filler due to cooldown
+      expect(result.filler).toBeNull();
+    });
+
+    it('selects filler when cooldown has expired', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller({ cooldown: 60000 }); // 1 minute list cooldown
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Played 45 minutes ago - exceeds both list cooldown (1 min) AND
+      // program repeat cooldown (30 min default)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 45 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000, now);
+
+      expect(result.fillerListId).toBe(filler.fillerShowUuid);
+      expect(result.filler).not.toBeNull();
+    });
+
+    it('treats never-played filler as having OneDayMillis time since played', async () => {
+      const filler = createFiller({ cooldown: OneDayMillis + 1 }); // Cooldown longer than default "never played" time
+
+      // No play history
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      // Should not pick because cooldown > OneDayMillis (default for never played)
+      expect(result.filler).toBeNull();
+    });
+
+    it('accumulates weight across all fillers regardless of cooldown', async () => {
+      const now = Date.now();
+
+      // First filler in cooldown
+      const filler1 = createFiller({ weight: 50, cooldown: 60000 });
+      // Second filler not in cooldown
+      const filler2 = createFiller({ weight: 50, cooldown: 0 });
+
+      // Return history that puts filler1 in cooldown
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(v4(), new Date(now - 30000), filler1.fillerShowUuid), // In cooldown
+      ]);
+
+      // Track the weight values passed to random.bool
+      const boolCalls: Array<{ weight: number; totalWeight: number }> = [];
+
+      let programCalls = 0,
+        fillerCalls = 0;
+      vi.spyOn(picker, 'weightedPick').mockImplementation(
+        (reason, num, den) => {
+          if (reason === 'filler') {
+            fillerCalls++;
+            boolCalls.push({
+              weight: num,
+              totalWeight: den,
+            });
+            return true;
+          } else if (reason === 'program') {
+            programCalls++;
+            return programCalls > 1;
+          }
+          return false;
+        },
+      );
+
+      await picker.pickFiller(mockChannel, [filler1, filler2], 60000, now);
+
+      // The second filler should see accumulated weight from first filler
+      // filler1 adds 50 to listWeight, then filler2 adds 50 more = 100 total
+      const listSelectionCall = boolCalls.find((c) => c.totalWeight === 100);
+      expect(listSelectionCall).toBeDefined();
+    });
+
+    it('breaks out of loop after selecting a filler list', async () => {
+      const filler1 = createFiller({ weight: 100 });
+      const filler2 = createFiller({ weight: 100 });
+
+      let boolCallCount = 0;
+      vi.mocked(random.bool).mockImplementation(() => {
+        boolCallCount++;
+        return true; // Always select
+      });
+
+      await picker.pickFiller(mockChannel, [filler1, filler2], 60000);
+
+      // Should break after first filler is selected
+      // One call for list selection, one for program selection
+      expect(boolCallCount).toBeLessThanOrEqual(2);
+    });
+  });
+
+  // ==========================================
+  // PROGRAM SELECTION TESTS
+  // ==========================================
+
+  describe('program selection within filler', () => {
+    it('skips programs that were played within repeat cooldown', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller();
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Program played 10 minutes ago (within 30-minute default cooldown)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 10 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000, now);
+
+      // Program should be skipped, so no filler returned even though list was selected
+      expect(result.filler).toBeNull();
+    });
+
+    it('selects program when repeat cooldown has expired', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller();
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Program played 45 minutes ago (outside 30-minute cooldown)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 45 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000, now);
+
+      expect(result.filler).not.toBeNull();
+      expect(result.filler?.uuid).toBe(programUuid);
+    });
+
+    it('can select from multiple programs in a filler', async () => {
+      const program1 = createProgram();
+      const program2 = createProgram();
+      const filler = createFiller();
+      filler.fillerContent = [program1, program2];
+
+      // With current implementation, list selection and program selection happen together.
+      // First random.bool selects the list and the first program in one pass.
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      // Should pick the first program when random.bool returns true
+      expect(result.filler).not.toBeNull();
+      expect(result.filler?.uuid).toBe(program1.uuid);
+    });
+
+    it('normalizes time since played to max of FiveMinutesMillis', async () => {
+      const now = Date.now();
+      const program1 = createProgram();
+      const program2 = createProgram();
+      const filler = createFiller();
+      filler.fillerContent = [program1, program2];
+
+      // program1 played 10 minutes ago, program2 played 1 hour ago
+      // Both should get same normalization (capped at 5 min) for timeSince
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          program1.uuid,
+          new Date(now - 10 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+        createPlayHistory(
+          program2.uuid,
+          new Date(now - 60 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      const weightCalls: number[] = [];
+      vi.mocked(random.bool).mockImplementation((weight) => {
+        weightCalls.push(weight as number);
+        return true;
+      });
+
+      await picker.pickFiller(mockChannel, [filler], 60000, now);
+
+      // Weights for programs should be similar since timeSince is capped
+      // (difference would only be from duration normalization if durations differ)
+    });
+  });
+
+  // ==========================================
+  // MAX DURATION FILTERING TESTS
+  // ==========================================
+
+  describe('maxDuration filtering', () => {
+    it('skips programs that exceed maxDuration', async () => {
+      const filler = createFiller();
+      filler.fillerContent = [
+        createProgram({ duration: 120000 }), // 2 minutes - too long
+      ];
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000, // 1 minute max
+      );
+
+      // Program exceeds maxDuration, so nothing should be picked
+      expect(result.filler).toBeNull();
+    });
+
+    it('selects programs that fit within maxDuration', async () => {
+      const shortProgram = createProgram({ duration: 30000 }); // 30 sec
+      const filler = createFiller();
+      filler.fillerContent = [shortProgram];
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000, // 1 minute max
+      );
+
+      expect(result.filler).not.toBeNull();
+      expect(result.filler?.uuid).toBe(shortProgram.uuid);
+    });
+
+    it('filters out long programs but keeps short ones', async () => {
+      const shortProgram = createProgram({ duration: 30000 }); // 30 sec
+      const longProgram = createProgram({ duration: 120000 }); // 2 min
+      const filler = createFiller();
+      filler.fillerContent = [longProgram, shortProgram];
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000, // 1 minute max
+      );
+
+      // Should pick the short program, not the long one
+      expect(result.filler).not.toBeNull();
+      expect(result.filler?.uuid).toBe(shortProgram.uuid);
+    });
+
+    it('returns null when all programs exceed maxDuration', async () => {
+      const filler = createFiller();
+      filler.fillerContent = [
+        createProgram({ duration: 120000 }), // 2 min
+        createProgram({ duration: 180000 }), // 3 min
+      ];
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000, // 1 minute max
+      );
+
+      expect(result.filler).toBeNull();
+    });
+  });
+
+  // ==========================================
+  // MINIMUM WAIT CALCULATION TESTS
+  // ==========================================
+
+  describe('minimumWait calculation', () => {
+    it('calculates minimumWait when filler is in cooldown but has fitting programs', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller({ cooldown: 60000 }); // 1 minute cooldown
+      filler.fillerContent = [
+        createProgram({ uuid: programUuid, duration: 10000 }), // Short program
+      ];
+
+      // Played 30 seconds ago, so 30 more seconds until cooldown expires
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 30000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000, // maxDuration allows program + wait time
+        now,
+      );
+
+      // minimumWait should be calculated (capped at 0 minimum per the code)
+      expect(result.minimumWait).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns MAX_SAFE_INTEGER minimumWait when no candidates available', async () => {
+      const filler = createFiller({ cooldown: 0 });
+      filler.fillerContent = []; // No programs
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result.minimumWait).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('returns minimumWait of 0 when filler is successfully picked', async () => {
+      const filler = createFiller();
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result.minimumWait).toBe(0);
+    });
+
+    it('calculates correct minimumWait based on program cooldown remaining', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller();
+      const programDuration = 10000; // 10 sec
+      filler.fillerContent = [
+        createProgram({ uuid: programUuid, duration: programDuration }),
+      ];
+
+      // Program played 20 minutes ago, cooldown is 30 min default
+      // So 10 minutes remaining until program can play
+      const twentyMinutesAgo = now - 20 * 60 * 1000;
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(twentyMinutesAgo),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000 * 15, // 15 min max (enough for wait + program)
+        now,
+      );
+
+      // minimumWait should be ~10 minutes (600000ms)
+      const expectedWait = DefaultFillerCooldownMillis - 20 * 60 * 1000; // 10 min
+      expect(result.minimumWait).toBe(expectedWait);
+    });
+
+    it('takes minimum of multiple program wait times', async () => {
+      const now = Date.now();
+      const program1 = createProgram({ duration: 10000 });
+      const program2 = createProgram({ duration: 10000 });
+      const filler = createFiller();
+      filler.fillerContent = [program1, program2];
+
+      // program1 played 25 min ago (5 min until available)
+      // program2 played 20 min ago (10 min until available)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          program1.uuid,
+          new Date(now - 25 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+        createPlayHistory(
+          program2.uuid,
+          new Date(now - 20 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000 * 15, // 15 min max
+        now,
+      );
+
+      // Should return the minimum wait (5 minutes for program1)
+      const expectedWait = DefaultFillerCooldownMillis - 25 * 60 * 1000; // 5 min
+      expect(result.minimumWait).toBe(expectedWait);
+    });
+  });
+
+  // ==========================================
+  // PROPERTY-BASED / INVARIANT TESTS
+  // ==========================================
+
+  describe('invariants', () => {
+    it('minimumWait is never negative', async () => {
+      const now = Date.now();
+      const programUuid = v4();
+      const filler = createFiller({ cooldown: 0 }); // No list cooldown
+      filler.fillerContent = [
+        createProgram({ uuid: programUuid, duration: 10000 }),
+      ];
+
+      // Program played 25 minutes ago - within program cooldown (30min default)
+      // Time until program can play: 30min - 25min = 5min = 300000ms
+      // Condition: program.duration + timeUntilProgramCanPlay <= maxDuration
+      // 10000 + 300000 = 310000 <= 600000 (10 min max) = true
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          programUuid,
+          new Date(now - 25 * 60 * 1000),
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(false);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        600000, // 10 minutes max
+        now,
+      );
+
+      // minimumWait should be non-negative
+      expect(result.minimumWait).toBeGreaterThanOrEqual(0);
+    });
+
+    it('minimumWait is not negative when filler list is in cooldown but program never played', async () => {
+      // Regression test: previously, the code used timeSincePlayed (for the program)
+      // instead of timeSincePlayedFiller (for the list) when calculating timeUntilListIsCandidate.
+      // This caused a large negative minimumWait when the program never played
+      // (timeSincePlayed defaults to OneDayMillis) but the filler list was in cooldown.
+      const now = Date.now();
+      const programUuid = v4();
+      const listCooldown = 60000; // 1 minute list cooldown
+      const filler = createFiller({ cooldown: listCooldown });
+      filler.fillerContent = [
+        createProgram({ uuid: programUuid, duration: 10000 }),
+      ];
+
+      // Filler list was played 30 seconds ago (still in cooldown),
+      // but using a DIFFERENT program (so our program has never been played)
+      const differentProgramUuid = v4();
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(
+          differentProgramUuid,
+          new Date(now - 30000), // 30 seconds ago
+          filler.fillerShowUuid,
+        ),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        600000, // 10 minutes max
+        now,
+      );
+
+      // minimumWait should be ~30 seconds (time until list cooldown expires)
+      // NOT a large negative value like (60000 - OneDayMillis)
+      expect(result.minimumWait).toBeGreaterThanOrEqual(0);
+      expect(result.minimumWait).toBeLessThanOrEqual(listCooldown);
+    });
+
+    it('always returns a valid FillerPickResult structure', async () => {
+      const filler = createFiller();
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result).toHaveProperty('filler');
+      expect(result).toHaveProperty('fillerListId');
+      expect(result).toHaveProperty('minimumWait');
+      expect(typeof result.minimumWait).toBe('number');
+    });
+
+    it('fillerListId is set whenever filler is set', async () => {
+      const filler = createFiller();
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      if (result.filler !== null) {
+        expect(result.fillerListId).not.toBeNull();
+      }
+    });
+
+    it('handles concurrent calls without interference', async () => {
+      const filler1 = createFiller();
+      const filler2 = createFiller();
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const [result1, result2] = await Promise.all([
+        picker.pickFiller(mockChannel, [filler1], 60000),
+        picker.pickFiller(mockChannel, [filler2], 60000),
+      ]);
+
+      // Each should pick from their own filler
+      expect(result1.fillerListId).toBe(filler1.fillerShowUuid);
+      expect(result2.fillerListId).toBe(filler2.fillerShowUuid);
+    });
+  });
+
+  // ==========================================
+  // STATISTICAL DISTRIBUTION TESTS
+  // ==========================================
+
+  describe('weight distribution (statistical)', () => {
+    it('respects weight ratio in list selection over many iterations', async () => {
+      // Temporarily use a predictable mock that simulates weighted selection
+      const fillerA = createFiller({ weight: 75 });
+      fillerA.fillerShowUuid = 'filler-a';
+      const fillerB = createFiller({ weight: 25 });
+      fillerB.fillerShowUuid = 'filler-b';
+
+      const counts = { 'filler-a': 0, 'filler-b': 0, null: 0 };
+      const iterations = 1000;
+
+      // Simulate weighted random: random.bool(weight, totalWeight) returns true
+      // with probability weight/totalWeight
+      vi.mocked(random.bool).mockImplementation((weight, totalWeight) => {
+        return Math.random() < (weight as number) / (totalWeight as number);
+      });
+
+      for (let i = 0; i < iterations; i++) {
+        const result = await picker.pickFiller(
+          mockChannel,
+          [fillerA, fillerB],
+          60000,
+        );
+        if (result.fillerListId === 'filler-a') {
+          counts['filler-a']++;
+        } else if (result.fillerListId === 'filler-b') {
+          counts['filler-b']++;
+        } else {
+          counts.null++;
+        }
+      }
+
+      // With the algorithm: first filler (75 weight) has 75/75 = 100% chance if selected
+      // If not selected, second filler (25 weight) has 25/100 = 25% chance
+      // So fillerA should be selected most of the time
+      const ratioA = counts['filler-a'] / iterations;
+
+      // Allow for statistical variance - fillerA should dominate
+      expect(ratioA).toBeGreaterThan(0.5);
+    });
+
+    it('multiple programs can be selected over many iterations', async () => {
+      const programs = Array.from({ length: 3 }, () => createProgram());
+      const filler = createFiller();
+      filler.fillerContent = programs;
+
+      const selectedPrograms = new Set<string>();
+      const iterations = 100;
+
+      // Simulate weighted random selection
+      vi.mocked(random.bool).mockImplementation((weight, totalWeight) => {
+        return Math.random() < (weight as number) / (totalWeight as number);
+      });
+
+      for (let i = 0; i < iterations; i++) {
+        const result = await picker.pickFiller(mockChannel, [filler], 60000);
+        if (result.filler) {
+          selectedPrograms.add(result.filler.uuid);
+        }
+      }
+
+      // At least some programs should have been selected
+      // (With reservoir sampling, earlier items have higher selection probability,
+      // but all should have some chance over many iterations)
+      expect(selectedPrograms.size).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ==========================================
+  // NORMALIZATION FUNCTION TESTS
+  // ==========================================
+
+  describe('normalization behavior', () => {
+    it('weights programs by both duration and time since played', async () => {
+      const shortProgram = createProgram({ duration: 30000 }); // 30 sec
+      const longProgram = createProgram({ duration: 300000 }); // 5 min
+
+      const filler = createFiller();
+      filler.fillerContent = [shortProgram, longProgram];
+
+      const weightCalls: Array<{ weight: number; total: number }> = [];
+
+      // In current implementation, list selection and program selection happen
+      // in the same random.bool call sequence. First call picks list and first program.
+      vi.mocked(random.bool).mockImplementation((weight, totalWeight) => {
+        weightCalls.push({
+          weight: weight as number,
+          total: totalWeight as number,
+        });
+        return false; // Reject all to see multiple calls
+      });
+
+      await picker.pickFiller(mockChannel, [filler], 600000);
+
+      // At least one weight call should happen for list/program selection
+      expect(weightCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ==========================================
+  // TIME PARAMETER TESTS
+  // ==========================================
+
+  describe('time parameter handling', () => {
+    it('uses provided now parameter for time calculations', async () => {
+      const fixedNow = dayjs('2024-06-15T12:00:00Z').valueOf();
+      const programUuid = v4();
+      const filler = createFiller();
+      filler.fillerContent = [createProgram({ uuid: programUuid })];
+
+      // Played at a time that would be within cooldown relative to fixedNow
+      const playedAt = new Date(fixedNow - 10 * 60 * 1000); // 10 min before fixedNow
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([
+        createPlayHistory(programUuid, playedAt, filler.fillerShowUuid),
+      ]);
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000,
+        fixedNow,
+      );
+
+      // Should skip program due to cooldown relative to fixedNow
+      expect(result.filler).toBeNull();
+    });
+
+    it('defaults to current time when now parameter is not provided', async () => {
+      const filler = createFiller();
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      // This should not throw and should use current time
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  // ==========================================
+  // REGRESSION / CHARACTERIZATION TESTS
+  // ==========================================
+
+  describe('characterization tests', () => {
+    it('produces expected result with controlled inputs', async () => {
+      const fixedNow = dayjs('2024-06-15T12:00:00Z').valueOf();
+      const programUuid = 'test-program-uuid';
+      const fillerUuid = 'test-filler-uuid';
+
+      const program = createProgram({ uuid: programUuid, duration: 30000 });
+      const filler = createFiller({ fillerShowUuid: fillerUuid });
+      filler.fillerContent = [program];
+
+      // No play history (never played)
+      vi.mocked(mockPlayHistoryDB.getFillerHistory).mockResolvedValue([]);
+
+      // Always select
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(
+        mockChannel,
+        [filler],
+        60000,
+        fixedNow,
+      );
+
+      expect(result).toEqual({
+        filler: program,
+        fillerListId: fillerUuid,
+        minimumWait: 0,
+      });
+    });
+
+    it('handles empty fillerContent gracefully', async () => {
+      const filler = createFiller();
+      filler.fillerContent = [];
+
+      vi.mocked(random.bool).mockReturnValue(true);
+
+      const result = await picker.pickFiller(mockChannel, [filler], 60000);
+
+      // List may be selected but no program to pick
+      expect(result.filler).toBeNull();
+    });
+  });
+});

--- a/server/src/services/scheduling/FillerPickerV2.ts
+++ b/server/src/services/scheduling/FillerPickerV2.ts
@@ -1,0 +1,196 @@
+import dayjs from 'dayjs';
+import { inject, injectable } from 'inversify';
+import { groupBy, isEmpty, maxBy, sumBy } from 'lodash-es';
+import { ProgramPlayHistoryDB } from '../../db/ProgramPlayHistoryDB.ts';
+import { Channel } from '../../db/schema/Channel.ts';
+import { ChannelFillerShowWithContent } from '../../db/schema/derivedTypes.ts';
+import {
+  FiveMinutesMillis,
+  OneDayMillis,
+} from '../../ffmpeg/builder/constants.ts';
+import { KEYS } from '../../types/inject.ts';
+import { Maybe } from '../../types/util.ts';
+import { Logger } from '../../util/logging/LoggerFactory.ts';
+import { loggingDef } from '../../util/logging/loggingDef.ts';
+import { random } from '../../util/random.ts';
+import {
+  DefaultFillerCooldownMillis,
+  EmptyFillerPickResult,
+  FillerPickResult,
+  IFillerPicker,
+} from '../interfaces/IFillerPicker.ts';
+
+// A (near) re-implementation of the original DTV filler picker.
+@injectable()
+@loggingDef({
+  category: 'scheduling',
+})
+export class FillerPickerV2 implements IFillerPicker {
+  constructor(
+    @inject(ProgramPlayHistoryDB)
+    private programPlayHistoryDB: ProgramPlayHistoryDB,
+    @inject(KEYS.Logger)
+    private logger: Logger,
+  ) {}
+
+  async pickFiller(
+    channel: Channel,
+    fillers: ChannelFillerShowWithContent[],
+    maxDuration: number,
+    now = +dayjs(),
+  ): Promise<FillerPickResult> {
+    if (isEmpty(fillers)) {
+      return Promise.resolve(EmptyFillerPickResult);
+    }
+
+    const fillerRepeatCooldownMs =
+      channel.fillerRepeatCooldown ?? DefaultFillerCooldownMillis;
+
+    const channelHistoryForFiller =
+      await this.programPlayHistoryDB.getFillerHistory(channel.uuid);
+
+    const fillerPlayHistoryById = groupBy(
+      channelHistoryForFiller,
+      (history) => history.fillerListId,
+    );
+
+    let listWeight = 0;
+    let pickedFiller: Maybe<ChannelFillerShowWithContent>;
+    let minimumWait = Number.MAX_SAFE_INTEGER;
+
+    if (this.logger.isLevelEnabled('debug')) {
+      const uniqFillers = sumBy(fillers, (f) => f.fillerContent.length);
+      this.logger.debug(
+        'Considering %d filler lists for channel %s. %d total programs',
+        fillers.length,
+        channel.uuid,
+        uniqFillers,
+      );
+    }
+
+    for (const filler of fillers) {
+      const { weight, cooldown, fillerShow, fillerContent } = filler;
+      const fillerHistory = fillerPlayHistoryById[fillerShow.uuid];
+      filler.fillerContent = random.shuffle(filler.fillerContent);
+
+      let programTotalWeight = 0;
+      for (const program of fillerContent) {
+        if (program.duration > maxDuration) {
+          this.logger.trace(
+            'Skipping program %s (%s) from filler list %s because it is too long (%d > %d)',
+            program.uuid,
+            program.title,
+            fillerShow.uuid,
+            program.duration,
+            maxDuration,
+          );
+          continue;
+        }
+        const programLastPlayed = fillerHistory?.find(
+          (h) => h.programUuid === program.uuid,
+        );
+        const timeSincePlayed = programLastPlayed
+          ? now - dayjs(programLastPlayed.playedAt).valueOf()
+          : OneDayMillis;
+
+        // Channel level cooldown in effect for this program
+        if (timeSincePlayed < fillerRepeatCooldownMs) {
+          this.logger.trace(
+            'Skipping program %s (%s) from filler list %s because cooldown is in effect (%d < %d)',
+            program.uuid,
+            program.title,
+            fillerShow.uuid,
+            timeSincePlayed,
+            fillerRepeatCooldownMs,
+          );
+          const timeUntilProgramCanPlay =
+            fillerRepeatCooldownMs - timeSincePlayed;
+          if (program.duration + timeUntilProgramCanPlay <= maxDuration) {
+            minimumWait = Math.min(minimumWait, timeUntilProgramCanPlay);
+          }
+        } else if (!pickedFiller) {
+          // Need to see if we can even use this list.
+          const fillerHistory = fillerPlayHistoryById[fillerShow.uuid];
+          const lastPlay = maxBy(fillerHistory, (history) =>
+            dayjs(history.playedAt).valueOf(),
+          );
+          const timeSincePlayedFiller = lastPlay
+            ? now - dayjs(lastPlay.playedAt).valueOf()
+            : OneDayMillis;
+          // Weights always count, despite cooldowns.
+          listWeight += weight;
+          if (timeSincePlayedFiller >= cooldown) {
+            if (this.weightedPick('filler', weight, listWeight)) {
+              pickedFiller = filler;
+            } else {
+              // Didn't pick this filler list based on weight
+              break;
+            }
+          } else {
+            this.logger.trace(
+              'Cannot pick filler list %s (%s) because cooldown is in effect (%d < %d)',
+              filler.fillerShowUuid,
+              filler.fillerShow.name,
+              timeSincePlayedFiller,
+              cooldown,
+            );
+            const timeUntilListIsCandidate = cooldown - timeSincePlayedFiller;
+            if (program.duration + timeUntilListIsCandidate <= maxDuration) {
+              minimumWait = Math.min(
+                minimumWait,
+                program.duration + timeUntilListIsCandidate,
+              );
+            }
+            // Cannot use this list because cooldown is in effect
+            break;
+          }
+
+          const normalizedSince = normalizeSince(
+            timeSincePlayed >= FiveMinutesMillis
+              ? FiveMinutesMillis
+              : timeSincePlayed,
+          );
+          const normalizedDuration = normalizeDuration(program.duration);
+          const programWeight = normalizedSince + normalizedDuration;
+          programTotalWeight += programWeight;
+          if (this.weightedPick('program', programWeight, programTotalWeight)) {
+            return {
+              filler: program,
+              fillerListId: pickedFiller.fillerShowUuid,
+              minimumWait: 0,
+            };
+          }
+        }
+      }
+    }
+
+    return {
+      filler: null,
+      fillerListId: null,
+      minimumWait,
+    };
+  }
+
+  // Exposed to we can delineate weighted pick calls in our tests
+  // It's ugly... but it works.
+  weightedPick(_reason: string, numerator: number, denominator: number) {
+    return random.bool(numerator, denominator);
+  }
+}
+
+// Moving old DTV normalizer functions here. Slightly changing them to make them
+// more readable and less verbose
+function normalizeDuration(durationMs: number) {
+  let durationSeconds = durationMs / (60 * 1000);
+  if (durationSeconds >= 3.0) {
+    durationSeconds = 3.0 + Math.log(durationSeconds);
+  }
+  const y = 10000 * (Math.ceil(durationSeconds * 1000) + 1);
+  return Math.ceil(y / 1000000) + 1;
+}
+
+function normalizeSince(timeSinceMs: number) {
+  let y = Math.ceil(timeSinceMs / 600) + 1;
+  y = y * y;
+  return Math.ceil(y / 1000000) + 1;
+}

--- a/server/src/stream/StreamModule.ts
+++ b/server/src/stream/StreamModule.ts
@@ -28,6 +28,7 @@ import type { IProgramDB } from '../db/interfaces/IProgramDB.ts';
 import type { ISettingsDB } from '../db/interfaces/ISettingsDB.ts';
 import type { FFmpegFactory } from '../ffmpeg/FFmpegModule.ts';
 import { FillerPicker } from '../services/FillerPicker.ts';
+import { FillerPickerV2 } from '../services/scheduling/FillerPickerV2.ts';
 import type { UpdatePlexPlayStatusScheduledTaskFactory } from '../tasks/plex/UpdatePlexPlayStatusTask.ts';
 import { UpdatePlexPlayStatusScheduledTask } from '../tasks/plex/UpdatePlexPlayStatusTask.ts';
 import { bindFactoryFunc } from '../util/inject.ts';
@@ -244,7 +245,14 @@ const configure: interfaces.ContainerModuleCallBack = (bind) => {
 
   bind(PersistentChannelCache).toSelf().inSingletonScope();
 
-  bind(KEYS.FillerPicker).to(FillerPicker).inSingletonScope();
+  bind(KEYS.FillerPicker)
+    .to(FillerPicker)
+    .inSingletonScope()
+    .whenTargetIsDefault();
+  bind(KEYS.FillerPicker)
+    .to(FillerPickerV2)
+    .inSingletonScope()
+    .whenTargetNamed('FillerPickerV2');
 };
 
 class StreamModule extends ContainerModule {

--- a/server/src/tasks/Task.ts
+++ b/server/src/tasks/Task.ts
@@ -69,9 +69,9 @@ export abstract class Task2<
     return this.#logger;
   }
 
-  protected set logger(logger: Logger) {
-    logger.setBindings({ caller: this.constructor.name });
-    this.#logger = logger;
+  protected set logger(newLogger: Logger) {
+    newLogger.setBindings({ caller: this.constructor.name });
+    this.#logger = newLogger;
   }
 
   async run(request: z.infer<RequestSchema>): Promise<Result<ResultT>> {

--- a/server/src/util/defaults.ts
+++ b/server/src/util/defaults.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { globalOptions } from '../globals.ts';
 import { isRunningInContainer } from './containerUtil.ts';
 import { DATABASE_LOCATION_ENV_VAR, SERVER_PORT_ENV_VAR } from './env.ts';
-import { isNonEmptyString, isProduction } from './index.js';
+import { isNonEmptyString } from './index.js';
 import type { LogLevels } from './logging/LoggerFactory.ts';
 import { getEnvironmentLogLevel } from './logging/LoggerFactory.ts';
 
@@ -34,7 +34,7 @@ export function getDefaultLogLevel(useEnvVar: boolean = true): LogLevels {
     }
   }
 
-  return isProduction ? 'info' : 'debug';
+  return 'info';
 }
 
 export function getDefaultDatabaseDirectory(): string {

--- a/server/src/util/logging/LoggerFactory.ts
+++ b/server/src/util/logging/LoggerFactory.ts
@@ -1,19 +1,22 @@
 import type { SettingsDB } from '@/db/SettingsDB.js';
 import type { Maybe, TupleToUnion } from '@/types/util.js';
 import { getDefaultLogLevel } from '@/util/defaults.js';
-import { isNonEmptyString, isProduction, isTest } from '@/util/index.js';
+import { inConstArr, isNonEmptyString, isTest } from '@/util/index.js';
 import {
   forEach,
   isEmpty,
   isEqual,
-  isString,
   isUndefined,
-  nth,
   toLower,
   trim,
 } from 'lodash-es';
-import path, { join } from 'node:path';
-import type { Bindings, MultiStreamRes, StreamEntry } from 'pino';
+import { join } from 'node:path';
+import type {
+  Bindings,
+  ChildLoggerOptions,
+  MultiStreamRes,
+  StreamEntry,
+} from 'pino';
 import pino, {
   levels,
   multistream,
@@ -23,7 +26,8 @@ import pino, {
 } from 'pino';
 import type { PrettyOptions } from 'pino-pretty';
 import pretty from 'pino-pretty';
-import type ThreadStream from 'thread-stream';
+import { TUNARR_ENV_VARS } from '../env.ts';
+import { RootLoggerWrapper } from './LoggerWrapper.ts';
 import { RollingLogDestination } from './RollingDestination.ts';
 
 export const LogConfigEnvVars = {
@@ -31,8 +35,10 @@ export const LogConfigEnvVars = {
   directory: 'LOG_DIRECTORY',
 } as const;
 
-export function getEnvironmentLogLevel(): Maybe<LogLevels> {
-  const envLevel = trim(toLower(process.env[LogConfigEnvVars.level]));
+export function getEnvironmentLogLevel(envVar?: string): Maybe<LogLevels> {
+  const envLevel = trim(
+    toLower(process.env[envVar ?? TUNARR_ENV_VARS.LOG_LEVEL_ENV_VAR]),
+  );
   if (isNonEmptyString(envLevel)) {
     if (ValidLogLevels.includes(envLevel)) {
       return envLevel as LogLevels;
@@ -61,6 +67,7 @@ export type LogLevels = LevelWithSilent | ExtraLogLevels;
 
 export type GetChildLoggerArgs = {
   caller?: ImportMeta | string;
+  category?: LogCategory;
   className: string;
 } & Bindings;
 
@@ -95,11 +102,16 @@ export function getPrettyStreamOpts(): PrettyOptions {
   };
 }
 
+export const LogCategories = ['streaming', 'scheduling'] as const;
+
+export type LogCategory = TupleToUnion<typeof LogCategories>;
+
 class LoggerFactoryImpl {
   private settingsDB: SettingsDB;
-  private rootLogger: PinoLogger<ExtraLogLevels>;
+  // private rootLogger: PinoLogger<ExtraLogLevels>;
+  private rootLogger!: RootLoggerWrapper;
   private initialized = false;
-  private children: Record<string, Logger> = {};
+  private children: Record<string, WeakRef<Logger>> = {};
   private currentStreams: MultiStreamRes<LogLevels>;
   private roller?: RollingLogDestination;
 
@@ -128,7 +140,7 @@ class LoggerFactoryImpl {
         const { level: newLevel } = this.logLevel;
 
         if (
-          this.rootLogger[symbols.getLevelSym] !== newLevel ||
+          this.rootLogger.logger[symbols.getLevelSym] !== newLevel ||
           !prevSettings ||
           !isEqual(prevSettings.system.logging.logRollConfig, currentSettings)
         ) {
@@ -152,7 +164,7 @@ class LoggerFactoryImpl {
   }
 
   get root() {
-    return this.rootLogger;
+    return this.rootLogger.logger;
   }
 
   get isInitialized() {
@@ -163,45 +175,20 @@ class LoggerFactoryImpl {
     this.roller?.roll();
   }
 
-  // HACK - but this is how we change transports without a restart:
-  // 1. Flush and close the existing transport
-  // 2. Update the transports to the new set
-  // 3. Manually attach them to the pino instance
-  reinitStream() {
-    if (!this.initialized) {
-      return;
-    }
-
-    const currentStream = this.rootLogger[symbols.streamSym] as ThreadStream;
-    currentStream.flushSync();
-    currentStream.end();
-    Object.assign(
-      this.rootLogger[symbols.streamSym],
-      this.currentStreams.clone(this.logLevel.level),
+  child(
+    args: GetChildLoggerArgs,
+    opts?: ChildLoggerOptions<LogLevels>,
+  ): Logger {
+    const { className } = args;
+    opts ??= {};
+    const levelOverride = getEnvironmentLogLevel(
+      `TUNARR_LOG_LEVEL_${className.toUpperCase()}`,
     );
-  }
-
-  child(opts: GetChildLoggerArgs): Logger {
-    const { caller, className, ...rest } = opts;
-
-    if (this.children[className]) {
-      return this.children[className];
+    const child = this.rootLogger.child(args, opts);
+    if (levelOverride) {
+      child.updateStreams(multistream(this.createStreams(levelOverride)));
     }
-
-    const childOpts = {
-      ...rest,
-      file: isProduction
-        ? undefined
-        : caller
-          ? isString(caller)
-            ? caller
-            : getCaller(caller)
-          : undefined,
-      caller: isProduction ? undefined : className, // Don't include this twice in production
-    };
-    const newChild = this.rootLogger.child(childOpts);
-    this.children[className] = newChild;
-    return newChild;
+    return child.logger;
   }
 
   private createLogStreams(level?: LogLevels) {
@@ -212,9 +199,9 @@ class LoggerFactoryImpl {
     return this.currentStreams;
   }
 
-  private createRootLogger() {
+  private createRootLogger(): RootLoggerWrapper {
     const { level } = this.logLevel;
-    return pino(
+    const root = pino(
       {
         level,
         customLevels: {
@@ -224,6 +211,8 @@ class LoggerFactoryImpl {
       },
       this.createLogStreams(),
     );
+
+    return new RootLoggerWrapper(root);
   }
 
   private get logLevel(): {
@@ -249,20 +238,22 @@ class LoggerFactoryImpl {
     }
   }
 
-  private updateLevel(newLevel: LogLevels) {
+  private updateLevel(newLevel: LogLevels, category?: string) {
+    if (category && inConstArr(LogCategories, category)) {
+      this.rootLogger.updateCategoryLevel(
+        newLevel,
+        category as LogCategory,
+        () => this.createLogStreams(newLevel),
+      );
+      return;
+    }
+
     // Reset the level of the root logger and all children
     // We do this by setting the level on the instance directly
     // but then for multistream to work, we have to manually reset the streams
     // by cloning them with new levels.
     this.rootLogger.level = newLevel;
-    Object.assign(
-      this.rootLogger[symbols.streamSym],
-      this.createLogStreams(newLevel),
-    );
-    forEach(this.children, (childLogger) => {
-      childLogger.level = newLevel;
-      Object.assign(childLogger[symbols.streamSym], this.currentStreams);
-    });
+    this.rootLogger.updateStreams(this.createLogStreams(newLevel));
   }
 
   private createStreams(logLevel: LogLevels): StreamEntry<LogLevels>[] {
@@ -318,13 +309,6 @@ class LoggerFactoryImpl {
     return streams;
   }
 }
-
-const getCaller = (callingModule: ImportMeta) => {
-  const parts = callingModule.url.split(path.sep);
-  const submodule = nth(parts, parts.length - 2) ?? '';
-  const last = parts.pop();
-  return join(submodule === 'src' ? '' : submodule, last ?? '');
-};
 
 export const LoggerFactory = new LoggerFactoryImpl();
 

--- a/server/src/util/logging/LoggerWrapper.ts
+++ b/server/src/util/logging/LoggerWrapper.ts
@@ -1,0 +1,179 @@
+import { isNonEmptyString } from '@tunarr/shared/util';
+import { isString, nth } from 'lodash-es';
+import path, { join } from 'path';
+import type { ChildLoggerOptions, MultiStreamRes } from 'pino';
+import { symbols } from 'pino';
+import { isProduction } from '../index.ts';
+import type {
+  GetChildLoggerArgs,
+  LogCategory,
+  Logger,
+  LogLevels,
+} from './LoggerFactory.ts';
+import { getEnvironmentLogLevel, LogCategories } from './LoggerFactory.ts';
+
+interface ILoggerWrapper {
+  child(
+    args: GetChildLoggerArgs,
+    opts?: ChildLoggerOptions<LogLevels>,
+  ): ILoggerWrapper;
+  updateStreams(streams: MultiStreamRes<LogLevels>): void;
+  logger: Logger;
+}
+
+abstract class BaseLoggerWrapper implements ILoggerWrapper {
+  protected children: Record<string, WeakRef<ILoggerWrapper>> = {};
+
+  constructor(protected wrappedLogger: Logger) {}
+
+  abstract child(
+    args: GetChildLoggerArgs,
+    opts?: ChildLoggerOptions<LogLevels>,
+  ): ILoggerWrapper;
+
+  updateStreams(streams: MultiStreamRes<LogLevels>) {
+    console.log('update streams ', this.className);
+    Object.assign(this.wrappedLogger[symbols.streamSym], streams);
+
+    for (const childRef of Object.values(this.children)) {
+      const child = childRef.deref();
+      if (child) {
+        child.updateStreams(streams);
+      }
+    }
+  }
+
+  get logger(): Logger {
+    return this.wrappedLogger;
+  }
+
+  protected get className() {
+    const maybeClassName: unknown =
+      this.wrappedLogger.bindings()['caller'] ??
+      this.wrappedLogger.bindings()['className'];
+    if (isNonEmptyString(maybeClassName)) {
+      return maybeClassName;
+    }
+    return;
+  }
+}
+
+export class RootLoggerWrapper extends BaseLoggerWrapper {
+  private loggerByCategory = new Map<LogCategory, ILoggerWrapper>();
+
+  constructor(wrappedLogger: Logger) {
+    super(wrappedLogger);
+    for (const category of LogCategories) {
+      const categoryLogger = this.wrappedLogger.child({ category });
+      const wrapped = new LoggerWrapper(categoryLogger);
+      this.children[`category:${category}`] = new WeakRef(wrapped);
+      this.loggerByCategory.set(category, wrapped);
+    }
+  }
+
+  child(
+    args: GetChildLoggerArgs,
+    opts?: ChildLoggerOptions<LogLevels>,
+  ): ILoggerWrapper {
+    const { caller, className, category, ...rest } = args;
+
+    const ref = this.children[className]?.deref();
+    if (ref) {
+      return ref;
+    }
+
+    const childOpts = {
+      ...rest,
+      file: isProduction
+        ? undefined
+        : caller
+          ? isString(caller)
+            ? caller
+            : getCaller(caller)
+          : undefined,
+      caller: isProduction ? undefined : className, // Don't include this twice in production
+    };
+    // console.log(this.loggerByCategory.get(category));
+    if (category && this.loggerByCategory.has(category)) {
+      const categoryLogger = this.loggerByCategory.get(category)!;
+      delete args.category;
+      const wrapped = categoryLogger.child(args, opts);
+      return wrapped;
+    } else {
+      const newLogger = this.wrappedLogger.child(childOpts, opts);
+      const wrapped = new LoggerWrapper(newLogger);
+      this.children[className] = new WeakRef(wrapped);
+      return wrapped;
+    }
+  }
+
+  set level(newLevel: LogLevels) {
+    this.wrappedLogger.level = newLevel;
+  }
+
+  updateCategoryLevel(
+    newLevel: LogLevels,
+    category: LogCategory,
+    newStreamFn: () => MultiStreamRes<LogLevels>,
+  ) {
+    const rootCategoryLogger = this.loggerByCategory.get(category);
+    if (!rootCategoryLogger) {
+      return;
+    }
+
+    rootCategoryLogger.logger.level = newLevel;
+    rootCategoryLogger.updateStreams(newStreamFn());
+  }
+}
+
+export class LoggerWrapper extends BaseLoggerWrapper {
+  constructor(wrappedLogger: Logger) {
+    super(wrappedLogger);
+    const className = this.className;
+    if (isNonEmptyString(className)) {
+      const l = getEnvironmentLogLevel(
+        `TUNARR_LOG_LEVEL_${className.toUpperCase()}`,
+      );
+      if (l) {
+        console.log('CUSTOM LOG LEVEL: ', l, className);
+        this.wrappedLogger.level = l;
+      }
+    }
+  }
+
+  child(
+    args: GetChildLoggerArgs,
+    opts?: ChildLoggerOptions<LogLevels>,
+  ): ILoggerWrapper {
+    const { caller, className, ...rest } = args;
+
+    const ref = this.children[className]?.deref();
+    if (ref) {
+      return ref;
+    }
+
+    const childOpts = {
+      ...rest,
+      file: isProduction
+        ? undefined
+        : caller
+          ? isString(caller)
+            ? caller
+            : getCaller(caller)
+          : undefined,
+      caller: isProduction ? undefined : className, // Don't include this twice in production
+    };
+    const newChild = new LoggerWrapper(
+      this.wrappedLogger.child(childOpts, opts),
+    );
+    this.children[className] = new WeakRef(newChild);
+    return newChild;
+  }
+}
+
+const getCaller = (callingModule: ImportMeta) => {
+  const parts = callingModule.url.split(path.sep);
+  const submodule = nth(parts, parts.length - 2) ?? '';
+  const last = parts.pop();
+  return join(submodule === 'src' ? '' : submodule, last ?? '');
+};

--- a/server/src/util/logging/loggingDef.ts
+++ b/server/src/util/logging/loggingDef.ts
@@ -1,0 +1,12 @@
+import type { LogCategory } from './LoggerFactory.ts';
+
+export type LoggingDefinition = {
+  category?: LogCategory;
+};
+
+export function loggingDef(def: LoggingDefinition = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function <T extends { new (...args: any[]): any }>(constructor: T) {
+    Reflect.set(constructor, 'tunarr:log_def', def);
+  };
+}

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -11,7 +11,7 @@ import type {
   SaveableChannel,
   SubtitlePreference,
 } from '@tunarr/types';
-import { isEmpty, keys, map, reject, some } from 'lodash-es';
+import { isEmpty, isNil, keys, map, reject, some } from 'lodash-es';
 import { useCallback, useState } from 'react';
 import {
   FormProvider,
@@ -40,7 +40,7 @@ function getDefaultFormValues(channel: Channel): DeepRequired<SaveableChannel> {
     streamMode: channel.streamMode ?? 'hls',
     fillerCollections: channel.fillerCollections ?? [],
     fillerRepeatCooldown:
-      (channel.fillerRepeatCooldown
+      (!isNil(channel.fillerRepeatCooldown)
         ? channel.fillerRepeatCooldown
         : DefaultChannel.fillerRepeatCooldown!) / 1000,
     guideFlexTitle: channel.guideFlexTitle ?? '',
@@ -177,7 +177,7 @@ export function EditChannelForm({
       ...data,
       // Transform this to milliseconds before we send it over
       guideMinimumDuration: data.guideMinimumDuration * 1000,
-      fillerRepeatCooldown: data.fillerRepeatCooldown
+      fillerRepeatCooldown: !isNil(data.fillerRepeatCooldown)
         ? data.fillerRepeatCooldown * 1000
         : undefined,
       guideFlexTitle: isNonEmptyString(data.guideFlexTitle)


### PR DESCRIPTION
* New picker uses the new database table that tracks play history
* Extensive tests for the way the picker works

Also includes redo of logging system to introduce more hierarchy and
allow for categorized loggers (e.g. streaming logs, scheduling logs).
