### PR TITLE
Update so that by default searching uses `sortTitle`.

### DIFF
--- a/server/src/services/MeilisearchService.ts
+++ b/server/src/services/MeilisearchService.ts
@@ -1156,7 +1156,7 @@ export class MeilisearchService implements ISearchService {
     if (isNonEmptyString(request.query)) {
       const sort = request.sort?.map(
         ({ field, direction }) => `${field}:${direction}`,
-      ) ?? ['title:asc'];
+      ) ?? ['sortTitle:asc'];
       const req = {
         filter,
         page: request.paging?.page,
@@ -1188,7 +1188,7 @@ export class MeilisearchService implements ISearchService {
         : undefined;
       const sort = request.sort?.map(
         ({ field, direction }) => `${field}:${direction}`,
-      ) ?? ['title:asc'];
+      ) ?? ['sortTitle:asc'];
 
       this.logger.debug(
         'Issuing get documents request: filter: "%s", sort: %O. offset: %d limit %d',


### PR DESCRIPTION
Fixes #1590