### PR TITLE
feat: allow setting log level for specific categories

### DIFF
--- a/server/src/services/MeilisearchService.ts
+++ b/server/src/services/MeilisearchService.ts
@@ -569,6 +569,11 @@ export class MeilisearchService implements ISearchService {
           );
         }
 
+        this.logger.trace(
+          'Starting meilisearch with args: %s %s',
+          executablePath,
+          args.join(' '),
+        );
         this.proc = await this.childProcessHelper.spawn(executablePath, args, {
           maxAttempts: 3,
           additionalOpts: {

--- a/server/src/services/TvGuideService.ts
+++ b/server/src/services/TvGuideService.ts
@@ -71,6 +71,7 @@ import {
   run,
   wait,
 } from '../util/index.ts';
+import { loggingDef } from '../util/logging/loggingDef.ts';
 import { EventService } from './EventService.ts';
 import { OnDemandChannelService } from './OnDemandChannelService.ts';
 import { XmlTvWriter } from './XmlTvWriter.ts';
@@ -119,6 +120,7 @@ type ChannelId = string;
 const PlaceholderChannelId = v4();
 
 @injectable()
+@loggingDef({ category: 'scheduling' })
 export class TVGuideService {
   private timer: Timer;
   private locks = new MutexMap();

--- a/server/src/services/XmlTvWriter.ts
+++ b/server/src/services/XmlTvWriter.ts
@@ -17,6 +17,7 @@ import { compact, escape, flatMap, isNil, map, round } from 'lodash-es';
 import { writeFile } from 'node:fs/promises';
 import { match } from 'ts-pattern';
 import { MaterializedGuideItem } from '../types/guide.ts';
+import { loggingDef } from '../util/logging/loggingDef.ts';
 
 const lock = new Mutex();
 
@@ -26,6 +27,7 @@ export type MaterializedChannelPrograms = {
 };
 
 @injectable()
+@loggingDef({ category: 'scheduling' })
 export class XmlTvWriter {
   private logger = LoggerFactory.child({
     caller: import.meta,

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -1,6 +1,7 @@
 import type { Func } from '@/types/func.js';
 import type { MarkNonNullable, Maybe, Nilable, Try } from '@/types/util.js';
 import { createExternalId } from '@tunarr/shared';
+import type { TupleToUnion } from '@tunarr/types';
 import dayjs from 'dayjs';
 import type { Duration } from 'dayjs/plugin/duration.js';
 import duration from 'dayjs/plugin/duration.js';
@@ -561,10 +562,10 @@ export function makeWritable<T>(obj: DeepReadonly<T>): DeepWritable<T> {
   return obj as DeepWritable<T>; // here be hacks
 }
 
-export function inConstArr<Arr extends readonly string[], S extends string>(
+export function inConstArr<S extends string, Arr extends readonly [S, ...S[]]>(
   arr: Arr,
   typ: S,
-): boolean {
+): typ is TupleToUnion<Arr> {
   for (const value of arr) {
     if (value === typ) {
       return true;

--- a/types/src/SystemSettings.ts
+++ b/types/src/SystemSettings.ts
@@ -3,17 +3,9 @@ import { BackupSettingsSchema } from './schemas/settingsSchemas.js';
 import { ScheduleSchema } from './schemas/utilSchemas.js';
 import { type TupleToUnion } from './util.js';
 
-export const LogLevelsSchema = z.union([
-  z.literal('silent'),
-  z.literal('fatal'),
-  z.literal('error'),
-  z.literal('warn'),
-  z.literal('info'),
-  z.literal('http'),
-  z.literal('debug'),
-  z.literal('http_out'),
-  z.literal('trace'),
-]);
+export const LogCategories = ['scheduling', 'streaming'] as const;
+
+export const LogCategoriesSchema = z.enum([...LogCategories]);
 
 export const LogLevels = [
   'silent',
@@ -27,6 +19,8 @@ export const LogLevels = [
   'trace',
 ] as const;
 
+export const LogLevelsSchema = z.enum([...LogLevels]);
+
 export type LogLevel = TupleToUnion<typeof LogLevels>;
 
 export const LogRollConfigSchema = z.object({
@@ -38,6 +32,9 @@ export const LogRollConfigSchema = z.object({
 
 export const LoggingSettingsSchema = z.object({
   logLevel: LogLevelsSchema,
+  categoryLogLevel: z
+    .partialRecord(LogCategoriesSchema, LogLevelsSchema.optional())
+    .optional(),
   logsDirectory: z.string(),
   useEnvVarLevel: z.boolean().default(true),
   logRollConfig: LogRollConfigSchema.optional().default({

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 import {
   CacheSettingsSchema,
+  LogCategoriesSchema,
   LoggingSettingsSchema,
   LogLevelsSchema,
   ServerSettingsSchema,
@@ -266,6 +267,11 @@ export const UpdateSystemSettingsRequestSchema = z.object({
     useEnvVarLevel: true,
     logRollConfig: true,
   })
+    .extend({
+      categoryLogLevel: z
+        .partialRecord(LogCategoriesSchema, LogLevelsSchema.nullish())
+        .optional(),
+    })
     .partial()
     .optional(),
   backup: BackupSettingsSchema.optional(),

--- a/web/src/hooks/useNavItems.tsx
+++ b/web/src/hooks/useNavItems.tsx
@@ -7,6 +7,7 @@ import {
   Psychology,
   Settings,
   SettingsRemote,
+  Storage as StorageIcon,
   Theaters,
   Tv,
   VideoLibrary,
@@ -89,6 +90,11 @@ export const useNavItems = () => {
             icon: <Delete />,
           },
         ],
+      },
+      {
+        name: 'Sources',
+        path: '/media_sources',
+        icon: <StorageIcon />,
       },
       {
         name: 'System',

--- a/web/src/pages/settings/MediaSourceSettingsPage.tsx
+++ b/web/src/pages/settings/MediaSourceSettingsPage.tsx
@@ -244,7 +244,7 @@ export default function MediaSourceSettingsPage() {
             sx={{ flexWrap: 'wrap' }}
           >
             <Typography
-              variant="h5"
+              variant="h3"
               sx={(theme) => ({
                 flexGrow: 1,
                 [theme.breakpoints.down('sm')]: {

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as SearchRouteImport } from './routes/search';
 import { Route as GuideRouteImport } from './routes/guide';
 import { Route as IndexRouteImport } from './routes/index';
 import { Route as SystemIndexRouteImport } from './routes/system/index';
+import { Route as Media_sourcesIndexRouteImport } from './routes/media_sources_/index';
 import { Route as LibraryIndexRouteImport } from './routes/library/index';
 import { Route as ChannelsIndexRouteImport } from './routes/channels_/index';
 import { Route as SystemTasksRouteImport } from './routes/system/tasks';
@@ -93,6 +94,11 @@ const SystemIndexRoute = SystemIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => SystemRoute,
+} as any);
+const Media_sourcesIndexRoute = Media_sourcesIndexRouteImport.update({
+  id: '/media_sources_/',
+  path: '/media_sources/',
+  getParentRoute: () => rootRouteImport,
 } as any);
 const LibraryIndexRoute = LibraryIndexRouteImport.update({
   id: '/library/',
@@ -347,6 +353,7 @@ export interface FileRoutesByFullPath {
   '/system/tasks': typeof SystemTasksRoute;
   '/channels': typeof ChannelsIndexRoute;
   '/library': typeof LibraryIndexRoute;
+  '/media_sources': typeof Media_sourcesIndexRoute;
   '/system/': typeof SystemIndexRoute;
   '/library/custom-shows/$showId': typeof LibraryCustomShowsShowIdRouteRouteWithChildren;
   '/library/custom-shows/new': typeof LibraryCustomShowsNewRouteRouteWithChildren;
@@ -396,6 +403,7 @@ export interface FileRoutesByTo {
   '/system/tasks': typeof SystemTasksRoute;
   '/channels': typeof ChannelsIndexRoute;
   '/library': typeof LibraryIndexRoute;
+  '/media_sources': typeof Media_sourcesIndexRoute;
   '/system': typeof SystemIndexRoute;
   '/library/custom-shows/$showId': typeof LibraryCustomShowsShowIdRouteRouteWithChildren;
   '/library/fillers/$fillerId': typeof LibraryFillersFillerIdRouteRouteWithChildren;
@@ -446,6 +454,7 @@ export interface FileRoutesById {
   '/system/tasks': typeof SystemTasksRoute;
   '/channels_/': typeof ChannelsIndexRoute;
   '/library/': typeof LibraryIndexRoute;
+  '/media_sources_/': typeof Media_sourcesIndexRoute;
   '/system/': typeof SystemIndexRoute;
   '/library/custom-shows_/$showId': typeof LibraryCustomShowsShowIdRouteRouteWithChildren;
   '/library/custom-shows_/new': typeof LibraryCustomShowsNewRouteRouteWithChildren;
@@ -499,6 +508,7 @@ export interface FileRouteTypes {
     | '/system/tasks'
     | '/channels'
     | '/library'
+    | '/media_sources'
     | '/system/'
     | '/library/custom-shows/$showId'
     | '/library/custom-shows/new'
@@ -548,6 +558,7 @@ export interface FileRouteTypes {
     | '/system/tasks'
     | '/channels'
     | '/library'
+    | '/media_sources'
     | '/system'
     | '/library/custom-shows/$showId'
     | '/library/fillers/$fillerId'
@@ -597,6 +608,7 @@ export interface FileRouteTypes {
     | '/system/tasks'
     | '/channels_/'
     | '/library/'
+    | '/media_sources_/'
     | '/system/'
     | '/library/custom-shows_/$showId'
     | '/library/custom-shows_/new'
@@ -641,6 +653,7 @@ export interface RootRouteChildren {
   LibraryFillersRoute: typeof LibraryFillersRoute;
   ChannelsIndexRoute: typeof ChannelsIndexRoute;
   LibraryIndexRoute: typeof LibraryIndexRoute;
+  Media_sourcesIndexRoute: typeof Media_sourcesIndexRoute;
   LibraryCustomShowsShowIdRouteRoute: typeof LibraryCustomShowsShowIdRouteRouteWithChildren;
   LibraryCustomShowsNewRouteRoute: typeof LibraryCustomShowsNewRouteRouteWithChildren;
   LibraryFillersFillerIdRouteRoute: typeof LibraryFillersFillerIdRouteRouteWithChildren;
@@ -703,6 +716,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/system/';
       preLoaderRoute: typeof SystemIndexRouteImport;
       parentRoute: typeof SystemRoute;
+    };
+    '/media_sources_/': {
+      id: '/media_sources_/';
+      path: '/media_sources';
+      fullPath: '/media_sources';
+      preLoaderRoute: typeof Media_sourcesIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
     };
     '/library/': {
       id: '/library/';
@@ -1152,6 +1172,7 @@ const rootRouteChildren: RootRouteChildren = {
   LibraryFillersRoute: LibraryFillersRoute,
   ChannelsIndexRoute: ChannelsIndexRoute,
   LibraryIndexRoute: LibraryIndexRoute,
+  Media_sourcesIndexRoute: Media_sourcesIndexRoute,
   LibraryCustomShowsShowIdRouteRoute:
     LibraryCustomShowsShowIdRouteRouteWithChildren,
   LibraryCustomShowsNewRouteRoute: LibraryCustomShowsNewRouteRouteWithChildren,

--- a/web/src/routes/media_sources_/index.tsx
+++ b/web/src/routes/media_sources_/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import MediaSourceSettingsPage from '../../pages/settings/MediaSourceSettingsPage.tsx';
+
+export const Route = createFileRoute('/media_sources_/')({
+  component: MediaSourceSettingsPage,
+});


### PR DESCRIPTION
Introduces log categories, starting with "scheduling" and "streaming"
which allows more granular control over log level for the system. Now
that Tunarr has become quite complex, debugging specific components by
turning up the log level can produce a TON of logs. This should help us
be more pointed when debugging.
