### PR TITLE
feat: persist color metadata.

### DIFF
--- a/server/src/db/converters/ProgramMinter.ts
+++ b/server/src/db/converters/ProgramMinter.ts
@@ -257,7 +257,10 @@ export class ProgramDaoMinter {
           uuid: v4(),
           bitsPerSample: stream.bitDepth,
           channels: stream.channels,
-          // TODO: color
+          colorRange: stream.colorRange ?? null,
+          colorSpace: stream.colorSpace ?? null,
+          colorTransfer: stream.colorTransfer ?? null,
+          colorPrimaries: stream.colorPrimaries ?? null,
           default: booleanToNumber(stream.default ?? false),
           //TODO: forced: stream.forced
           language: stream.languageCodeISO6392,

--- a/server/src/stream/emby/EmbyStreamDetails.ts
+++ b/server/src/stream/emby/EmbyStreamDetails.ts
@@ -267,6 +267,10 @@ export class EmbyStreamDetails extends ExternalStreamDetailsFetcher<EmbyT> {
         codec: videoStream.Codec ?? undefined,
         profile: videoStream.Profile?.toLowerCase(),
         pixelFormat: videoStream.PixelFormat ?? undefined,
+        colorRange: videoStream.VideoRange ?? undefined,
+        colorSpace: videoStream.ColorSpace ?? undefined,
+        colorTransfer: videoStream.ColorTransfer ?? undefined,
+        colorPrimaries: videoStream.ColorPrimaries ?? undefined,
       };
     }
 

--- a/server/src/stream/jellyfin/JellyfinStreamDetails.ts
+++ b/server/src/stream/jellyfin/JellyfinStreamDetails.ts
@@ -276,6 +276,10 @@ export class JellyfinStreamDetails extends ExternalStreamDetailsFetcher<Jellyfin
         codec: videoStream.Codec ?? undefined,
         profile: videoStream.Profile?.toLowerCase(),
         pixelFormat: videoStream.PixelFormat ?? undefined,
+        colorRange: videoStream.ColorRange ?? undefined,
+        colorSpace: videoStream.ColorSpace ?? undefined,
+        colorTransfer: videoStream.ColorTransfer ?? undefined,
+        colorPrimaries: videoStream.ColorPrimaries ?? undefined,
       };
     }
 

--- a/server/src/stream/local/LocalProgramStreamDetails.ts
+++ b/server/src/stream/local/LocalProgramStreamDetails.ts
@@ -76,6 +76,10 @@ export class LocalProgramStreamDetails extends ExternalStreamDetailsFetcher<'loc
             scanType: nullToUndefined(firstVersion.scanKind),
             streamIndex: videoStream.index,
             pixelFormat: videoStream.pixelFormat ?? undefined,
+            colorRange: videoStream.colorRange ?? undefined,
+            colorSpace: videoStream.colorSpace ?? undefined,
+            colorTransfer: videoStream.colorTransfer ?? undefined,
+            colorPrimaries: videoStream.colorPrimaries ?? undefined,
           }) satisfies VideoStreamDetails,
       ) ?? [];
 

--- a/server/src/stream/plex/PlexStreamDetails.ts
+++ b/server/src/stream/plex/PlexStreamDetails.ts
@@ -384,6 +384,10 @@ export class PlexStreamDetails extends ExternalStreamDetailsFetcher<PlexT> {
         codec: videoStream.codec,
         profile: videoStream.profile?.toLowerCase(),
         streamIndex: videoStream.index,
+        colorRange: videoStream.colorRange,
+        colorSpace: videoStream.colorSpace,
+        colorTransfer: videoStream.colorTrc,
+        colorPrimaries: videoStream.colorPrimaries,
       } satisfies VideoStreamDetails;
     }
 


### PR DESCRIPTION
First step to enabling tonemapping is to persist color metadata.