### PR TITLE
feat: expose color metadata

### DIFF
--- a/server/src/ffmpeg/FfmpegStreamFactory.ts
+++ b/server/src/ffmpeg/FfmpegStreamFactory.ts
@@ -352,6 +352,10 @@ export class FfmpegStreamFactory extends IFFMPEG {
           width: videoStreamDetails.width,
         }),
         frameRate: videoStreamDetails.framerate?.toString(),
+        colorRange: videoStreamDetails.colorRange,
+        colorSpace: videoStreamDetails.colorSpace,
+        colorTransfer: videoStreamDetails.colorTransfer,
+        colorPrimaries: videoStreamDetails.colorPrimaries,
       });
 
       videoInputSource = new VideoInputSource(streamSource, [videoStream]);

--- a/server/src/ffmpeg/builder/MediaStream.ts
+++ b/server/src/ffmpeg/builder/MediaStream.ts
@@ -58,6 +58,10 @@ export class VideoStream implements MediaStream {
   frameSize: FrameSize;
   frameRate?: string;
   inputKind: VideoInputKind = 'video' as const;
+  colorRange?: string;
+  colorSpace?: string;
+  colorTransfer?: string;
+  colorPrimaries?: string;
   providedSampleAspectRatio: Nullable<string>;
   displayAspectRatio: string;
 

--- a/server/src/ffmpeg/builder/state/FrameState.ts
+++ b/server/src/ffmpeg/builder/state/FrameState.ts
@@ -28,6 +28,10 @@ export const DefaultFrameState: Omit<
   deinterlace: false,
   pixelFormat: null,
   bitDepth: 8,
+  colorRange: null,
+  colorSpace: null,
+  colorTransfer: null,
+  colorPrimaries: null,
   forceSoftwareOverlay: false,
   infiniteLoop: false,
 };
@@ -48,6 +52,10 @@ export class FrameState {
   frameDataLocation: FrameDataLocation;
   deinterlace: boolean;
   pixelFormat: Nullable<PixelFormat>;
+  colorRange: Nullable<string>;
+  colorSpace: Nullable<string>;
+  colorTransfer: Nullable<string>;
+  colorPrimaries: Nullable<string>;
   infiniteLoop: boolean = false;
 
   forceSoftwareOverlay = false;


### PR DESCRIPTION
Second step to enabling tonemapping is to expose the color metadata to the pipeline.