### PR TITLE
feat(stream): skip end credits using Plex outro markers

### DIFF
--- a/server/src/db/ChannelDB.test.ts
+++ b/server/src/db/ChannelDB.test.ts
@@ -117,6 +117,7 @@ function createSaveableChannel(
     streamMode: 'hls' as const,
     transcodeConfigId,
     subtitlesEnabled: false,
+    skipCredits: false,
     ...overrides,
   };
 }

--- a/server/src/db/ChannelDB.ts
+++ b/server/src/db/ChannelDB.ts
@@ -201,6 +201,7 @@ function updateRequestToChannel(updateReq: SaveableChannel): ChannelUpdate {
     transcodeConfigId: updateReq.transcodeConfigId,
     streamMode: updateReq.streamMode,
     subtitlesEnabled: booleanToNumber(updateReq.subtitlesEnabled),
+    skipCredits: booleanToNumber(updateReq.skipCredits),
   } satisfies ChannelUpdate;
 }
 
@@ -227,6 +228,7 @@ function createRequestToChannel(saveReq: SaveableChannel): NewChannel {
     streamMode: saveReq.streamMode,
     transcodeConfigId: saveReq.transcodeConfigId,
     subtitlesEnabled: booleanToNumber(saveReq.subtitlesEnabled),
+    skipCredits: booleanToNumber(saveReq.skipCredits),
   } satisfies NewChannel;
 }
 

--- a/server/src/db/converters/channelConverters.ts
+++ b/server/src/db/converters/channelConverters.ts
@@ -64,6 +64,7 @@ export const dbChannelToApiChannel = ({
     subtitlePreferences: isNonEmptyArray(subtitlePreferences)
       ? subtitlePreferences
       : undefined,
+    skipCredits: numberToBoolean(channel.skipCredits),
   };
 };
 
@@ -117,5 +118,6 @@ export const ormChannelToApiChannel = ({
     subtitlePreferences: isNonEmptyArray(subtitlePreferences)
       ? subtitlePreferences
       : undefined,
+    skipCredits: channel.skipCredits ?? false,
   };
 };

--- a/server/src/db/schema/Channel.ts
+++ b/server/src/db/schema/Channel.ts
@@ -46,6 +46,7 @@ export const Channel = sqliteTable(
     transcodeConfigId: text().notNull(),
     watermark: text({ mode: 'json' }).$type<ChannelWatermark>(),
     subtitlesEnabled: integer({ mode: 'boolean' }).default(false),
+    skipCredits: integer({ mode: 'boolean' }).default(false),
   },
   (table) => [
     uniqueIndex('channel_number_unique').on(table.number),

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -201,6 +201,9 @@ export class DirectMigrationProvider implements MigrationProvider {
             './sql/0041_easy_firebird.sql',
           ),
           migration1771271020: Migration1771271020_FixCustomShowContentKey,
+          migration1771459200_AddSkipCredits: makeKyselyMigrationFromSqlFile(
+            './sql/0042_add_skip_credits.sql',
+          ),
         },
         wrapWithTransaction,
       ),

--- a/server/src/migration/db/sql/0042_add_skip_credits.sql
+++ b/server/src/migration/db/sql/0042_add_skip_credits.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `channel` ADD `skip_credits` integer DEFAULT false;

--- a/server/src/services/TvGuideService.ts
+++ b/server/src/services/TvGuideService.ts
@@ -1273,6 +1273,7 @@ export class TVGuideService {
           .executeTakeFirstOrThrow()
       ).uuid,
       subtitlesEnabled: false,
+      skipCredits: false,
     };
 
     // Placeholder channel with random ID.

--- a/server/src/stream/StreamProgramCalculator.ts
+++ b/server/src/stream/StreamProgramCalculator.ts
@@ -17,6 +17,7 @@ import {
   isContentBackedLineupItem,
   ProgramStreamLineupItem,
   StreamLineupItem,
+  isProgramLineupItem,
 } from '../db/derived_types/StreamLineup.ts';
 import { IChannelDB } from '../db/interfaces/IChannelDB.ts';
 import { IFillerListDB } from '../db/interfaces/IFillerListDB.ts';
@@ -229,6 +230,38 @@ export class StreamProgramCalculator {
           "No video to play, this means there's a serious unexpected bug or the channel db is corrupted.";
         this.logger.error(msg);
         return Result.forError(new Error(msg));
+      }
+
+      // Skip end credits if enabled on the channel. When an outro chapter
+      // exists, cap the stream duration so FFmpeg stops before credits start.
+      // If the viewer tuned in during credits, replace with an offline item
+      // so the filler system fills the remaining slot time.
+      if (
+        channelContext.skipCredits &&
+        isProgramLineupItem(currentProgram.program)
+      ) {
+        const outroChapter =
+          currentProgram.program.program.versions?.[0]?.chapters?.find(
+            (c) => c.chapterType === 'outro',
+          );
+
+        if (outroChapter) {
+          const creditsRemaining =
+            outroChapter.startTime - currentProgram.timeElapsed;
+          if (creditsRemaining <= 0) {
+            // Tuned in during credits — show filler for remaining slot time
+            currentProgram = {
+              ...currentProgram,
+              program: {
+                ...createOfflineStreamLineupItem(streamDuration, req.startTime),
+                programBeginMs: currentProgram.program.programBeginMs,
+              },
+            };
+          } else {
+            // Cap stream duration to end when credits begin
+            streamDuration = Math.min(streamDuration, creditsRemaining);
+          }
+        }
       }
 
       lineupItem = await this.createLineupItem(

--- a/server/src/stream/StreamProgramCalculator.ts
+++ b/server/src/stream/StreamProgramCalculator.ts
@@ -249,14 +249,14 @@ export class StreamProgramCalculator {
           const creditsRemaining =
             outroChapter.startTime - currentProgram.timeElapsed;
           if (creditsRemaining <= 0) {
-            // Tuned in during credits — show filler for remaining slot time
-            currentProgram = {
-              ...currentProgram,
-              program: {
-                ...createOfflineStreamLineupItem(streamDuration, req.startTime),
-                programBeginMs: currentProgram.program.programBeginMs,
-              },
-            };
+            // Credits are already playing — advance past this program's
+            // remaining slot time so the next program starts immediately.
+            const remainingSlotTime =
+              currentProgram.program.duration - currentProgram.timeElapsed;
+            return await this.getCurrentLineupItem({
+              ...req,
+              startTime: req.startTime + remainingSlotTime + 1,
+            });
           } else {
             // Cap stream duration to end when credits begin
             streamDuration = Math.min(streamDuration, creditsRemaining);

--- a/server/src/testing/fakes/FakeChannelDB.ts
+++ b/server/src/testing/fakes/FakeChannelDB.ts
@@ -233,6 +233,7 @@ export class FakeChannelDB implements IChannelDB {
         | undefined;
     } | null;
     subtitlesEnabled: number;
+    skipCredits: number;
   } | null> {
     throw new Error('Method not implemented.');
   }

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -148,6 +148,7 @@ export const ChannelSchema = z.object({
   sessions: z.array(ChannelSessionSchema).optional(),
   subtitlesEnabled: z.boolean(),
   subtitlePreferences: z.array(SubtitlePreference).nonempty().optional(),
+  skipCredits: z.boolean().default(false),
 });
 
 export const SaveableChannelSchema = ChannelSchema.omit({

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -188,6 +188,33 @@ export default function ChannelTranscodingConfig() {
             </FormControl>
           </Stack>
         </Box>
+        <Box>
+          <Typography sx={{ mb: 1 }} variant="h5">
+            Playback
+          </Typography>
+          <Typography variant="subtitle1">
+            Control playback behavior for programs on this channel.
+          </Typography>
+          <FormControlLabel
+            label="Skip End Credits"
+            sx={{ mt: 1 }}
+            control={
+              <Controller
+                control={control}
+                name="skipCredits"
+                render={({ field }) => (
+                  <Switch {...field} checked={field.value} />
+                )}
+              />
+            }
+          />
+          <FormHelperText>
+            When enabled, programs with detected end credits will stop playback
+            before credits begin. The remaining time is filled with configured
+            filler content. Requires credit markers from Plex (via library
+            scan).
+          </FormHelperText>
+        </Box>
         <Stack gap={1}>
           <Stack>
             <Typography sx={{ mb: 1 }} variant="h5">

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -107,6 +107,7 @@ const EditChannelTabsProps: EditChannelTabProps[] = [
       'streamMode',
       'subtitlesEnabled',
       'subtitlePreferences',
+      'skipCredits',
     ],
   },
 ];

--- a/web/src/generated/types.gen.ts
+++ b/web/src/generated/types.gen.ts
@@ -2037,6 +2037,7 @@ export type GetChannelsResponses = {
             allowExternal: boolean;
             filter: 'none' | 'forced' | 'default' | 'any';
         }>;
+        skipCredits: boolean;
     }>;
 };
 
@@ -2103,6 +2104,7 @@ export type CreateChannelV2Data = {
                 allowExternal: boolean;
                 filter?: 'none' | 'forced' | 'default' | 'any';
             }>;
+            skipCredits: boolean;
         };
     } | {
         type: 'copy';
@@ -2238,6 +2240,7 @@ export type CreateChannelV2Responses = {
             allowExternal: boolean;
             filter: 'none' | 'forced' | 'default' | 'any';
         }>;
+        skipCredits: boolean;
     };
 };
 
@@ -2396,6 +2399,7 @@ export type GetChannelsByNumberV2Responses = {
             allowExternal: boolean;
             filter: 'none' | 'forced' | 'default' | 'any';
         }>;
+        skipCredits: boolean;
     };
 };
 
@@ -2460,6 +2464,7 @@ export type PutApiChannelsByIdData = {
             allowExternal: boolean;
             filter?: 'none' | 'forced' | 'default' | 'any';
         }>;
+        skipCredits: boolean;
     };
     path: {
         id: string;
@@ -2589,6 +2594,7 @@ export type PutApiChannelsByIdResponses = {
             allowExternal: boolean;
             filter: 'none' | 'forced' | 'default' | 'any';
         }>;
+        skipCredits: boolean;
     };
 };
 
@@ -8076,6 +8082,7 @@ export type GetApiChannelsByIdScheduleResponses = {
                         allowExternal: boolean;
                         filter: 'none' | 'forced' | 'default' | 'any';
                     }>;
+                    skipCredits: boolean;
                 } | null;
                 isMissing: boolean;
             } | {
@@ -8322,6 +8329,7 @@ export type GetApiChannelsByIdScheduleResponses = {
                         allowExternal: boolean;
                         filter: 'none' | 'forced' | 'default' | 'any';
                     }>;
+                    skipCredits: boolean;
                 } | null;
                 isMissing: boolean;
             } | {

--- a/web/src/helpers/constants.ts
+++ b/web/src/helpers/constants.ts
@@ -39,6 +39,7 @@ export const DefaultChannel: MarkOptional<
   programCount: 0,
   streamMode: 'hls',
   subtitlesEnabled: false,
+  skipCredits: false,
 } as const;
 
 export const TranscodeResolutionOptions = [


### PR DESCRIPTION
Adds a per-channel "Skip End Credits" toggle. When enabled, programs stop playback when credits begin (using Plex credit markers already stored as chapter data) and the next program starts immediately. The existing flex/filler system fills any remaining schedule gaps naturally.

### Changes

- **Channel schema + migration 0038**: Add `skipCredits` boolean column, wired through DB converters, API types, and OpenAPI spec
- **StreamProgramCalculator**: Cap `streamDuration` at outro start time.
  If the viewer tunes in during credits, advance to the next program
- **Web UI**: Toggle under new Playback section in channel Streaming settings
- **Tests**: 5 new tests (duration cap, mid-credits advance, no-outro passthrough, disabled toggle, filler item immunity)

### Notes

- Depends on correct `outro` chapter types from #1654
- Only affects programs with Plex credit markers. Programs without markers play normally regardless of the toggle.
- Defaults to off. No behavior change for existing channels.