### PR TITLE
fix: remove deleted channels from guide cache

### DIFF
--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -349,11 +349,9 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
       await req.serverCtx.m3uService.regenerateCache();
 
       try {
-        GlobalScheduler.getScheduledJob(UpdateXmlTvTask.ID)
-          .runNow()
-          .catch((err) => logger.error(err, 'Error regenerating guide'));
+        await req.serverCtx.guideService.removeCachedChannel(channel.uuid);
       } catch (e) {
-        logger.error(e, 'Unable to update guide after lineup update %O');
+        logger.error(e, 'Error removing channel from guide cache');
       }
 
       return res.send();

--- a/server/src/services/TvGuideService.test.ts
+++ b/server/src/services/TvGuideService.test.ts
@@ -135,4 +135,56 @@ describe('TVGuideService', () => {
       expect(secondWriteChannelIds).not.toContain(channelB.channel.uuid);
     });
   });
+
+  describe('removeCachedChannel', () => {
+    it('immediately removes the channel from XMLTV output', async () => {
+      const channelA = makeChannelWithLineup({ number: 1, name: 'Channel A' });
+      const channelB = makeChannelWithLineup({ number: 2, name: 'Channel B' });
+
+      const mockLoadAllLineups = vi.fn().mockResolvedValue({
+        [channelA.channel.uuid]: channelA,
+        [channelB.channel.uuid]: channelB,
+      });
+
+      const mockGetProgramsByIds = vi.fn().mockResolvedValue([]);
+      const mockWrite = vi.fn().mockResolvedValue(undefined);
+
+      const service = new TVGuideService(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        makeMockLogger() as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { write: mockWrite } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { push: vi.fn() } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { loadAllLineups: mockLoadAllLineups } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { getProgramsByIds: mockGetProgramsByIds } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+      );
+
+      const guideDuration = dayjs.duration({ hours: 4 });
+
+      // Populate the cache with both channels
+      await service.buildAllChannels(guideDuration, true);
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+
+      // Simulate the delete endpoint: channel B is gone from DB, remove from cache
+      await service.removeCachedChannel(channelB.channel.uuid);
+
+      expect(mockWrite).toHaveBeenCalledTimes(2);
+      const writeChannelIds = (
+        mockWrite.mock.calls[1][0] as MaterializedChannelPrograms[]
+      ).map((entry) => entry.channel.uuid);
+      expect(writeChannelIds).toContain(channelA.channel.uuid);
+      expect(writeChannelIds).not.toContain(channelB.channel.uuid);
+    });
+  });
 });

--- a/server/src/services/TvGuideService.ts
+++ b/server/src/services/TvGuideService.ts
@@ -334,6 +334,20 @@ export class TVGuideService {
   }
 
   /**
+   * Removes a deleted channel from the cached guide and rewrites the XMLTV
+   * file immediately. This mirrors updateCachedChannel but for deletion.
+   */
+  async removeCachedChannel(channelId: string) {
+    delete this.cachedGuide[channelId];
+    delete this.lastUpdateTime[channelId];
+    delete this.lastEndTime[channelId];
+    delete this.currentUpdateTime[channelId];
+    delete this.currentEndTime[channelId];
+
+    return await this.writeXmlTv();
+  }
+
+  /**
    * Materialize a guide for a specific channel
    * @returns Materialized guide for a channel within the date range
    */


### PR DESCRIPTION
Fixes an issue where deleted channels were returned in XMLTV data until the server was restarted.