### PR TITLE
Smart grouping for marathon style channels

### DIFF
--- a/server/src/db/ChannelDB.ts
+++ b/server/src/db/ChannelDB.ts
@@ -355,6 +355,11 @@ export class ChannelDB implements IChannelDB {
                 artist: true,
                 album: true,
                 externalIds: true,
+                tags: {
+                  with: {
+                    tag: true,
+                  },
+                },
               },
             },
           },

--- a/server/src/db/ProgramDB.ts
+++ b/server/src/db/ProgramDB.ts
@@ -2549,6 +2549,11 @@ export class ProgramDB implements IProgramDB {
             ? true
             : undefined,
         externalIds: true,
+        tags: {
+          with: {
+            tag: true,
+          },
+        },
       },
       orderBy: (fields, { asc }) => [
         asc(fields.seasonNumber),

--- a/server/src/services/scheduling/ProgramIterator.ts
+++ b/server/src/services/scheduling/ProgramIterator.ts
@@ -128,9 +128,13 @@ export function getProgramOrderer(
 // There is probably a way to make this typesafe by asserting the
 // programming subtype, but I haven't figured it out yet.
 export function slotIteratorKey<T extends BaseSlot>(slot: T): SlotIteratorKey {
+  const groupSuffix =
+    (slot.type === 'movie' || slot.type === 'smart-collection') && slot.groupBy
+      ? '_grouped'
+      : '';
   switch (slot.type) {
     case 'movie':
-      return `movie_${slot.order}`;
+      return `movie_${slot.order}${groupSuffix}` as SlotIteratorKey;
     case 'show':
       return `tv_${slot.showId}_${slot.order}`;
     case 'redirect':
@@ -140,7 +144,7 @@ export function slotIteratorKey<T extends BaseSlot>(slot: T): SlotIteratorKey {
     case 'filler':
       return `filler_${slot.fillerListId}_${slot.order}`;
     case 'smart-collection':
-      return `smart_collection_${slot.smartCollectionId}_${slot.order}`;
+      return `smart_collection_${slot.smartCollectionId}_${slot.order}${groupSuffix}` as SlotIteratorKey;
     case 'flex':
       return 'flex';
   }

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -14,6 +14,7 @@ import type {
   BaseSlot,
   FillerProgrammingSlot,
   SlotFillerTypes,
+  SlotGroupBy,
 } from '@tunarr/types/api';
 import { FillerTypes } from '@tunarr/types/schemas';
 import type { Duration } from 'dayjs/plugin/duration.js';
@@ -345,18 +346,37 @@ export function createProgramIterators(
               .with({ type: 'movie' }, () => 'movie')
               .with({ type: 'show' }, (show) => `show.${show.showId}`)
               .exhaustive();
+            const groupByConfig =
+              slot.type === 'movie' ? slot.groupBy : undefined;
             return getContentProgramIterator(
               programBySlotType,
               slotId,
               slot,
               random,
+              groupByConfig,
             );
           })
           .with({ type: 'smart-collection' }, (slot) => {
-            const programs =
+            let programs =
               programBySlotType.smartCollection[
                 smartCollectionId(slot.smartCollectionId)
               ] ?? [];
+            if (slot.groupBy) {
+              programs = groupProgramsByTag(
+                programs,
+                slot.groupBy,
+                slot.order,
+                random,
+              );
+              const indexMap = new Map(
+                programs.map((p, i) => [p.uuid, i]),
+              );
+              return new ContentProgramOrderedIterator(
+                programs,
+                (p) => indexMap.get(p.uuid) ?? 0,
+                true,
+              );
+            }
             switch (slot.order) {
               case 'next':
               case 'alphanumeric':
@@ -474,11 +494,118 @@ export function slotFillerIterators(
   return out;
 }
 
+/**
+ * Groups programs by their tags for marathon-style playback.
+ * Programs within each group are always sorted chronologically.
+ * Group order is determined by the slot's order setting.
+ *
+ * When order is 'shuffle', groups are shuffled using the provided Random.
+ * When order is 'alphanumeric', groups are sorted A-Z by tag name.
+ * When order is 'next' or 'chronological', groups are sorted by earliest year.
+ * When order is 'ordered_shuffle', groups are sorted then rotated randomly.
+ */
+export function groupProgramsByTag(
+  programs: SlotSchedulerProgram[],
+  groupBy: SlotGroupBy,
+  order: string,
+  random: Random,
+): SlotSchedulerProgram[] {
+  const groups = new Map<string, SlotSchedulerProgram[]>();
+  const ungrouped: SlotSchedulerProgram[] = [];
+
+  for (const program of programs) {
+    const tags = program.tags?.map((t) => t.tag.tag).filter(Boolean) ?? [];
+
+    if (tags.length === 0) {
+      if (groupBy.ungrouped === 'include') {
+        ungrouped.push(program);
+      }
+      continue;
+    }
+
+    const tagsToUse =
+      groupBy.multiTagBehavior === 'first' ? [tags[0]!] : tags;
+
+    for (const tag of tagsToUse) {
+      const existing = groups.get(tag) ?? [];
+      existing.push(program);
+      groups.set(tag, existing);
+    }
+  }
+
+  // Sort programs within each group chronologically by year
+  const sortChronologically = (
+    a: SlotSchedulerProgram,
+    b: SlotSchedulerProgram,
+  ) => {
+    const aDate = a.year ?? 0;
+    const bDate = b.year ?? 0;
+    return aDate - bDate;
+  };
+
+  for (const [, groupPrograms] of groups) {
+    groupPrograms.sort(sortChronologically);
+  }
+
+  // Order the groups based on the slot's order setting
+  let orderedGroupKeys = [...groups.keys()];
+
+  switch (order) {
+    case 'alphanumeric':
+      orderedGroupKeys.sort();
+      break;
+    case 'next':
+    case 'chronological': {
+      // Sort groups by earliest year in the group
+      orderedGroupKeys.sort((a, b) => {
+        const aMin = groups.get(a)![0]?.year ?? 0;
+        const bMin = groups.get(b)![0]?.year ?? 0;
+        return aMin - bMin;
+      });
+      break;
+    }
+    case 'shuffle':
+      // Shuffle the group order
+      orderedGroupKeys = random.shuffle(orderedGroupKeys);
+      break;
+    case 'ordered_shuffle': {
+      // Sort then rotate randomly
+      orderedGroupKeys.sort((a, b) => {
+        const aMin = groups.get(a)![0]?.year ?? 0;
+        const bMin = groups.get(b)![0]?.year ?? 0;
+        return aMin - bMin;
+      });
+      if (orderedGroupKeys.length > 1) {
+        const rotation = random.integer(0, orderedGroupKeys.length - 1);
+        orderedGroupKeys = [
+          ...orderedGroupKeys.slice(rotation),
+          ...orderedGroupKeys.slice(0, rotation),
+        ];
+      }
+      break;
+    }
+  }
+
+  // Flatten groups into final program list
+  const result: SlotSchedulerProgram[] = [];
+  for (const key of orderedGroupKeys) {
+    result.push(...groups.get(key)!);
+  }
+
+  // Append ungrouped programs as individual entries
+  for (const program of ungrouped) {
+    result.push(program);
+  }
+
+  return result;
+}
+
 function getContentProgramIterator(
   programBySlotType: ProgramMapping,
   contentSlotId: ContentSlotId,
   slot: BaseMovieProgrammingSlot | BaseShowProgrammingSlot,
   random: Random,
+  groupBy?: SlotGroupBy,
 ) {
   let programs = uniqBy(
     programBySlotType.content[contentSlotId] ?? [],
@@ -490,6 +617,18 @@ function getContentProgramIterator(
       const season = program.season?.index ?? program.seasonNumber;
       return season && slot.seasonFilter.includes(season);
     });
+  }
+
+  if (groupBy) {
+    programs = groupProgramsByTag(programs, groupBy, slot.order, random);
+    // When grouping is active, use an ordered iterator that preserves
+    // the pre-computed group order. Build an index map for O(1) lookups.
+    const indexMap = new Map(programs.map((p, i) => [p.uuid, i]));
+    return new ContentProgramOrderedIterator(
+      programs,
+      (p) => indexMap.get(p.uuid) ?? 0,
+      true, // Always asc since groupProgramsByTag already ordered correctly
+    );
   }
 
   switch (slot.order) {

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -586,15 +586,25 @@ export function groupProgramsByTag(
     }
   }
 
-  // Flatten groups into final program list
+  // Flatten groups into final program list, deduplicating programs
+  // that appear in multiple groups (when multiTagBehavior === 'all')
   const result: SlotSchedulerProgram[] = [];
+  const seen = new Set<string>();
   for (const key of orderedGroupKeys) {
-    result.push(...groups.get(key)!);
+    for (const program of groups.get(key)!) {
+      if (!seen.has(program.uuid)) {
+        seen.add(program.uuid);
+        result.push(program);
+      }
+    }
   }
 
   // Append ungrouped programs as individual entries
   for (const program of ungrouped) {
-    result.push(program);
+    if (!seen.has(program.uuid)) {
+      seen.add(program.uuid);
+      result.push(program);
+    }
   }
 
   return result;

--- a/types/src/api/CommonSlots.ts
+++ b/types/src/api/CommonSlots.ts
@@ -43,6 +43,14 @@ export const Slot = z.object({
   filler: z.array(SlotFiller).optional(),
 });
 
+export const SlotGroupBySchema = z.object({
+  type: z.literal('tag'),
+  ungrouped: z.enum(['include', 'exclude']),
+  multiTagBehavior: z.enum(['first', 'all']),
+});
+
+export type SlotGroupBy = z.infer<typeof SlotGroupBySchema>;
+
 //
 // Base slots
 //
@@ -51,6 +59,7 @@ export const MovieProgrammingSlotSchema = z.object({
   type: z.literal('movie'),
   ...BaseSlotOrdering.shape,
   ...Slot.shape,
+  groupBy: SlotGroupBySchema.optional(),
 });
 
 export type BaseMovieProgrammingSlot = z.infer<
@@ -104,6 +113,7 @@ export const SmartCollectionProgrammingSlot = z.object({
   smartCollectionId: z.uuid(),
   ...BaseSlotOrdering.shape,
   ...Slot.shape,
+  groupBy: SlotGroupBySchema.optional(),
 });
 
 export const BaseSlotSchema = z.discriminatedUnion('type', [

--- a/web/src/components/slot_scheduler/EditSlotProgrammingForm.tsx
+++ b/web/src/components/slot_scheduler/EditSlotProgrammingForm.tsx
@@ -13,6 +13,7 @@ import { CustomShowSlotProgrammingForm } from './CustomShowSlotProgrammingForm.t
 import { FillerListSlotProgrammingForm } from './FillerListSlotProgrammingForm.tsx';
 import { RedirectProgrammingForm } from './RedirectProgrammingForm.tsx';
 import { ShowSearchSlotProgrammingForm } from './ShowSearchSlotProgrammingForm.tsx';
+import { SlotGroupByFormControl } from './SlotGroupByFormControl.tsx';
 import { SlotOrderFormControl } from './SlotOrderFormControl.tsx';
 import { SmartCollectionSlotProgrammingForm } from './SmartCollectionSlotProgrammingForm.tsx';
 
@@ -79,7 +80,12 @@ export const EditSlotProgrammingForm = <
       {typeSelectValue === 'filler' && <FillerListSlotProgrammingForm />}
       {typeSelectValue === 'show' && <ShowSearchSlotProgrammingForm />}
       {typeSelectValue === 'redirect' && <RedirectProgrammingForm />}
-      {typeSelectValue === 'movie' && <SlotOrderFormControl />}
+      {typeSelectValue === 'movie' && (
+        <>
+          <SlotOrderFormControl />
+          <SlotGroupByFormControl />
+        </>
+      )}
     </>
   );
 };

--- a/web/src/components/slot_scheduler/SlotGroupByFormControl.tsx
+++ b/web/src/components/slot_scheduler/SlotGroupByFormControl.tsx
@@ -1,0 +1,84 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+} from '@mui/material';
+import type { SlotGroupBy } from '@tunarr/types/api';
+import { Controller, useFormContext } from 'react-hook-form';
+
+type SlotWithGroupBy = {
+  groupBy?: SlotGroupBy;
+};
+
+export const SlotGroupByFormControl = () => {
+  const { control, watch, setValue } = useFormContext<SlotWithGroupBy>();
+  const groupBy = watch('groupBy');
+  const isEnabled = !!groupBy;
+
+  const handleToggle = (checked: boolean) => {
+    if (checked) {
+      setValue('groupBy', {
+        type: 'tag',
+        ungrouped: 'include',
+        multiTagBehavior: 'first',
+      });
+    } else {
+      setValue('groupBy', undefined);
+    }
+  };
+
+  return (
+    <Stack spacing={2}>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={isEnabled}
+            onChange={(_, checked) => handleToggle(checked)}
+          />
+        }
+        label="Group by Tag"
+      />
+      {isEnabled && (
+        <>
+          <FormHelperText>
+            Group programs by shared tags for marathon-style playback. Programs
+            within each group play in chronological order.
+          </FormHelperText>
+          <Controller
+            control={control}
+            name="groupBy.ungrouped"
+            render={({ field }) => (
+              <FormControl fullWidth size="small">
+                <InputLabel>Untagged Programs</InputLabel>
+                <Select label="Untagged Programs" {...field}>
+                  <MenuItem value="include">
+                    Include as individual items
+                  </MenuItem>
+                  <MenuItem value="exclude">Exclude</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            name="groupBy.multiTagBehavior"
+            render={({ field }) => (
+              <FormControl fullWidth size="small">
+                <InputLabel>Multi-tag Behavior</InputLabel>
+                <Select label="Multi-tag Behavior" {...field}>
+                  <MenuItem value="first">First matching tag</MenuItem>
+                  <MenuItem value="all">All matching groups</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+          />
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/web/src/components/slot_scheduler/SmartCollectionSlotProgrammingForm.tsx
+++ b/web/src/components/slot_scheduler/SmartCollectionSlotProgrammingForm.tsx
@@ -5,6 +5,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import type { SmartCollectionOption } from '../../helpers/slotSchedulerUtil.ts';
 import { useSlotProgramOptionsContext } from '../../hooks/programming_controls/useSlotProgramOptions.ts';
 import type { CommonSmartCollectionViewModel } from '../../model/CommonSlotModels.ts';
+import { SlotGroupByFormControl } from './SlotGroupByFormControl.tsx';
 import { SlotOrderFormControl } from './SlotOrderFormControl.tsx';
 
 export const SmartCollectionSlotProgrammingForm = () => {
@@ -53,6 +54,7 @@ export const SmartCollectionSlotProgrammingForm = () => {
         )}
       />
       <SlotOrderFormControl />
+      <SlotGroupByFormControl />
     </>
   );
 };

--- a/web/src/model/CommonSlotModels.ts
+++ b/web/src/model/CommonSlotModels.ts
@@ -4,6 +4,7 @@ import type { RandomSlotForm } from './SlotModels.ts';
 import {
   BaseSlotOrdering,
   SlotFiller,
+  SlotGroupBySchema,
   SlotProgrammingFillerOrder,
 } from '@tunarr/types/api';
 import {
@@ -21,6 +22,7 @@ export const WithSlotFiller = z.object({
 
 export const CommonMovieSlotViewModel = z.object({
   type: z.literal('movie'),
+  groupBy: SlotGroupBySchema.optional(),
 });
 
 export const CommonCustomShowSlotViewModel = z.object({
@@ -81,6 +83,7 @@ export const CommonSmartCollectionViewModel = z.object({
   smartCollectionId: z.uuid(),
   smartCollection: SmartCollection.nullable(),
   isMissing: z.boolean().optional().default(false),
+  groupBy: SlotGroupBySchema.optional(),
 });
 
 export type CommonSmartCollectionViewModel = z.infer<


### PR DESCRIPTION
I wanted to make a channel where I had "marathon" style playback so different movie series would get grouped together in chronological release order. The only way I saw this working was with the tags attribute on each movie, in my case with plex they include enough information to link collections together as each movie series has the same collection tag.

I'm not too familiar with this repo yet but was able to add this to the slots editor functionality with help of claude. Please excuse any mistakes, will work on any suggestions and improvements as necessary. Would love for help in testing and making this feature better, I have pushed a tagged build on my fork `ghcr.io/stasadance/tunarr:smart-grouping`

<img width="877" height="257" alt="image" src="https://github.com/user-attachments/assets/df8c8362-3065-441b-a943-e3f194984598" />


 ## Summary
   - Adds a **Group by Tag** toggle to movie and smart collection slots, enabling marathon-style playback where
   programs sharing a tag (e.g., "Harry Potter Collection") play back-to-back
   - Groups are ordered by the slot's existing order setting (shuffle, alphabetical, chronological, etc.), while
   programs within each group always play in chronological/release order
   - Configurable options for untagged programs (include as individuals or exclude) and multi-tag behavior (first
   match or all matching groups, deduplicated)

   ## Changes
   - **Types**: New `SlotGroupBySchema` with `type`, `ungrouped`, and `multiTagBehavior` fields; added optional
   `groupBy` to movie and smart-collection slot schemas
   - **Server DB**: Added tag relation loading to `getChannelAndPrograms` and `getProgramGroupingDescendants` so tags
    are available during scheduling
   - **Server Scheduling**: New `groupProgramsByTag()` pre-processing step that buckets programs by tag, sorts within
    groups chronologically, orders groups by slot order, and deduplicates across groups
   - **Web UI**: New `SlotGroupByFormControl` component with toggle switch and dropdown options, added to movie slot
   and smart collection slot editors