### PR TITLE
fix(server): MeiliSearch --schedule-snapshot arg push changed to use .asSeconds()

### DIFF
--- a/server/src/services/MeilisearchService.ts
+++ b/server/src/services/MeilisearchService.ts
@@ -504,7 +504,7 @@ export class MeilisearchService implements ISearchService {
                 this.settingsDB.systemSettings().server.searchSettings
                   .snapshotIntervalHours,
             })
-            .asMinutes()
+            .asSeconds()
             .toFixed(0),
           '--snapshot-dir',
           this.fileSystemService.getMsSnapshotsPath(),


### PR DESCRIPTION
Previously used .asMinutes() but the CLI wants the arg as seconds. This change fixes the MS snapshot from being pulled every X minutes to every X hours.