### PR TITLE
fix: apply path replacements sequentially and use replaceAll

### DIFF
--- a/server/src/stream/PathCalculator.ts
+++ b/server/src/stream/PathCalculator.ts
@@ -1,4 +1,3 @@
-import { replace } from 'lodash-es';
 import type { MediaSourceLibraryReplacePath } from '../db/schema/MediaSourceLibraryReplacePath.ts';
 import { fileExists } from '../util/fsUtil.ts';
 
@@ -11,8 +10,21 @@ export class PathCalculator {
       return;
     }
 
+    // Apply all replacements sequentially, each building on the previous result.
+    // This handles cases like Windows→Linux path conversion where you need
+    // both a prefix swap (D:\media → /data) and separator conversion (\ → /).
+    let sequentialResult = inPath;
     for (const { localPath, serverPath } of replacements) {
-      const replaced = replace(inPath, serverPath, localPath);
+      sequentialResult = sequentialResult.replaceAll(serverPath, localPath);
+    }
+
+    if (sequentialResult !== inPath && (await fileExists(sequentialResult))) {
+      return sequentialResult;
+    }
+
+    // Fall back to trying each replacement independently.
+    for (const { localPath, serverPath } of replacements) {
+      const replaced = inPath.replaceAll(serverPath, localPath);
       if (await fileExists(replaced)) {
         return replaced;
       }


### PR DESCRIPTION
## Summary

Fixes #1700

`PathCalculator.findFirstValidPath()` previously tried each path replacement **independently** against the original path, using `lodash.replace()` which wraps `String.prototype.replace()` — this only replaces the **first occurrence**. This caused Windows→Linux path mappings to silently fail, forcing all media to stream over HTTP from Plex instead of being read from disk.

### The bug

Given a Plex-reported path `D:\media\movies\Movie\file.mkv` and two replacements:
1. `D:\media` → `/data`
2. `\` → `/`

**Before (broken):** Each replacement is tried independently against the original path:
- Replacement 1 produces `/data\movies\Movie\file.mkv` — mixed slashes, `fileExists()` fails
- Replacement 2 produces `D:/media\movies\Movie\file.mkv` — only first `\` replaced, `fileExists()` fails
- Both fail → falls back to Plex HTTP streaming

**After (fixed):** Replacements are applied sequentially, each building on the previous result:
- After replacement 1: `/data\movies\Movie\file.mkv`
- After replacement 2: `/data/movies/Movie/file.mkv` ← valid path, `fileExists()` succeeds
- Tunarr reads directly from disk

### Changes

- Try applying all replacements **sequentially** first (each builds on previous result)
- Fall back to **independent** replacement for backward compatibility
- Use native `String.replaceAll()` instead of lodash `replace()` to handle all occurrences
- Remove unused `lodash-es` `replace` import

### Verified

Tested inside a Tunarr Docker container (v1.2.0-dev.8) with media mounted at `/data`:
```javascript
// Broken path (what current code produces):
fs.statSync('/data\movies/Movie/file.mkv');  // ENOENT

// Fixed path (what this PR produces):
fs.statSync('/data/movies/Movie/file.mkv');   // Success
```

## Test plan

- [ ] Configure a Plex media source with Windows-style path replacements (`D:\media` → `/data`, `\` → `/`)
- [ ] Start a channel stream in HLS mode
- [ ] Verify ffmpeg `-i` argument uses a local file path (e.g., `/data/movies/...`) instead of `http://plex-ip:32400/library/parts/...`
- [ ] Verify existing single-replacement configurations still work (backward compatible)


🤖 Generated with [Claude Code](https://claude.com/claude-code)