### PR TITLE
Include default URL for Tunarr in setup guide

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -2,7 +2,7 @@
 
 ## Initial Setup
 
-Upon first launching Tunarr, you will see the Welcome page with a few required setup steps.
+Upon first launching Tunarr, you will see the Welcome page with a few required setup steps. By default, Tunarr will be available at http://localhost:8000.
 
 ![Welcome Page Plex-Jellyfin](../assets/add-media-source.png)
 


### PR DESCRIPTION
Added default URL for Tunarr in setup instructions. The macOS binary doesn't automatically open a browser window to the welcome page and it took me an embarrassing long time to find the URL to access it manually.