### PR TITLE
fix: remove improper parameter from software tonemap filter

### DIFF
--- a/server/src/ffmpeg/builder/filter/TonemapFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/TonemapFilter.test.ts
@@ -28,7 +28,7 @@ describe('TonemapFilter', () => {
     expect(filter.filter).to.eq(
       'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,' +
         'tonemap=tonemap=hable:desat=0,' +
-        'zscale=s=bt709:t=bt709:m=bt709:r=tv,format=yuv420p',
+        'zscale=t=bt709:m=bt709:r=tv,format=yuv420p',
     );
   });
 
@@ -47,7 +47,7 @@ describe('TonemapFilter', () => {
       'hwdownload,format=p010le|nv12,' +
         'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,' +
         'tonemap=tonemap=hable:desat=0,' +
-        'zscale=s=bt709:t=bt709:m=bt709:r=tv,format=yuv420p',
+        'zscale=t=bt709:m=bt709:r=tv,format=yuv420p',
     );
   });
 

--- a/server/src/ffmpeg/builder/filter/TonemapFilter.ts
+++ b/server/src/ffmpeg/builder/filter/TonemapFilter.ts
@@ -15,7 +15,7 @@ export class TonemapFilter extends FilterOption {
     const transfer = this.currentState.colorFormat?.colorTransfer;
     // DV Profile 5 may have `color_transfer = null/unknown` explicitly specify so zscale does not incorrectly convert PQ when color transfer is unknown
     const tinParam = transfer ? `:tin=${transfer}` : '';
-    const tonemap = `zscale=t=linear${tinParam}:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=s=bt709:t=bt709:m=bt709:r=tv,format=yuv420p`;
+    const tonemap = `zscale=t=linear${tinParam}:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p`;
     return this.currentState.frameDataLocation === FrameDataLocation.Hardware
       ? `hwdownload,format=p010le|nv12,${tonemap}`
       : tonemap;


### PR DESCRIPTION
An improper parameter was added to `TonemapFilter` causing playback errors.