### PR TITLE
build: add shell.nix for local development

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,12 +37,5 @@ pkgs.mkShell {
     echo "  node: $(node --version)"
     echo "  pnpm: $(pnpm --version 2>/dev/null)"
     echo "  ffmpeg: $(ffmpeg -version 2>&1 | head -1)"
-    echo ""
-    echo "Common commands:"
-    echo "  pnpm i               - Install dependencies"
-    echo "  pnpm turbo dev       - Start backend (:8000) and frontend (:5173)"
-    echo "  pnpm turbo build     - Build all packages"
-    echo "  pnpm turbo test      - Run tests"
-    echo "  pnpm turbo typecheck - Run typechecker"
   '';
 }


### PR DESCRIPTION
Adds `shell.nix` with dependencies required for local development, so I don't need to have them installed globally.

Launch using `nix-shell`.

on linux:

```bash
% nix-shell
Tunarr dev environment
  node: v22.22.0
  pnpm: 10.28.0
  ffmpeg: ffmpeg version n7.1.1-56-gc2184b65d2-20250716 Copyright (c) 2000-2025 the FFmpeg developers

[nix-shell:~/code/tunarr]$
```

on mac:

```bash
% nix-shell
Tunarr dev environment
  node: v22.22.1
  pnpm: 10.28.0
  ffmpeg: ffmpeg version 7.1.3 Copyright (c) 2000-2025 the FFmpeg developers

[nix-shell:~/code/tunarr]$
```