### PR TITLE
fix: improve mobile container size on small devices

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,11 +50,11 @@ export function Root({ children }: { children?: React.ReactNode }) {
           disableGutters
           maxWidth="xl"
           sx={{
-            mt: 4,
+            mt: [2, 4],
             mb: ['56px', 4],
-            px: [undefined, 5],
+            px: [2, 5],
             pb: [4, undefined],
-            maxWidth: 'calc(100vw - 240px)',
+            maxWidth: { xs: '100vw', sm: 'calc(100vw - 240px)' },
             flexGrow: 1,
           }}
         >


### PR DESCRIPTION
This change addresses the issue of container size being too small in mobile as mentioned in #1728.

Some before and after screenshots:

| Before               | After               |
| ---------------------- | ---------------------- |
| <img width="402" height="754" alt="guide-before" src="https://github.com/user-attachments/assets/551e0251-aaba-462c-86a8-e570b8d16d37" /> | <img width="402" height="754" alt="guide-after" src="https://github.com/user-attachments/assets/f2620be6-c485-4466-9d91-ffc0424a8c38" /> |
| <img width="402" height="754" alt="channels-before" src="https://github.com/user-attachments/assets/98c9bfa0-3d5d-40e7-8ce4-a2a635f756a7" /> | <img width="402" height="754" alt="channels-after" src="https://github.com/user-attachments/assets/e3f8e96c-ab13-4762-b590-808c28642348" /> |
| <img width="402" height="754" alt="library-before" src="https://github.com/user-attachments/assets/7881874e-f0f2-4841-96c9-d76934be1dd1" /> | <img width="402" height="754" alt="library-after" src="https://github.com/user-attachments/assets/0e1afdc2-1243-4be6-8808-649409a00eb2" /> |
| <img width="402" height="754" alt="mediasources-before" src="https://github.com/user-attachments/assets/67c8b0ae-2e64-4f9c-9fc9-bf7a1fa17a85" /> | <img width="402" height="754" alt="mediasources-after" src="https://github.com/user-attachments/assets/20697f4f-0252-471a-9833-3f667988d872" /> |
| <img width="402" height="754" alt="system-before" src="https://github.com/user-attachments/assets/6922487f-85c3-4da4-a252-2f76b7ff90e8" /> | <img width="402" height="754" alt="system-after" src="https://github.com/user-attachments/assets/afc0f754-2dbd-44f7-a232-494222492215" /> |
| <img width="402" height="754" alt="settings-before" src="https://github.com/user-attachments/assets/e6c421ca-248a-4207-b8b0-986c786ff25f" /> | <img width="402" height="754" alt="settings-after" src="https://github.com/user-attachments/assets/9b952b23-5af5-4b47-a2f0-6712f0564542" /> |



