### PR TITLE
guard against non-finite values in stream play time cache

### DIFF
--- a/server/src/stream/ChannelCache.ts
+++ b/server/src/stream/ChannelCache.ts
@@ -101,15 +101,27 @@ export class ChannelCache implements IStreamLineupCache {
       remaining = lineupItem.duration - (lineupItem.startOffset ?? 0);
     }
 
+    const playTime = t0 + remaining;
+
+    if (!Number.isFinite(playTime)) {
+      this.logger.warn(
+        'Refusing to write non-finite playTime for channel %s (t0=%s, remaining=%s)',
+        channelId,
+        t0,
+        remaining,
+      );
+      return;
+    }
+
     if (lineupItem.type === 'program') {
       const key = this.getKey(channelId, lineupItem.program.uuid);
-      await this.persistentChannelCache.setProgramPlayTime(key, t0 + remaining);
+      await this.persistentChannelCache.setProgramPlayTime(key, playTime);
     }
 
     if (isCommercialLineupItem(lineupItem)) {
       await this.persistentChannelCache.setFillerPlayTime(
         this.getKey(channelId, lineupItem.fillerListId),
-        t0 + remaining,
+        playTime,
       );
     }
   }


### PR DESCRIPTION
`recordProgramPlayTime` in `ChannelCache.ts` can write NaN to the persistent stream cache when lineupItem.duration is undefined or when upstream time calculations produce non-finite values. Once written, JSON.stringify(NaN) becomes null, which fails Zod validation on the next cache read. This causes a bug that I've been facing recently which corrupts the entire guide data of all channels. 

This fix adds a Number.isFinite() check before writing to the cache. If the computed play time is non-finite, the write is skipped and a warning is logged instead of silently corrupting stream-cache.json. Users with an already-corrupted cache can delete stream caches to reset.

