### PR TITLE
fix(search): render "starts with" operator as < in filter string

### DIFF
--- a/shared/src/util/searchUtil.test.ts
+++ b/shared/src/util/searchUtil.test.ts
@@ -627,4 +627,31 @@ describe('searchFilterToString', () => {
     const request = parsedSearchToRequest(query);
     expect(searchFilterToString(request)).toEqual('genre in ["comedy"]');
   });
+
+  test('starts with renders as < not literal "starts with"', () => {
+    const filter = {
+      type: 'value',
+      fieldSpec: {
+        key: 'title',
+        name: 'title',
+        op: 'starts with',
+        type: 'string',
+        value: ['The'],
+      },
+    } satisfies SearchFilter;
+
+    expect(searchFilterToString(filter)).toEqual('title < "The"');
+  });
+
+  test('round-trips starts with through parse and stringify', () => {
+    const input = 'title < "The"';
+    const lexerResult = tokenizeSearchQuery(input);
+    expect(lexerResult.errors).toHaveLength(0);
+    const parser = new SearchParser();
+    parser.input = lexerResult.tokens;
+    const query = parser.searchExpression();
+    expect(parser.errors).toHaveLength(0);
+    const request = parsedSearchToRequest(query);
+    expect(searchFilterToString(request)).toEqual(input);
+  });
 });

--- a/shared/src/util/searchUtil.test.ts
+++ b/shared/src/util/searchUtil.test.ts
@@ -645,12 +645,7 @@ describe('searchFilterToString', () => {
 
   test('round-trips starts with through parse and stringify', () => {
     const input = 'title < "The"';
-    const lexerResult = tokenizeSearchQuery(input);
-    expect(lexerResult.errors).toHaveLength(0);
-    const parser = new SearchParser();
-    parser.input = lexerResult.tokens;
-    const query = parser.searchExpression();
-    expect(parser.errors).toHaveLength(0);
+    const query = parseAndCheckExpression(input);
     const request = parsedSearchToRequest(query);
     expect(searchFilterToString(request)).toEqual(input);
   });

--- a/shared/src/util/searchUtil.ts
+++ b/shared/src/util/searchUtil.ts
@@ -234,7 +234,16 @@ const SearchExpressionLexer = new Lexer({
   defaultMode: 'normalMode',
 });
 
-const StringOps = ['=', '!=', '<', '<=', 'in', 'not in', 'contains', 'not contains'] as const;
+const StringOps = [
+  '=',
+  '!=',
+  '<',
+  '<=',
+  'in',
+  'not in',
+  'contains',
+  'not contains',
+] as const;
 type StringOps = TupleToUnion<typeof StringOps>;
 const NumericOps = ['=', '!=', '<', '<=', '>', '>=', 'between'] as const;
 type NumericOps = TupleToUnion<typeof NumericOps>;
@@ -364,6 +373,7 @@ const indexOperatorToSyntax: Dictionary<string> = {
   contains: '~',
   'not contains': '!~',
   to: 'between',
+  'starts with': '<',
 };
 
 function normalizeReleaseDate(value: string) {


### PR DESCRIPTION
Add missing entry to `indexOperatorToSyntax` so that `searchFilterToString` converts the `starts with` API operator back to `<` instead of displaying the literal string "starts with" in the filter box. Add unit tests to prevent regression.

Fixes #1760