### PR TITLE
fix: resolve "default" transcodeConfigId to actual UUID when saving channels

### DIFF
--- a/server/src/db/ChannelDB.ts
+++ b/server/src/db/ChannelDB.ts
@@ -6,6 +6,7 @@ import {
   type IChannelDB,
 } from '@/db/interfaces/IChannelDB.js';
 import type { IProgramDB } from '@/db/interfaces/IProgramDB.js';
+import type { ITranscodeConfigDB } from '@/db/ITranscodeConfigDB.js';
 import { globalOptions } from '@/globals.js';
 import { FileSystemService } from '@/services/FileSystemService.js';
 import { CacheImageService } from '@/services/cacheImageService.js';
@@ -254,7 +255,25 @@ export class ChannelDB implements IChannelDB {
     @inject(KEYS.DrizzleDB) private drizzleDB: DrizzleDBAccess,
     @inject(MaterializeLineupCommand)
     private materializeLineupCommand: MaterializeLineupCommand,
+    @inject(KEYS.TranscodeConfigDB)
+    private transcodeConfigDB: ITranscodeConfigDB,
   ) {}
+
+  /**
+   * Resolves the transcodeConfigId, converting "default" to the actual default config UUID.
+   */
+  private async resolveTranscodeConfigId(
+    transcodeConfigId: string,
+  ): Promise<string> {
+    if (transcodeConfigId === 'default') {
+      const defaultConfig = await this.transcodeConfigDB.getDefaultConfig();
+      if (!defaultConfig) {
+        throw new Error('No default transcode config found');
+      }
+      return defaultConfig.uuid;
+    }
+    return transcodeConfigId;
+  }
 
   async channelExists(channelId: string) {
     const channel = await this.db
@@ -711,10 +730,18 @@ export class ChannelDB implements IChannelDB {
       );
     }
 
+    // Resolve "default" to actual transcode config UUID
+    const resolvedReq = {
+      ...createReq,
+      transcodeConfigId: await this.resolveTranscodeConfigId(
+        createReq.transcodeConfigId,
+      ),
+    };
+
     const channel = await this.db.transaction().execute(async (tx) => {
       const channel = await tx
         .insertInto('channel')
-        .values(createRequestToChannel(createReq))
+        .values(createRequestToChannel(resolvedReq))
         .returningAll()
         .executeTakeFirst();
 
@@ -788,7 +815,15 @@ export class ChannelDB implements IChannelDB {
       throw new ChannelNotFoundError(id);
     }
 
-    const update = updateRequestToChannel(updateReq);
+    // Resolve "default" to actual transcode config UUID
+    const resolvedReq = {
+      ...updateReq,
+      transcodeConfigId: await this.resolveTranscodeConfigId(
+        updateReq.transcodeConfigId,
+      ),
+    };
+
+    const update = updateRequestToChannel(resolvedReq);
 
     if (
       isNonEmptyString(updateReq.watermark?.url) &&

--- a/server/src/db/DBModule.ts
+++ b/server/src/db/DBModule.ts
@@ -1,7 +1,9 @@
 import { ChannelDB } from '@/db/ChannelDB.js';
 import { ProgramDB } from '@/db/ProgramDB.js';
+import { TranscodeConfigDB } from '@/db/TranscodeConfigDB.js';
 import type { IChannelDB } from '@/db/interfaces/IChannelDB.js';
 import type { IProgramDB } from '@/db/interfaces/IProgramDB.js';
+import type { ITranscodeConfigDB } from '@/db/ITranscodeConfigDB.js';
 import { KEYS } from '@/types/inject.js';
 import type { interfaces } from 'inversify';
 import { ContainerModule } from 'inversify';
@@ -14,6 +16,9 @@ import type { DB } from './schema/db.ts';
 import type { DrizzleDBAccess } from './schema/index.ts';
 
 const DBModule = new ContainerModule((bind) => {
+  bind<ITranscodeConfigDB>(KEYS.TranscodeConfigDB)
+    .to(TranscodeConfigDB)
+    .inSingletonScope();
   bind<IProgramDB>(KEYS.ProgramDB).to(ProgramDB).inSingletonScope();
   bind<IChannelDB>(KEYS.ChannelDB).to(ChannelDB).inSingletonScope();
   bind<DBAccess>(DBAccess).toSelf().inSingletonScope();

--- a/server/src/types/inject.ts
+++ b/server/src/types/inject.ts
@@ -22,6 +22,7 @@ const KEYS = {
   ProgramDB: Symbol.for('ProgramDB'),
   FillerListDB: Symbol.for('FillerListDB'),
   SettingsDB: Symbol.for('SettingsDB'),
+  TranscodeConfigDB: Symbol.for('TranscodeConfigDB'),
   MediaSourceApiFactory: Symbol.for('MediaSourceApiFactory'),
   TimeSlotSchedulerServiceFactory: Symbol.for(
     'TimeSlotSchedulerServiceFactory',


### PR DESCRIPTION
## Summary

Fixes #1772

When creating or updating a channel via the API with `transcodeConfigId: "default"`, the literal string `"default"` was being stored in the database instead of being resolved to the actual default transcode config UUID.

This caused streaming to fail with "Channel not found" because the Drizzle ORM join on `transcodeConfig` returned null when the `transcode_config_id` was not a valid UUID reference.

## Root Cause

In `ChannelDB.ts`, both `createRequestToChannel()` and `updateRequestToChannel()` passed through the `transcodeConfigId` value directly without validation or resolution.

Then in `SessionManager.ts`, the streaming code does a Drizzle join with `with: { transcodeConfig: true }`. When `transcode_config_id = 'default'` (not a valid UUID), the join returns null for `transcodeConfig`, triggering the misleading "Channel not found" error.

## Changes

- Add `ITranscodeConfigDB` injection to `ChannelDB`
- Add `resolveTranscodeConfigId()` helper method that converts `"default"` to the actual default config UUID
- Call the resolver in both `saveChannel()` and `updateChannel()` before persisting
- Add `KEYS.TranscodeConfigDB` symbol and bind `TranscodeConfigDB` in `DBModule`

## Testing

1. Created a fresh Tunarr instance
2. Created channels via API with `transcodeConfigId: "default"`
3. Verified channels now have the actual UUID stored in the database
4. Confirmed streaming works correctly
