### PR TITLE
fix: run all transactions synchronously

### DIFF
--- a/server/src/api/ApiProgramConverters.ts
+++ b/server/src/api/ApiProgramConverters.ts
@@ -26,7 +26,7 @@ import type {
   ProgramGroupingOrmWithRelations,
   ProgramWithRelationsOrm,
 } from '../db/schema/derivedTypes.ts';
-import type { MediaSourceLibraryOrm } from '../db/schema/MediaSourceLibrary.ts';
+import type { MediaSourceLibrary } from '../db/schema/MediaSourceLibrary.ts';
 import type {
   ProgramGroupingSearchDocument,
   TerminalProgramSearchDocument,
@@ -51,7 +51,7 @@ export class ApiProgramConverters {
     program: ProgramWithRelationsOrm,
     searchDoc: Maybe<TerminalProgramSearchDocument>,
     mediaSource?: MediaSourceWithRelations,
-    mediaLibrary?: MediaSourceLibraryOrm,
+    mediaLibrary?: MediaSourceLibrary,
   ): Nullable<TerminalProgram> {
     if (!program.canonicalId) {
       this.logger.warn(`Program %s doesn't have a canonicalId!`, program.uuid);
@@ -207,7 +207,7 @@ export class ApiProgramConverters {
     doc: Maybe<ProgramGroupingSearchDocument>,
     childCounts: Maybe<ProgramGroupingChildCounts>,
     mediaSource: MediaSourceWithRelations,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Nullable<ProgramGrouping> {
     if (!grouping.canonicalId) {
       this.logger.warn(

--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -56,7 +56,7 @@ import { MaterializeProgramsCommand } from '../commands/MaterializeProgramsComma
 import { RegenerateChannelLineupCommand } from '../commands/RegenerateChannelLineupCommand.ts';
 import { container } from '../container.ts';
 import { transcodeConfigOrmToDto } from '../db/converters/transcodeConfigConverters.ts';
-import type { LegacyChannelAndLineup } from '../db/interfaces/IChannelDB.ts';
+import type { ChannelAndLineup } from '../db/interfaces/IChannelDB.ts';
 import type { SessionType } from '../stream/Session.ts';
 import { Result } from '../types/result.ts';
 import { PagingParams } from '../types/schemas.ts';
@@ -159,7 +159,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
     async (req, res) => {
       try {
         const channelAndLineup =
-          await req.serverCtx.channelDB.loadChannelAndLineup(req.params.id);
+          await req.serverCtx.channelDB.loadChannelAndLineupOrm(req.params.id);
 
         if (!isNil(channelAndLineup)) {
           // TODO: This is super gnarly and we're doing this sorta custom everywhere.
@@ -217,7 +217,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
     },
     async (req, res) => {
       const body: CreateChannelRequest = req.body;
-      let insertResult: Result<LegacyChannelAndLineup>;
+      let insertResult: Result<ChannelAndLineup>;
       switch (body.type) {
         case 'copy':
           insertResult = await Result.attemptAsync(() =>

--- a/server/src/api/ffmpegSettingsApi.ts
+++ b/server/src/api/ffmpegSettingsApi.ts
@@ -302,7 +302,7 @@ export const ffmpegSettingsRouter: RouterPluginCallback = (
       if (!config) {
         return res.status(404).send();
       }
-      await req.serverCtx.transcodeConfigDB.deleteConfig(req.params.id);
+      req.serverCtx.transcodeConfigDB.deleteConfig(req.params.id);
       return res.send();
     },
   );

--- a/server/src/db/ChannelDB.ts
+++ b/server/src/db/ChannelDB.ts
@@ -93,14 +93,16 @@ export class ChannelDB implements IChannelDB {
     return this.basicChannel.getAllChannels();
   }
 
-  saveChannel(createReq: SaveableChannel): Promise<ChannelAndLineup<Channel>> {
+  saveChannel(
+    createReq: SaveableChannel,
+  ): Promise<ChannelAndLineup<ChannelOrm>> {
     return this.basicChannel.saveChannel(createReq);
   }
 
   updateChannel(
     id: string,
     updateReq: SaveableChannel,
-  ): Promise<ChannelAndLineup<Channel>> {
+  ): Promise<ChannelAndLineup> {
     return this.basicChannel.updateChannel(id, updateReq);
   }
 
@@ -116,7 +118,7 @@ export class ChannelDB implements IChannelDB {
     return this.basicChannel.syncChannelDuration(id);
   }
 
-  copyChannel(id: string): Promise<ChannelAndLineup<Channel>> {
+  copyChannel(id: string): Promise<ChannelAndLineup<ChannelOrm>> {
     return this.basicChannel.copyChannel(id);
   }
 
@@ -175,8 +177,8 @@ export class ChannelDB implements IChannelDB {
   replaceChannelPrograms(
     channelId: string,
     programIds: string[],
-  ): Promise<void> {
-    return this.channelProgram.replaceChannelPrograms(channelId, programIds);
+  ): void {
+    this.channelProgram.replaceChannelPrograms(channelId, programIds);
   }
 
   findChannelsForProgramId(programId: string): Promise<ChannelOrm[]> {
@@ -257,18 +259,23 @@ export class ChannelDB implements IChannelDB {
   setChannelPrograms(
     channel: Channel,
     lineup: readonly LineupItem[],
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null> {
-    return this.lineup.setChannelPrograms(channel, lineup, startTime);
+  ): Promise<ChannelOrm | null> {
+    // TODO: Update LineupRepository.setChannelPrograms to return ChannelOrm
+    return this.lineup.setChannelPrograms(
+      channel,
+      lineup,
+      startTime,
+    );
   }
 
   addPendingPrograms(

--- a/server/src/db/CustomShowDB.test.ts
+++ b/server/src/db/CustomShowDB.test.ts
@@ -183,7 +183,6 @@ const test = baseTest.extend<Fixture>({
     );
     const upsertRepo = new ProgramUpsertRepository(
       logger,
-      dbAccess.getKyselyDatabase(':memory:')!,
       dbAccess.getConnection(':memory:')!.drizzle!,
       mockTaskFactory,
       mockTaskFactory,

--- a/server/src/db/CustomShowDB.ts
+++ b/server/src/db/CustomShowDB.ts
@@ -189,12 +189,12 @@ export class CustomShowDB {
       return false;
     }
 
-    await this.db.transaction().execute(async (tx) => {
-      await tx
-        .deleteFrom('customShowContent')
-        .where('customShowContent.customShowUuid', '=', show.uuid)
-        .execute();
-      await tx.deleteFrom('customShow').where('uuid', '=', show.uuid).execute();
+    this.drizzle.transaction((tx) => {
+      // TODO: Do this deletion in the DB with foreign keys.
+      tx.delete(CustomShowContent)
+        .where(eq(CustomShowContent.customShowUuid, show.uuid))
+        .run();
+      tx.delete(CustomShow).where(eq(CustomShow.uuid, show.uuid)).run();
     });
 
     return true;
@@ -346,17 +346,13 @@ export class CustomShowDB {
       'asc',
     );
 
-    await this.db.transaction().execute(async (tx) => {
+    this.drizzle.transaction((tx) => {
       if (allNewCustomContent.length > 0) {
-        await tx
-          .deleteFrom('customShowContent')
-          .where('customShowContent.customShowUuid', '=', customShowId)
-          .execute();
+        tx.delete(CustomShowContent)
+          .where(eq(CustomShowContent.customShowUuid, customShowId))
+          .run();
         for (const contentChunk of chunk(allNewCustomContent, 1_000)) {
-          await tx
-            .insertInto('customShowContent')
-            .values(contentChunk)
-            .execute();
+          tx.insert(CustomShowContent).values(contentChunk).run();
         }
       }
     });

--- a/server/src/db/DBAccess.ts
+++ b/server/src/db/DBAccess.ts
@@ -1,3 +1,5 @@
+import type { TunarrMigrationInfo } from '@/migration/DrizzleMigrator.js';
+import { DrizzleMigrator } from '@/migration/DrizzleMigrator.js';
 import { attempt, isNonEmptyString } from '@/util/index.js';
 import type { Logger } from '@/util/logging/LoggerFactory.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
@@ -12,7 +14,7 @@ import {
   ParseJSONResultsPlugin,
   SqliteDialect,
 } from 'kysely';
-import { findIndex, has, isError, last, map, slice } from 'lodash-es';
+import { findIndex, isError, last, map, slice } from 'lodash-es';
 import { DatabaseCopyMigrator } from '../migration/db/DatabaseCopyMigrator.ts';
 import {
   DirectMigrationProvider,
@@ -108,13 +110,17 @@ class Connection {
     return this.kysely;
   }
 
-  async pendingDatabaseMigrations() {
+  async pendingDatabaseMigrations(): Promise<TunarrMigrationInfo[]> {
     return lock.runExclusive(async () => {
       const tables = await this.db.introspection.getTables({
         withInternalKyselyTables: true,
       });
+
+      const migrator = this.getDrizzleMigrator();
       if (!tables.some((table) => table.name === MigrationTableName)) {
-        return this.getMigrator().getMigrations();
+        // Trigger internal Kysely code to create the migration table.
+        await this.getMigrator().migrateUp();
+        return migrator.getMigrations();
       }
 
       const executedMigrations =
@@ -127,8 +133,7 @@ class Connection {
       const executedMigrationNames = executedMigrations.map(
         (migration) => migration.name as string,
       );
-      const migrator = this.getMigrator();
-      const knownMigrations = await migrator.getMigrations();
+      const knownMigrations = migrator.getMigrations();
       return knownMigrations.filter(
         (migration) => !executedMigrationNames.includes(migration.name),
       );
@@ -148,6 +153,10 @@ class Connection {
     });
   }
 
+  getDrizzleMigrator() {
+    return new DrizzleMigrator(this.drizzle, this.db);
+  }
+
   async syncMigrationTablesIfNecessary() {
     const tables = await this.db.introspection.getTables({
       withInternalKyselyTables: true,
@@ -156,6 +165,7 @@ class Connection {
     const newMigrationTableExists = tables.some(
       (table) => table.name === MigrationTableName,
     );
+    console.log(tables);
 
     const legacyMigrationTableExists = tables.some(
       (table) => table.name === 'mikro_orm_migrations',
@@ -235,14 +245,20 @@ class Connection {
           .ifExists()
           .execute();
       }
+    } else if (!newMigrationTableExists) {
+      // This will run our placeholder "first" migration which will
+      // force kysely to create the migration tables.
+      // Now port over the legacy migrations
+      console.log('migrate up');
+      await migrator.migrateUp();
     } else {
       this.logger.debug('New migration table already exists');
     }
   }
 
   async runDBMigrations(migrateTo?: string) {
-    const migrator = this.getMigrator();
-    this.logger.debug(
+    const migrator = this.getDrizzleMigrator();
+    this.logger.trace(
       'Migrating DB %s %s',
       this.name,
       isNonEmptyString(migrateTo) ? `to ${migrateTo}` : 'to latest',
@@ -344,11 +360,7 @@ export class DBAccess {
     const copyMigrator = new DatabaseCopyMigrator(this);
     for (const migration of pendingMigrations) {
       this.logger.info('Running database migration "%s"', migration.name);
-      if (
-        (has(migration.migration, 'fullCopy') &&
-          migration.migration.fullCopy) ||
-        (has(migration.migration, 'inPlace') && !migration.migration.inPlace)
-      ) {
+      if (migration.migration.fullCopy) {
         await copyMigrator.migrate(dbPathToMigrate, migration.name);
       } else {
         // Refresh the connection every time.

--- a/server/src/db/FillerListDB.ts
+++ b/server/src/db/FillerListDB.ts
@@ -6,8 +6,9 @@ import {
   UpdateFillerListRequest,
 } from '@tunarr/types/api';
 import dayjs from 'dayjs';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { inject, injectable } from 'inversify';
-import { CaseWhenBuilder, Kysely } from 'kysely';
+import { Kysely } from 'kysely';
 import { jsonArrayFrom } from 'kysely/helpers/sqlite';
 import {
   chunk,
@@ -15,20 +16,22 @@ import {
   find,
   forEach,
   groupBy,
+  head,
   isEmpty,
   isNil,
   isUndefined,
   map,
   mapValues,
   omitBy,
-  reduce,
   reject,
   round,
+  tail,
   uniq,
   values,
 } from 'lodash-es';
 import { v4 } from 'uuid';
 import { Maybe, Nilable } from '../types/util.ts';
+import { caseWhen } from './DrizzleSqlCaseWhen.ts';
 import {
   FillerShowWithContent,
   IFillerListDB,
@@ -36,8 +39,11 @@ import {
 import { createPendingProgramIndexMap } from './programHelpers.ts';
 import { withFillerPrograms } from './programQueryHelpers.ts';
 import { ChannelFillerShow } from './schema/ChannelFillerShow.ts';
-import type { FillerShow, NewFillerShow } from './schema/FillerShow.ts';
-import type { NewFillerShowContent } from './schema/FillerShowContent.ts';
+import { FillerShow, NewFillerShow } from './schema/FillerShow.ts';
+import {
+  FillerShowContent,
+  type NewFillerShowContent,
+} from './schema/FillerShowContent.ts';
 import { DB } from './schema/db.ts';
 import type {
   ChannelFillerShowWithContent,
@@ -127,19 +133,17 @@ export class FillerDB implements IFillerListDB {
           }) satisfies NewFillerShowContent,
       );
 
-      await this.db.transaction().execute(async (tx) => {
-        await tx
-          .deleteFrom('fillerShowContent')
-          .where('fillerShowContent.fillerShowUuid', '=', filler.uuid)
-          .execute();
-        await Promise.all(
-          chunk(
-            [...persistedFillerShowContent, ...newFillerShowContent],
-            1_000,
-          ).map((fsc) =>
-            tx.insertInto('fillerShowContent').values(fsc).execute(),
-          ),
-        );
+      this.drizzle.transaction((tx) => {
+        tx.delete(FillerShowContent)
+          .where(eq(FillerShowContent.fillerShowUuid, filler.uuid))
+          .run();
+
+        for (const fsc of chunk(
+          [...persistedFillerShowContent, ...newFillerShowContent],
+          1_000,
+        )) {
+          tx.insert(FillerShowContent).values(fsc).run();
+        }
       });
     }
 
@@ -218,23 +222,24 @@ export class FillerDB implements IFillerListDB {
       .execute();
   }
 
-  async deleteFiller(id: string): Promise<void> {
-    await this.db.transaction().execute(async (tx) => {
-      const relevantChannelFillers = await tx
-        .selectFrom('channelFillerShow')
-        .selectAll()
-        .where('fillerShowUuid', '=', id)
-        .execute();
+  deleteFiller(id: string): void {
+    this.drizzle.transaction((tx) => {
+      const relevantChannelFillers = tx
+        .select()
+        .from(ChannelFillerShow)
+        .where(eq(ChannelFillerShow.fillerShowUuid, id))
+        .all();
 
-      const allRelevantChannelFillers = await tx
-        .selectFrom('channelFillerShow')
-        .selectAll()
+      const allRelevantChannelFillers = tx
+        .select()
+        .from(ChannelFillerShow)
         .where(
-          'channelFillerShow.channelUuid',
-          'in',
-          uniq(map(relevantChannelFillers, (cf) => cf.channelUuid)),
+          inArray(
+            ChannelFillerShow.channelUuid,
+            uniq(map(relevantChannelFillers, (cf) => cf.channelUuid)),
+          ),
         )
-        .execute();
+        .all();
 
       const fillersByChannel = groupBy(
         allRelevantChannelFillers,
@@ -259,10 +264,9 @@ export class FillerDB implements IFillerListDB {
         });
       });
 
-      await tx
-        .deleteFrom('channelFillerShow')
-        .where('channelFillerShow.fillerShowUuid', '=', id)
-        .execute();
+      tx.delete(ChannelFillerShow)
+        .where(eq(ChannelFillerShow.fillerShowUuid, id))
+        .run();
 
       const reminaingChannelFillers = omitBy<ChannelFillerShow[]>(
         mapValues(fillersByChannel, (cfs) =>
@@ -271,55 +275,38 @@ export class FillerDB implements IFillerListDB {
         isEmpty,
       );
 
-      if (!isEmpty(fillersByChannel) && !isEmpty(reminaingChannelFillers)) {
-        await tx
-          .updateTable('channelFillerShow')
-          .set(({ eb }) => {
-            const weight = reduce(
-              reminaingChannelFillers,
-              (builder, channelFillers) => {
-                return reduce(
-                  channelFillers,
-                  (caseBuilder, channelFiller) =>
-                    caseBuilder
-                      .when(
-                        eb.and([
-                          eb(
-                            'channelFillerShow.fillerShowUuid',
-                            '=',
-                            channelFiller.fillerShowUuid,
-                          ),
-                          eb(
-                            'channelFillerShow.channelUuid',
-                            '=',
-                            channelFiller.channelUuid,
-                          ),
-                        ]),
-                      )
-                      .then(channelFiller.weight),
-                  builder,
-                );
-              },
-              eb.case() as unknown as CaseWhenBuilder<
-                DB,
-                'channelFillerShow',
-                unknown,
-                number
-              >,
-            )
-              .else(eb.ref('channelFillerShow.weight'))
-              .end();
-            return { weight };
-          })
-          .execute();
+      const allRemainingFillers = Object.values(reminaingChannelFillers).flat();
+      if (!isEmpty(fillersByChannel) && !isEmpty(allRemainingFillers)) {
+        const firstFiller = head(allRemainingFillers)!;
+        const rest = tail(allRemainingFillers);
+        const baseCase = caseWhen(
+          and(
+            eq(ChannelFillerShow.fillerShowUuid, firstFiller.fillerShowUuid),
+            eq(ChannelFillerShow.channelUuid, firstFiller.channelUuid),
+          )!,
+          sql`${firstFiller.weight}`,
+        );
+        const cases = rest
+          .reduce(
+            (caseBuilder, channelFiller) =>
+              caseBuilder.when(
+                and(
+                  eq(
+                    ChannelFillerShow.fillerShowUuid,
+                    channelFiller.fillerShowUuid,
+                  ),
+                  eq(ChannelFillerShow.channelUuid, channelFiller.channelUuid),
+                )!,
+                sql`${channelFiller.weight}`,
+              ),
+            baseCase,
+          )
+          .else(ChannelFillerShow.weight);
+
+        tx.update(ChannelFillerShow).set({ weight: cases }).run();
       }
 
-      await tx
-        .deleteFrom('fillerShow')
-        .where('uuid', '=', id)
-        // TODO: Blocked on https://github.com/oven-sh/bun/issues/16909
-        // .limit(1)
-        .execute();
+      tx.delete(FillerShow).where(eq(FillerShow.uuid, id)).run();
     });
 
     return;

--- a/server/src/db/ITranscodeConfigDB.ts
+++ b/server/src/db/ITranscodeConfigDB.ts
@@ -21,5 +21,5 @@ export interface ITranscodeConfigDB {
     Result<TranscodeConfigOrm, TranscodeConfigNotFoundError | WrappedError>
   >;
   updateConfig(id: string, updatedConfig: TranscodeConfig): Promise<void>;
-  deleteConfig(id: string): Promise<void>;
+  deleteConfig(id: string): void;
 }

--- a/server/src/db/LocalMediaDB.ts
+++ b/server/src/db/LocalMediaDB.ts
@@ -13,7 +13,7 @@ import {
   LocalMediaFolderOrm,
   NewLocalMediaFolderOrm,
 } from './schema/LocalMediaFolder.ts';
-import { MediaSourceLibraryOrm } from './schema/MediaSourceLibrary.ts';
+import { MediaSourceLibrary } from './schema/MediaSourceLibrary.ts';
 import { ProgramType } from './schema/Program.ts';
 
 @injectable()
@@ -21,7 +21,7 @@ export class LocalMediaDB {
   constructor(@inject(KEYS.DrizzleDB) private db: DrizzleDBAccess) {}
 
   async findFolder(
-    library: MediaSourceLibraryOrm,
+    library: MediaSourceLibrary,
     parentPath: string,
   ): Promise<Maybe<LocalMediaFolderOrm>> {
     if (isEmpty(parentPath)) {
@@ -35,7 +35,7 @@ export class LocalMediaDB {
   }
 
   async upsertFolder(
-    library: MediaSourceLibraryOrm,
+    library: MediaSourceLibrary,
     knownParentId: Maybe<string>,
     folderName: string,
     canonicalId: string,

--- a/server/src/db/ProgramDB.test.ts
+++ b/server/src/db/ProgramDB.test.ts
@@ -119,7 +119,6 @@ const test = baseTest.extend<Fixture>({
     );
     const upsertRepo = new ProgramUpsertRepository(
       logger,
-      dbAccess.db!,
       dbAccess.drizzle!,
       mockTaskFactory,
       mockTaskFactory,

--- a/server/src/db/ProgramDB.ts
+++ b/server/src/db/ProgramDB.ts
@@ -244,18 +244,21 @@ export class ProgramDB implements IProgramDB {
     newExternalId: NewProgramExternalId,
     oldExternalId?: MinimalProgramExternalId,
   ): Promise<void> {
-    return this.externalIdRepo.replaceProgramExternalId(
+    this.externalIdRepo.replaceProgramExternalId(
       programId,
       newExternalId,
       oldExternalId,
     );
+    return Promise.resolve();
   }
 
   upsertProgramExternalIds(
     externalIds: NewSingleOrMultiExternalId[],
     chunkSize?: number,
   ): Promise<Dictionary<ProgramExternalId[]>> {
-    return this.externalIdRepo.upsertProgramExternalIds(externalIds, chunkSize);
+    return Promise.resolve(
+      this.externalIdRepo.upsertProgramExternalIds(externalIds, chunkSize),
+    );
   }
 
   upsertContentPrograms(
@@ -286,8 +289,8 @@ export class ProgramDB implements IProgramDB {
     }
   }
 
-  upsertArtwork(artwork: NewArtwork[]): Promise<void> {
-    return this.metadataRepo.upsertArtwork(artwork).then(() => {});
+  upsertArtwork(artwork: NewArtwork[]): void {
+    this.metadataRepo.upsertArtwork(artwork);
   }
 
   upsertProgramGroupingGenres(

--- a/server/src/db/TranscodeConfigDB.ts
+++ b/server/src/db/TranscodeConfigDB.ts
@@ -112,33 +112,35 @@ export class TranscodeConfigDB implements ITranscodeConfigDB {
       .where(eq(TranscodeConfigTable.uuid, id));
   }
 
-  async deleteConfig(id: string) {
+  deleteConfig(id: string) {
     // A few cases to handle:
     // 1. if we are deleting the default configuration, we have to pick a new one.
     // 2. If we are deleting the last configuration, we have to create a default configuration
     // 3. We have to update all related channels.
-    await this.drizzle.transaction(async (tx) => {
-      const numConfigs = await tx
-        .select({
-          count: count(),
-        })
-        .from(TranscodeConfigTable)
-        .then((results) => sumBy(results, (r) => r.count));
+    this.drizzle.transaction((tx) => {
+      const numConfigs = sumBy(
+        tx
+          .select({
+            count: count(),
+          })
+          .from(TranscodeConfigTable)
+          .all(),
+        (r) => r.count,
+      );
 
       // If there are no configs (should be impossible) create a default, assign it to all channels
       // and move on.
       if (numConfigs === 0) {
-        const newDefaultConfigId = await this.insertDefaultConfiguration(tx);
-        await tx
-          .update(Channel)
-          .set({ transcodeConfigId: newDefaultConfigId })
-          .execute();
+        const newDefaultConfigId = this.insertDefaultConfiguration(tx);
+        tx.update(Channel).set({ transcodeConfigId: newDefaultConfigId }).run();
         return;
       }
 
-      const configToDelete = await tx.query.transcodeConfigs.findFirst({
-        where: (fields, { eq }) => eq(fields.uuid, id),
-      });
+      const configToDelete = tx.query.transcodeConfigs
+        .findFirst({
+          where: (fields, { eq }) => eq(fields.uuid, id),
+        })
+        .sync();
 
       if (!configToDelete) {
         return;
@@ -146,64 +148,54 @@ export class TranscodeConfigDB implements ITranscodeConfigDB {
 
       // If this is the last config, we'll need a new one and will have to assign it
       if (numConfigs === 1) {
-        const newDefaultConfigId = await this.insertDefaultConfiguration(tx);
-        await tx
-          .update(Channel)
-          .set({ transcodeConfigId: newDefaultConfigId })
-          .execute();
-        await tx
-          .delete(TranscodeConfigTable)
+        const newDefaultConfigId = this.insertDefaultConfiguration(tx);
+        tx.update(Channel).set({ transcodeConfigId: newDefaultConfigId }).run();
+        tx.delete(TranscodeConfigTable)
           .where(eq(TranscodeConfigTable.uuid, id))
           .limit(1)
-          .execute();
+          .run();
         return;
       }
 
       let replacementId: string;
       if (configToDelete.isDefault) {
-        const newDefaultConfig = (
-          await tx
-            .select({ uuid: TranscodeConfigTable.uuid })
-            .from(TranscodeConfigTable)
-            .where(eq(TranscodeConfigTable.isDefault, false))
-            .limit(1)
-        )[0]!;
-        await tx
-          .update(TranscodeConfigTable)
+        const newDefaultConfig = tx
+          .select({ uuid: TranscodeConfigTable.uuid })
+          .from(TranscodeConfigTable)
+          .where(eq(TranscodeConfigTable.isDefault, false))
+          .limit(1)
+          .get()!;
+        tx.update(TranscodeConfigTable)
           .set({ isDefault: true })
           .where(eq(TranscodeConfigTable.uuid, newDefaultConfig.uuid));
         replacementId = newDefaultConfig.uuid;
       } else {
-        const defaultId = (
-          await tx
-            .select({ uuid: TranscodeConfigTable.uuid })
-            .from(TranscodeConfigTable)
-            .where(eq(TranscodeConfigTable.isDefault, true))
-            .limit(1)
-        )[0]!;
+        const defaultId = tx
+          .select({ uuid: TranscodeConfigTable.uuid })
+          .from(TranscodeConfigTable)
+          .where(eq(TranscodeConfigTable.isDefault, true))
+          .limit(1)
+          .get()!;
         replacementId = defaultId.uuid;
       }
 
-      await tx
-        .update(Channel)
+      tx.update(Channel)
         .set({ transcodeConfigId: replacementId })
         .where(eq(Channel.transcodeConfigId, configToDelete.uuid))
-        .execute();
+        .run();
 
-      await tx
-        .delete(TranscodeConfigTable)
+      tx.delete(TranscodeConfigTable)
         .where(eq(TranscodeConfigTable.uuid, id))
         .limit(1)
-        .execute();
+        .run();
     });
   }
 
-  private async insertDefaultConfiguration(db: DrizzleDBAccess = this.drizzle) {
-    return head(
-      await db
-        .insert(TranscodeConfigTable)
-        .values(defaultTranscodeConfig(true))
-        .returning({ uuid: TranscodeConfigTable.uuid }),
-    )!.uuid;
+  private insertDefaultConfiguration(db: DrizzleDBAccess = this.drizzle) {
+    return db
+      .insert(TranscodeConfigTable)
+      .values(defaultTranscodeConfig(true))
+      .returning({ uuid: TranscodeConfigTable.uuid })
+      .get().uuid;
   }
 }

--- a/server/src/db/channel/BasicChannelRepository.ts
+++ b/server/src/db/channel/BasicChannelRepository.ts
@@ -5,9 +5,8 @@ import { KEYS } from '@/types/inject.js';
 import { Result } from '@/types/result.js';
 import { Maybe } from '@/types/util.js';
 import dayjs from '@/util/dayjs.js';
-import { booleanToNumber } from '@/util/sqliteUtil.js';
 import type { SaveableChannel, Watermark } from '@tunarr/types';
-import { eq } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { inject, injectable } from 'inversify';
 import { Kysely } from 'kysely';
 import { jsonArrayFrom } from 'kysely/helpers/sqlite';
@@ -27,15 +26,18 @@ import { ChannelAndLineup } from '../interfaces/IChannelDB.ts';
 import {
   Channel,
   ChannelOrm,
-  ChannelUpdate,
-  NewChannel,
+  NewChannelOrm,
 } from '../schema/Channel.ts';
-import { NewChannelFillerShow } from '../schema/ChannelFillerShow.ts';
+import { ChannelFillerShow } from '../schema/ChannelFillerShow.ts';
+import { ChannelPrograms } from '../schema/ChannelPrograms.ts';
 import {
   ChannelWithRelations,
   ChannelOrmWithTranscodeConfig,
 } from '../schema/derivedTypes.ts';
-import { NewChannelSubtitlePreference } from '../schema/SubtitlePreferences.ts';
+import {
+  ChannelSubtitlePreferences,
+  NewChannelSubtitlePreferenceOrm,
+} from '../schema/SubtitlePreferences.ts';
 import type { DB } from '../schema/db.ts';
 import type { DrizzleDBAccess } from '../schema/index.ts';
 import { LineupRepository } from './LineupRepository.ts';
@@ -57,32 +59,32 @@ function sanitizeChannelWatermark(
   };
 }
 
-function updateRequestToChannel(updateReq: SaveableChannel): ChannelUpdate {
+function updateRequestToChannel(
+  updateReq: SaveableChannel,
+): Partial<NewChannelOrm> {
   const sanitizedWatermark = sanitizeChannelWatermark(updateReq.watermark);
 
   return {
     number: updateReq.number,
-    watermark: sanitizedWatermark
-      ? JSON.stringify(sanitizedWatermark)
-      : undefined,
-    icon: JSON.stringify(updateReq.icon),
+    watermark: sanitizedWatermark ?? undefined,
+    icon: updateReq.icon,
     guideMinimumDuration: updateReq.guideMinimumDuration,
     groupTitle: updateReq.groupTitle,
-    disableFillerOverlay: booleanToNumber(updateReq.disableFillerOverlay),
+    disableFillerOverlay: updateReq.disableFillerOverlay,
     startTime: +dayjs(updateReq.startTime).second(0).millisecond(0),
-    offline: JSON.stringify(updateReq.offline),
+    offline: updateReq.offline,
     name: updateReq.name,
     duration: updateReq.duration,
-    stealth: booleanToNumber(updateReq.stealth),
+    stealth: updateReq.stealth,
     fillerRepeatCooldown: updateReq.fillerRepeatCooldown,
     guideFlexTitle: updateReq.guideFlexTitle,
     transcodeConfigId: updateReq.transcodeConfigId,
     streamMode: updateReq.streamMode,
-    subtitlesEnabled: booleanToNumber(updateReq.subtitlesEnabled),
-  } satisfies ChannelUpdate;
+    subtitlesEnabled: updateReq.subtitlesEnabled,
+  } satisfies Partial<NewChannelOrm>;
 }
 
-function createRequestToChannel(saveReq: SaveableChannel): NewChannel {
+function createRequestToChannel(saveReq: SaveableChannel): NewChannelOrm {
   const now = +dayjs();
 
   return {
@@ -90,22 +92,22 @@ function createRequestToChannel(saveReq: SaveableChannel): NewChannel {
     createdAt: now,
     updatedAt: now,
     number: saveReq.number,
-    watermark: saveReq.watermark ? JSON.stringify(saveReq.watermark) : null,
-    icon: JSON.stringify(saveReq.icon),
+    watermark: saveReq.watermark ?? null,
+    icon: saveReq.icon,
     guideMinimumDuration: saveReq.guideMinimumDuration,
     groupTitle: saveReq.groupTitle,
-    disableFillerOverlay: saveReq.disableFillerOverlay ? 1 : 0,
+    disableFillerOverlay: saveReq.disableFillerOverlay,
     startTime: saveReq.startTime,
-    offline: JSON.stringify(saveReq.offline),
+    offline: saveReq.offline,
     name: saveReq.name,
     duration: saveReq.duration,
-    stealth: saveReq.stealth ? 1 : 0,
+    stealth: saveReq.stealth,
     fillerRepeatCooldown: saveReq.fillerRepeatCooldown,
     guideFlexTitle: saveReq.guideFlexTitle,
     streamMode: saveReq.streamMode,
     transcodeConfigId: saveReq.transcodeConfigId,
-    subtitlesEnabled: booleanToNumber(saveReq.subtitlesEnabled),
-  } satisfies NewChannel;
+    subtitlesEnabled: saveReq.subtitlesEnabled,
+  } satisfies NewChannelOrm;
 }
 
 @injectable()
@@ -185,7 +187,7 @@ export class BasicChannelRepository {
 
   async saveChannel(
     createReq: SaveableChannel,
-  ): Promise<ChannelAndLineup<Channel>> {
+  ): Promise<ChannelAndLineup<ChannelOrm>> {
     const existing = await this.getChannel(createReq.number);
     if (!isNil(existing)) {
       throw new Error(
@@ -193,33 +195,28 @@ export class BasicChannelRepository {
       );
     }
 
-    const channel = await this.db.transaction().execute(async (tx) => {
-      const channel = await tx
-        .insertInto('channel')
+    const channel = this.drizzleDB.transaction((tx) => {
+      const channel = tx
+        .insert(Channel)
         .values(createRequestToChannel(createReq))
-        .returningAll()
-        .executeTakeFirst();
+        .returning()
+        .get();
 
       if (!channel) {
         throw new Error('Error while saving new channel.');
       }
 
       if (!isEmpty(createReq.fillerCollections)) {
-        await tx
-          .insertInto('channelFillerShow')
+        tx.insert(ChannelFillerShow)
           .values(
-            map(
-              createReq.fillerCollections,
-              (fc) =>
-                ({
-                  channelUuid: channel.uuid,
-                  cooldown: fc.cooldownSeconds,
-                  fillerShowUuid: fc.id,
-                  weight: fc.weight,
-                }) satisfies NewChannelFillerShow,
-            ),
+            map(createReq.fillerCollections, (fc) => ({
+              channelUuid: channel.uuid,
+              cooldown: fc.cooldownSeconds,
+              fillerShowUuid: fc.id,
+              weight: fc.weight,
+            })),
           )
-          .execute();
+          .run();
       }
 
       const subtitlePreferences = createReq.subtitlePreferences?.map(
@@ -228,17 +225,16 @@ export class BasicChannelRepository {
             channelId: channel.uuid,
             uuid: v4(),
             languageCode: pref.langugeCode,
-            allowExternal: booleanToNumber(pref.allowExternal),
-            allowImageBased: booleanToNumber(pref.allowImageBased),
+            allowExternal: pref.allowExternal,
+            allowImageBased: pref.allowImageBased,
             filterType: pref.filter,
             priority: pref.priority,
-          }) satisfies NewChannelSubtitlePreference,
+          }) satisfies NewChannelSubtitlePreferenceOrm,
       );
       if (subtitlePreferences) {
-        await tx
-          .insertInto('channelSubtitlePreferences')
+        tx.insert(ChannelSubtitlePreferences)
           .values(subtitlePreferences)
-          .executeTakeFirstOrThrow();
+          .run();
       }
 
       return channel;
@@ -265,7 +261,7 @@ export class BasicChannelRepository {
   async updateChannel(
     id: string,
     updateReq: SaveableChannel,
-  ): Promise<ChannelAndLineup<Channel>> {
+  ): Promise<ChannelAndLineup> {
     const channel = await this.getChannel(id);
 
     if (isNil(channel)) {
@@ -287,33 +283,24 @@ export class BasicChannelRepository {
       }
     }
 
-    await this.db.transaction().execute(async (tx) => {
-      await tx
-        .updateTable('channel')
-        .where('channel.uuid', '=', id)
-        .set(update)
-        .executeTakeFirstOrThrow();
+    this.drizzleDB.transaction((tx) => {
+      tx.update(Channel).set(update).where(eq(Channel.uuid, id)).run();
 
       if (!isEmpty(updateReq.fillerCollections)) {
         const channelFillerShows = map(
           updateReq.fillerCollections,
-          (filler) =>
-            ({
-              cooldown: filler.cooldownSeconds,
-              channelUuid: channel.uuid,
-              fillerShowUuid: filler.id,
-              weight: filler.weight,
-            }) satisfies NewChannelFillerShow,
+          (filler) => ({
+            cooldown: filler.cooldownSeconds,
+            channelUuid: channel.uuid,
+            fillerShowUuid: filler.id,
+            weight: filler.weight,
+          }),
         );
 
-        await tx
-          .deleteFrom('channelFillerShow')
-          .where('channelFillerShow.channelUuid', '=', channel.uuid)
-          .executeTakeFirstOrThrow();
-        await tx
-          .insertInto('channelFillerShow')
-          .values(channelFillerShows)
-          .executeTakeFirstOrThrow();
+        tx.delete(ChannelFillerShow)
+          .where(eq(ChannelFillerShow.channelUuid, channel.uuid))
+          .run();
+        tx.insert(ChannelFillerShow).values(channelFillerShows).run();
       }
       const subtitlePreferences = updateReq.subtitlePreferences?.map(
         (pref) =>
@@ -321,21 +308,19 @@ export class BasicChannelRepository {
             channelId: channel.uuid,
             uuid: v4(),
             languageCode: pref.langugeCode,
-            allowExternal: booleanToNumber(pref.allowExternal),
-            allowImageBased: booleanToNumber(pref.allowImageBased),
+            allowExternal: pref.allowExternal,
+            allowImageBased: pref.allowImageBased,
             filterType: pref.filter,
             priority: pref.priority,
-          }) satisfies NewChannelSubtitlePreference,
+          }) satisfies NewChannelSubtitlePreferenceOrm,
       );
-      await tx
-        .deleteFrom('channelSubtitlePreferences')
-        .where('channelSubtitlePreferences.channelId', '=', channel.uuid)
-        .executeTakeFirstOrThrow();
+      tx.delete(ChannelSubtitlePreferences)
+        .where(eq(ChannelSubtitlePreferences.channelId, channel.uuid))
+        .run();
       if (subtitlePreferences) {
-        await tx
-          .insertInto('channelSubtitlePreferences')
+        tx.insert(ChannelSubtitlePreferences)
           .values(subtitlePreferences)
-          .executeTakeFirstOrThrow();
+          .run();
       }
     });
 
@@ -354,7 +339,7 @@ export class BasicChannelRepository {
     }
 
     return {
-      channel: (await this.getChannel(id, true))!,
+      channel: (await this.getChannelOrm(id))!,
       lineup: await this.lineupRepository.loadLineup(id),
     };
   }
@@ -399,8 +384,8 @@ export class BasicChannelRepository {
     return false;
   }
 
-  async copyChannel(id: string): Promise<ChannelAndLineup<Channel>> {
-    const channel = await this.getChannel(id);
+  async copyChannel(id: string): Promise<ChannelAndLineup<ChannelOrm>> {
+    const channel = await this.getChannelOrm(id);
     if (!channel) {
       throw new Error(`Cannot copy channel: channel ID: ${id} not found`);
     }
@@ -409,59 +394,60 @@ export class BasicChannelRepository {
 
     const newChannelId = v4();
     const now = +dayjs();
-    const newChannel = await this.db.transaction().execute(async (tx) => {
-      const { number: maxId } = await tx
-        .selectFrom('channel')
-        .select('number')
-        .orderBy('number desc')
+    const newChannel = this.drizzleDB.transaction((tx) => {
+      const maxRow = tx
+        .select({ number: Channel.number })
+        .from(Channel)
+        .orderBy(desc(Channel.number))
         .limit(1)
-        .executeTakeFirstOrThrow();
-      const newChannel = await tx
-        .insertInto('channel')
+        .get();
+
+      const maxNumber = maxRow?.number ?? 0;
+
+      const { transcodeConfig: _, ...channelFields } = channel;
+      const newChannel = tx
+        .insert(Channel)
         .values({
-          ...channel,
+          ...channelFields,
           uuid: newChannelId,
           name: `${channel.name} - Copy`,
-          number: maxId + 1,
-          icon: JSON.stringify(channel.icon),
-          offline: JSON.stringify(channel.offline),
-          watermark: JSON.stringify(channel.watermark),
+          number: maxNumber + 1,
+          icon: channel.icon,
+          offline: channel.offline,
+          watermark: channel.watermark,
           createdAt: now,
           updatedAt: now,
           transcoding: null,
+          transcodeConfigId: channel.transcodeConfigId,
         })
-        .returningAll()
-        .executeTakeFirstOrThrow();
+        .returning()
+        .get();
 
-      await tx
-        .insertInto('channelFillerShow')
-        .columns(['channelUuid', 'cooldown', 'fillerShowUuid', 'weight'])
-        .expression((eb) =>
-          eb
-            .selectFrom('channelFillerShow')
-            .select([
-              eb.val(newChannelId).as('channelUuid'),
-              'channelFillerShow.cooldown',
-              'channelFillerShow.fillerShowUuid',
-              'channelFillerShow.weight',
-            ])
-            .where('channelFillerShow.channelUuid', '=', channel.uuid),
+      tx.insert(ChannelFillerShow)
+        .select(
+          tx
+            .select({
+              channelUuid: sql<string>`${newChannelId}`.as('channelUuid'),
+              fillerShowUuid: ChannelFillerShow.fillerShowUuid,
+              cooldown: ChannelFillerShow.cooldown,
+              weight: ChannelFillerShow.weight,
+            })
+            .from(ChannelFillerShow)
+            .where(eq(ChannelFillerShow.channelUuid, channel.uuid)),
         )
-        .executeTakeFirstOrThrow();
+        .run();
 
-      await tx
-        .insertInto('channelPrograms')
-        .columns(['channelUuid', 'programUuid'])
-        .expression((eb) =>
-          eb
-            .selectFrom('channelPrograms')
-            .select([
-              eb.val(newChannelId).as('channelUuid'),
-              'channelPrograms.programUuid',
-            ])
-            .where('channelPrograms.channelUuid', '=', channel.uuid),
+      tx.insert(ChannelPrograms)
+        .select(
+          tx
+            .select({
+              channelUuid: sql<string>`${newChannelId}`.as('channelUuid'),
+              programUuid: ChannelPrograms.programUuid,
+            })
+            .from(ChannelPrograms)
+            .where(eq(ChannelPrograms.channelUuid, channel.uuid)),
         )
-        .executeTakeFirstOrThrow();
+        .run();
 
       return newChannel;
     });
@@ -486,16 +472,11 @@ export class BasicChannelRepository {
       await this.lineupRepository.markLineupFileForDeletion(channelId);
       marked = true;
 
-      await this.db.transaction().execute(async (tx) => {
-        await tx
-          .deleteFrom('channelSubtitlePreferences')
-          .where('channelId', '=', channelId)
-          .executeTakeFirstOrThrow();
-        await tx
-          .deleteFrom('channel')
-          .where('uuid', '=', channelId)
-          .limit(1)
-          .executeTakeFirstOrThrow();
+      this.drizzleDB.transaction((tx) => {
+        tx.delete(ChannelSubtitlePreferences)
+          .where(eq(ChannelSubtitlePreferences.channelId, channelId))
+          .run();
+        tx.delete(Channel).where(eq(Channel.uuid, channelId)).run();
       });
 
       const removeRefs = () =>

--- a/server/src/db/channel/ChannelProgramRepository.ts
+++ b/server/src/db/channel/ChannelProgramRepository.ts
@@ -421,19 +421,19 @@ export class ChannelProgramRepository {
     return result?.program;
   }
 
-  async replaceChannelPrograms(
+  replaceChannelPrograms(
     channelId: string,
     programIds: string[],
-  ): Promise<void> {
+  ): void {
     const uniqueIds = uniq(programIds);
-    await this.drizzleDB.transaction(async (tx) => {
-      await tx
-        .delete(ChannelPrograms)
-        .where(eq(ChannelPrograms.channelUuid, channelId));
+    this.drizzleDB.transaction((tx) => {
+      tx.delete(ChannelPrograms)
+        .where(eq(ChannelPrograms.channelUuid, channelId))
+        .run();
       for (const c of chunk(uniqueIds, 250)) {
-        await tx
-          .insert(ChannelPrograms)
-          .values(c.map((id) => ({ channelUuid: channelId, programUuid: id })));
+        tx.insert(ChannelPrograms)
+          .values(c.map((id) => ({ channelUuid: channelId, programUuid: id })))
+          .run();
       }
     });
   }

--- a/server/src/db/channel/LineupRepository.ts
+++ b/server/src/db/channel/LineupRepository.ts
@@ -70,7 +70,10 @@ import {
 import { SchemaBackedDbAdapter } from '../json/SchemaBackedJsonDBAdapter.ts';
 import { calculateStartTimeOffsets } from '../lineupUtil.ts';
 import { Channel, ChannelOrm } from '../schema/Channel.ts';
-import { NewChannelProgram } from '../schema/ChannelPrograms.ts';
+import {
+  ChannelPrograms,
+  NewChannelProgram,
+} from '../schema/ChannelPrograms.ts';
 import { DB } from '../schema/db.ts';
 import { DrizzleDBAccess } from '../schema/index.ts';
 import { ChannelOrmWithPrograms } from '../schema/derivedTypes.ts';
@@ -86,7 +89,7 @@ import {
 } from '../../util/index.ts';
 import { typedProperty } from '@/types/path.js';
 import { globalOptions } from '@/globals.js';
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, notInArray } from 'drizzle-orm';
 import { chunk } from 'lodash-es';
 
 // Module-level cache shared within this module
@@ -343,17 +346,17 @@ export class LineupRepository {
   async setChannelPrograms(
     channel: Channel,
     lineup: readonly LineupItem[],
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   async setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   async setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null> {
+  ): Promise<ChannelOrm | null> {
     const loadedChannel = await run(async () => {
       if (isString(channel)) {
         return this.db
@@ -372,38 +375,38 @@ export class LineupRepository {
 
     const allIds = uniq(map(filter(lineup, isContentItem), 'id'));
 
-    return await this.db.transaction().execute(async (tx) => {
-      if (!isUndefined(startTime)) {
-        loadedChannel.startTime = startTime;
-      }
-      loadedChannel.duration = sumBy(lineup, typedProperty('durationMs'));
-      const updatedChannel = await tx
-        .updateTable('channel')
-        .where('channel.uuid', '=', loadedChannel.uuid)
-        .set('duration', sumBy(lineup, typedProperty('durationMs')))
-        .$if(isDefined(startTime), (_) => _.set('startTime', startTime!))
-        .returningAll()
-        .executeTakeFirst();
+    return this.drizzleDB.transaction((tx) => {
+      const updatedChannel = tx
+        .update(Channel)
+        .set({
+          duration: sumBy(lineup, typedProperty('durationMs')),
+          startTime: isDefined(startTime) ? startTime : undefined,
+        })
+        .where(eq(Channel.uuid, loadedChannel.uuid))
+        .returning()
+        .get();
 
       for (const idChunk of chunk(allIds, 500)) {
-        await tx
-          .deleteFrom('channelPrograms')
-          .where('channelUuid', '=', loadedChannel.uuid)
-          .where('programUuid', 'not in', idChunk)
-          .execute();
+        tx.delete(ChannelPrograms)
+          .where(
+            and(
+              eq(ChannelPrograms.channelUuid, loadedChannel.uuid),
+              notInArray(ChannelPrograms.programUuid, idChunk),
+            ),
+          )
+          .run();
       }
 
       for (const idChunk of chunk(allIds, 500)) {
-        await tx
-          .insertInto('channelPrograms')
+        tx.insert(ChannelPrograms)
           .values(
             map(idChunk, (id) => ({
               programUuid: id,
               channelUuid: loadedChannel.uuid,
             })),
           )
-          .onConflict((oc) => oc.doNothing())
-          .executeTakeFirst();
+          .onConflictDoNothing()
+          .run();
       }
 
       return updatedChannel ?? null;
@@ -771,16 +774,14 @@ export class LineupRepository {
       return null;
     }
 
-    const updateChannel = async (lineup: readonly LineupItem[]) => {
-      return await this.db.transaction().execute(async (tx) => {
-        await tx
-          .updateTable('channel')
-          .where('channel.uuid', '=', id)
+    const updateChannel = (lineup: readonly LineupItem[]) => {
+      return this.drizzleDB.transaction((tx) => {
+        tx.update(Channel)
           .set({
             duration: sumBy(lineup, typedProperty('durationMs')),
           })
-          .limit(1)
-          .executeTakeFirstOrThrow();
+          .where(eq(Channel.uuid, id))
+          .run();
 
         const allNewIds = new Set([
           ...uniq(map(filter(lineup, isContentItem), (p) => p.id)),
@@ -816,16 +817,21 @@ export class LineupRepository {
           );
 
           if (!isEmpty(removes)) {
-            await tx
-              .deleteFrom('channelPrograms')
-              .where('channelPrograms.programUuid', 'in', map(removes, 'id'))
-              .where('channelPrograms.channelUuid', '=', id)
-              .execute();
+            tx.delete(ChannelPrograms)
+              .where(
+                and(
+                  inArray(
+                    ChannelPrograms.programUuid,
+                    map(removes, typedProperty('id')),
+                  ),
+                  eq(ChannelPrograms.channelUuid, id),
+                ),
+              )
+              .run();
           }
 
           if (!isEmpty(adds)) {
-            await tx
-              .insertInto('channelPrograms')
+            tx.insert(ChannelPrograms)
               .values(
                 map(
                   adds,
@@ -836,7 +842,7 @@ export class LineupRepository {
                     }) satisfies NewChannelProgram,
                 ),
               )
-              .execute();
+              .run();
           }
         }
         return channel;
@@ -910,7 +916,7 @@ export class LineupRepository {
         }
       });
 
-      const updatedChannel = await this.timer.timeAsync('updateChannel', () =>
+      const updatedChannel = this.timer.timeSync('updateChannel', () =>
         updateChannel(newLineupItems),
       );
 
@@ -971,7 +977,7 @@ export class LineupRepository {
 
       const newLineup = await createNewLineup(programs);
 
-      const updatedChannel = await updateChannel(newLineup);
+      const updatedChannel = updateChannel(newLineup);
       await this.saveLineup(id, {
         items: newLineup,
         schedule: req.schedule,

--- a/server/src/db/converters/ProgramGroupingMinter.ts
+++ b/server/src/db/converters/ProgramGroupingMinter.ts
@@ -28,7 +28,7 @@ import {
   NewProgramGroupingWithRelations,
 } from '../schema/derivedTypes.js';
 import { MediaSourceOrm } from '../schema/MediaSource.ts';
-import { MediaSourceLibraryOrm } from '../schema/MediaSourceLibrary.ts';
+import { MediaSourceLibrary } from '../schema/MediaSourceLibrary.ts';
 import { ProgramGroupingType } from '../schema/ProgramGrouping.ts';
 import { CommonDaoMinter } from './CommonDaoMinter.ts';
 
@@ -39,7 +39,7 @@ export class ProgramGroupingMinter {
   mintGrandparentGrouping(
     item: EpisodeWithHierarchy | MusicTrackWithHierarchy,
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
   ): Nullable<NewProgramGroupingWithRelations> {
     if (item.type === 'episode') {
       return this.mintForMediaSourceShow(
@@ -61,7 +61,7 @@ export class ProgramGroupingMinter {
   mintParentGrouping(
     item: EpisodeWithHierarchy | MusicTrackWithHierarchy,
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
   ): Nullable<NewProgramGroupingWithRelations> {
     if (item.type === 'episode') {
       return this.mintSeason(mediaSource, mediaSourceLibrary, item.season);
@@ -74,7 +74,7 @@ export class ProgramGroupingMinter {
 
   mintForMediaSourceShow(
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
     show: Show,
   ): NewProgramGroupingWithRelations<'show'> {
     const now = dayjs();
@@ -173,7 +173,7 @@ export class ProgramGroupingMinter {
 
   mintForMediaSourceArtist(
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
     artist: MediaSourceMusicArtist,
   ): NewProgramGroupingWithRelations<'artist'> {
     const now = +dayjs();
@@ -228,7 +228,7 @@ export class ProgramGroupingMinter {
 
   mintSeason(
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
     season: Season,
   ): NewProgramGroupingWithRelations<'season'> {
     const now = +dayjs();
@@ -291,7 +291,7 @@ export class ProgramGroupingMinter {
 
   mintMusicAlbum(
     mediaSource: MediaSourceOrm,
-    mediaSourceLibrary: MediaSourceLibraryOrm,
+    mediaSourceLibrary: MediaSourceLibrary,
     album: MediaSourceMusicAlbum,
   ): NewProgramGroupingWithRelations<'album'> {
     const now = +dayjs();

--- a/server/src/db/converters/ProgramMinter.ts
+++ b/server/src/db/converters/ProgramMinter.ts
@@ -45,11 +45,10 @@ import { KEYS } from '../../types/inject.ts';
 import { Nilable } from '../../types/util.ts';
 import { parsePlexGuid } from '../../util/externalIds.ts';
 import { isNonEmptyString } from '../../util/index.ts';
-import { booleanToNumber } from '../../util/sqliteUtil.ts';
 import { NewArtwork } from '../schema/Artwork.ts';
 import { CreditType, NewCredit } from '../schema/Credit.ts';
 import { MediaSourceOrm } from '../schema/MediaSource.ts';
-import { MediaSourceLibraryOrm } from '../schema/MediaSourceLibrary.ts';
+import { MediaSourceLibrary } from '../schema/MediaSourceLibrary.ts';
 import type { NewProgramDao } from '../schema/Program.ts';
 import { ProgramType } from '../schema/Program.ts';
 import { NewProgramMediaFile } from '../schema/ProgramMediaFile.ts';
@@ -83,7 +82,7 @@ export class ProgramDaoMinter {
 
   mint(
     mediaSource: MediaSourceOrm,
-    library: MediaSourceLibraryOrm,
+    library: MediaSourceLibrary,
     program: ContentProgramOriginalProgram,
   ): NewProgramWithExternalIds {
     const ret = match(program)
@@ -135,7 +134,7 @@ export class ProgramDaoMinter {
 
   mint2(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     program: TerminalProgram & HasMediaSourceInfo,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -173,7 +172,7 @@ export class ProgramDaoMinter {
 
   mintMovie(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     movie: MediaSourceMovie,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -258,7 +257,7 @@ export class ProgramDaoMinter {
           colorSpace: stream.colorSpace ?? null,
           colorTransfer: stream.colorTransfer ?? null,
           colorPrimaries: stream.colorPrimaries ?? null,
-          default: booleanToNumber(stream.default ?? false),
+          default: stream.default ?? false,
           //TODO: forced: stream.forced
           language: stream.languageCodeISO6392,
           pixelFormat: stream.pixelFormat,
@@ -284,8 +283,8 @@ export class ProgramDaoMinter {
       if (resolution) {
         const version: NewProgramVersion = {
           uuid: versionId,
-          createdAt: now,
-          updatedAt: now,
+          createdAt: new Date(now),
+          updatedAt: new Date(now),
           programId,
           displayAspectRatio: item.mediaItem.displayAspectRatio,
           duration: item.mediaItem.duration,
@@ -419,7 +418,7 @@ export class ProgramDaoMinter {
 
   mintEpisode(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     episode: Episode,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -487,7 +486,7 @@ export class ProgramDaoMinter {
 
   mintMusicTrack(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     track: MediaSourceMusicTrack,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -542,7 +541,7 @@ export class ProgramDaoMinter {
 
   mintOtherVideo(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     video: MediaSourceOtherVideo,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -599,7 +598,7 @@ export class ProgramDaoMinter {
 
   mintMusicVideo(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     video: MediaSourceMusicVideo,
     localFolderId?: string,
     now: number = +dayjs(),
@@ -656,7 +655,7 @@ export class ProgramDaoMinter {
 
   private mintProgramForPlexMovie(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     plexMovie: ApiPlexMovie,
   ): NewProgramDao {
     const file = first(first(plexMovie.Media)?.Part ?? []);
@@ -739,7 +738,7 @@ export class ProgramDaoMinter {
 
   private mintProgramForPlexEpisode(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     plexEpisode: PlexEpisode,
   ): NewProgramDao {
     const file = first(first(plexEpisode.Media)?.Part ?? []);
@@ -775,7 +774,7 @@ export class ProgramDaoMinter {
 
   private mintProgramForPlexTrack(
     mediaSource: MediaSourceOrm,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
     plexTrack: PlexMusicTrack,
   ): NewProgramDao {
     const file = first(first(plexTrack.Media)?.Part ?? []);

--- a/server/src/db/converters/channelConverters.ts
+++ b/server/src/db/converters/channelConverters.ts
@@ -9,15 +9,12 @@ import {
 } from '../../util/index.ts';
 import { numberToBoolean } from '../../util/sqliteUtil.ts';
 import type { ChannelAndLineup } from '../interfaces/IChannelDB.ts';
-import type {
-  ChannelOrmWithRelations,
-  ChannelWithRelations,
-} from '../schema/derivedTypes.ts';
+import type { ChannelOrmWithRelations } from '../schema/derivedTypes.ts';
 
 export const dbChannelToApiChannel = ({
   channel,
   lineup,
-}: ChannelAndLineup<ChannelWithRelations>): Channel => {
+}: ChannelAndLineup<ChannelOrmWithRelations>): Channel => {
   const subtitlePreferences = orderBy(
     channel.subtitlePreferences?.map(
       (pref) =>
@@ -46,21 +43,21 @@ export const dbChannelToApiChannel = ({
     icon: channel.icon ?? DefaultChannelIcon,
     guideMinimumDuration: channel.guideMinimumDuration,
     groupTitle: channel.groupTitle || '',
-    disableFillerOverlay: channel.disableFillerOverlay === 1,
+    disableFillerOverlay: channel.disableFillerOverlay ?? false,
     fillerRepeatCooldown: nullToUndefined(channel.fillerRepeatCooldown),
     startTime: channel.startTime,
     offline: channel.offline,
     name: channel.name,
     transcoding: nilToUndefined(channel.transcoding),
     duration: channel.duration,
-    stealth: channel.stealth === 1,
+    stealth: channel.stealth ?? false,
     onDemand: {
       enabled: isDefined(lineup.onDemandConfig),
     },
     programCount: filter(lineup.items, { type: 'content' }).length,
     streamMode: channel.streamMode,
     transcodeConfigId: channel.transcodeConfigId,
-    subtitlesEnabled: numberToBoolean(channel.subtitlesEnabled),
+    subtitlesEnabled: channel.subtitlesEnabled ?? false,
     subtitlePreferences: isNonEmptyArray(subtitlePreferences)
       ? subtitlePreferences
       : undefined,

--- a/server/src/db/interfaces/IChannelDB.ts
+++ b/server/src/db/interfaces/IChannelDB.ts
@@ -89,7 +89,9 @@ export interface IChannelDB {
     uuid: string,
   ): Promise<Maybe<ProgramOrmWithExternalIds>>;
 
-  saveChannel(createReq: SaveableChannel): Promise<ChannelAndLineup<Channel>>;
+  saveChannel(
+    createReq: SaveableChannel,
+  ): Promise<ChannelAndLineup<ChannelOrm>>;
 
   deleteChannel(
     channelId: string,
@@ -99,11 +101,11 @@ export interface IChannelDB {
   updateChannel(
     id: string,
     updateReq: SaveableChannel,
-  ): Promise<ChannelAndLineup<Channel>>;
+  ): Promise<ChannelAndLineup>;
 
   updateChannelDuration(id: string, duration: number): Promise<number>;
 
-  copyChannel(id: string): Promise<ChannelAndLineup<Channel>>;
+  copyChannel(id: string): Promise<ChannelAndLineup<ChannelOrm>>;
 
   loadLineup(channelId: string, forceRead?: boolean): Promise<Lineup>;
 
@@ -121,7 +123,7 @@ export interface IChannelDB {
   replaceChannelPrograms(
     channelId: string,
     programIds: string[],
-  ): Promise<void>;
+  ): void;
 
   updateLineup(
     id: string,
@@ -173,12 +175,12 @@ export interface IChannelDB {
   setChannelPrograms(
     channel: Channel,
     lineup: readonly LineupItem[],
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
 
   updateChannelStartTime(id: string, newTime: number): Promise<void>;
 

--- a/server/src/db/interfaces/IFillerListDB.ts
+++ b/server/src/db/interfaces/IFillerListDB.ts
@@ -36,7 +36,7 @@ export interface IFillerListDB {
     id: string,
   ): Promise<Array<{ number: number; name: string }>>;
 
-  deleteFiller(id: string): Promise<void>;
+  deleteFiller(id: string): void;
 
   getAllFillerIds(): Promise<string[]>;
 

--- a/server/src/db/mediaSourceDB.ts
+++ b/server/src/db/mediaSourceDB.ts
@@ -8,7 +8,7 @@ import type {
   UpdateMediaSourceRequest,
 } from '@tunarr/types/api';
 import dayjs from 'dayjs';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { inject, injectable, interfaces } from 'inversify';
 import { Kysely } from 'kysely';
 import {
@@ -43,12 +43,14 @@ import {
   PlexMediaSource,
 } from './schema/derivedTypes.js';
 import { DrizzleDBAccess } from './schema/index.ts';
+import { MediaSource } from './schema/MediaSource.ts';
 import {
   MediaSourceLibrary,
   MediaSourceLibraryUpdate,
   NewMediaSourceLibrary,
 } from './schema/MediaSourceLibrary.ts';
 import { MediaSourceLibraryReplacePath } from './schema/MediaSourceLibraryReplacePath.ts';
+import { Program } from './schema/Program.ts';
 
 type MediaSourceUserInfo = {
   userId?: string;
@@ -186,11 +188,8 @@ export class MediaSourceDB {
     // Remove all associations of this program
     for (const programChunk of chunk(allPrograms, 100)) {
       const programIds = programChunk.map((p) => p.uuid);
-      await this.db.transaction().execute(async (tx) => {
-        await tx
-          .deleteFrom('program')
-          .where('uuid', 'in', programIds)
-          .execute();
+      this.drizzleDB.transaction((tx) => {
+        tx.delete(Program).where(inArray(Program.uuid, programIds)).run();
       });
     }
 
@@ -226,15 +225,14 @@ export class MediaSourceDB {
     }
 
     if (updateReq.type === 'local') {
-      await this.db.transaction().execute(async (tx) => {
-        await tx
-          .updateTable('mediaSource')
+      this.drizzleDB.transaction((tx) => {
+        tx.update(MediaSource)
           .set({
             mediaType: updateReq.mediaType,
             name: tag<MediaSourceName>(updateReq.name),
           })
-          .where('mediaSource.uuid', '=', id)
-          .executeTakeFirstOrThrow();
+          .where(eq(MediaSource.uuid, id))
+          .run();
 
         const newPaths = differenceWith(
           updateReq.paths,
@@ -248,20 +246,18 @@ export class MediaSourceDB {
         ).map(({ externalKey }) => externalKey);
 
         if (deletePaths.length > 0) {
-          await tx
-            .deleteFrom('mediaSourceLibrary')
+          tx.delete(MediaSourceLibrary)
             .where(
-              'mediaSourceLibrary.mediaSourceId',
-              '=',
-              tag<MediaSourceId>(updateReq.id),
+              and(
+                eq(MediaSourceLibrary, tag<MediaSourceId>(updateReq.id)),
+                inArray(MediaSourceLibrary.externalKey, deletePaths),
+              ),
             )
-            .where('mediaSourceLibrary.externalKey', 'in', deletePaths)
-            .executeTakeFirstOrThrow();
+            .run();
         }
 
         if (newPaths.length > 0) {
-          await tx
-            .insertInto('mediaSourceLibrary')
+          tx.insert(MediaSourceLibrary)
             .values(
               newPaths.map((path) => ({
                 externalKey: path,
@@ -269,11 +265,11 @@ export class MediaSourceDB {
                 mediaType: updateReq.mediaType,
                 name: path,
                 uuid: v4(),
-                enabled: booleanToNumber(true),
+                enabled: true,
                 lastScannedAt: null,
               })),
             )
-            .executeTakeFirstOrThrow();
+            .run();
         }
       });
     } else {
@@ -354,16 +350,15 @@ export class MediaSourceDB {
       .then((_) => _?.count ?? 0);
 
     const now = +dayjs();
-    const newServer = await this.db.transaction().execute(async (tx) => {
-      const newServer = await tx
-        .insertInto('mediaSource')
+    const newServer = this.drizzleDB.transaction((tx) => {
+      const newServer = tx
+        .insert(MediaSource)
         .values({
-          // ...server,
           uuid: tag<MediaSourceId>(v4()),
           name,
           uri: server.type === 'local' ? '' : trimEnd(server.uri, '/'),
-          sendChannelUpdates: booleanToNumber(false),
-          sendGuideUpdates: booleanToNumber(sendGuideUpdates),
+          sendChannelUpdates: false,
+          sendGuideUpdates: sendGuideUpdates,
           createdAt: now,
           updatedAt: now,
           index,
@@ -382,13 +377,12 @@ export class MediaSourceDB {
                 : null,
           accessToken: server.type === 'local' ? '' : server.accessToken,
           mediaType: server.type === 'local' ? server.mediaType : null,
-        })
-        .returning('uuid')
-        .executeTakeFirstOrThrow();
+        } satisfies typeof MediaSource.$inferInsert)
+        .returning({ uuid: MediaSource.uuid })
+        .get();
 
       if (server.type === 'local') {
-        await tx
-          .insertInto('mediaSourceLibrary')
+        tx.insert(MediaSourceLibrary)
           .values(
             server.paths.map(
               (path) =>
@@ -398,12 +392,12 @@ export class MediaSourceDB {
                   mediaType: server.mediaType,
                   name: path,
                   uuid: v4(),
-                  enabled: booleanToNumber(true),
+                  enabled: true,
                   lastScannedAt: null,
-                }) satisfies NewMediaSourceLibrary,
+                }) satisfies typeof MediaSourceLibrary.$inferInsert,
             ),
           )
-          .executeTakeFirstOrThrow();
+          .all();
       }
 
       return newServer;
@@ -425,30 +419,25 @@ export class MediaSourceDB {
     return newServer?.uuid;
   }
 
-  async updateLibraries(updates: MediaSourceLibrariesUpdate) {
-    return this.db.transaction().execute(async (tx) => {
+  updateLibraries(updates: MediaSourceLibrariesUpdate) {
+    this.drizzleDB.transaction((tx) => {
       if (!isEmpty(updates.addedLibraries)) {
-        await tx
-          .insertInto('mediaSourceLibrary')
-          .values(updates.addedLibraries)
-          .execute();
+        tx.insert(MediaSourceLibrary).values(updates.addedLibraries).run();
       }
 
       if (updates.updatedLibraries.length > 0) {
         for (const update of updates.updatedLibraries) {
-          await tx
-            .updateTable('mediaSourceLibrary')
+          tx.update(MediaSourceLibrary)
             .set(update)
-            .where('uuid', '=', update.uuid)
-            .executeTakeFirstOrThrow();
+            .where(eq(MediaSourceLibrary.uuid, update.uuid))
+            .run();
         }
       }
 
       if (updates.deletedLibraries.length > 0) {
-        await tx
-          .deleteFrom('mediaSourceLibrary')
-          .where('uuid', 'in', updates.deletedLibraries)
-          .execute();
+        tx.delete(MediaSourceLibrary)
+          .where(inArray(MediaSourceLibrary.uuid, updates.deletedLibraries))
+          .run();
       }
     });
   }

--- a/server/src/db/program/ProgramExternalIdRepository.ts
+++ b/server/src/db/program/ProgramExternalIdRepository.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@/util/logging/LoggerFactory.js';
 import { seq } from '@tunarr/shared/util';
 import { flatMapAsyncSeq, isNonEmptyString } from '../../util/index.ts';
 import { createExternalId } from '@tunarr/shared';
+import { and, eq, isNull as dbIsNull, isNotNull, sql } from 'drizzle-orm';
 import { inject, injectable } from 'inversify';
 import type { Kysely } from 'kysely';
 import { chunk, first, isEmpty, isNil, last, map, mapValues } from 'lodash-es';
@@ -16,9 +17,11 @@ import type {
   MinimalProgramExternalId,
   NewProgramExternalId,
   NewSingleOrMultiExternalId,
-  ProgramExternalId,
 } from '../schema/ProgramExternalId.ts';
-import { toInsertableProgramExternalId } from '../schema/ProgramExternalId.ts';
+import {
+  ProgramExternalId,
+  toInsertableProgramExternalId,
+} from '../schema/ProgramExternalId.ts';
 import type { MediaSourceId, RemoteSourceType } from '../schema/base.ts';
 import type { DB } from '../schema/db.ts';
 import type { ProgramWithRelationsOrm } from '../schema/derivedTypes.ts';
@@ -28,8 +31,7 @@ import { groupByUniq } from '../../util/index.ts';
 import type { RemoteMediaSourceType } from '../schema/MediaSource.ts';
 import type { ProgramDao } from '../schema/Program.ts';
 import type { Dictionary } from 'ts-essentials';
-import { groupBy, flatten, partition } from 'lodash-es';
-import { mapAsyncSeq } from '../../util/index.ts';
+import { groupBy, partition } from 'lodash-es';
 
 @injectable()
 export class ProgramExternalIdRepository {
@@ -262,37 +264,35 @@ export class ProgramExternalIdRepository {
     }
   }
 
-  async replaceProgramExternalId(
+  replaceProgramExternalId(
     programId: string,
     newExternalId: NewProgramExternalId,
     oldExternalId?: MinimalProgramExternalId,
   ) {
-    await this.db.transaction().execute(async (tx) => {
+    this.drizzleDB.transaction((tx) => {
       if (oldExternalId) {
-        await tx
-          .deleteFrom('programExternalId')
-          .where('programExternalId.programUuid', '=', programId)
+        tx.delete(ProgramExternalId)
           .where(
-            'programExternalId.externalKey',
-            '=',
-            oldExternalId.externalKey,
+            and(
+              eq(ProgramExternalId.programUuid, programId),
+              eq(ProgramExternalId.externalKey, oldExternalId.externalKey),
+              eq(
+                ProgramExternalId.externalSourceId,
+                oldExternalId.externalSourceId!,
+              ),
+              eq(ProgramExternalId.sourceType, oldExternalId.sourceType),
+            ),
           )
-          .where(
-            'programExternalId.externalSourceId',
-            '=',
-            oldExternalId.externalSourceId,
-          )
-          .where('programExternalId.sourceType', '=', oldExternalId.sourceType)
-          .execute();
+          .run();
       }
-      await tx.insertInto('programExternalId').values(newExternalId).execute();
+      tx.insert(ProgramExternalId).values(newExternalId).run();
     });
   }
 
-  async upsertProgramExternalIds(
+  upsertProgramExternalIds(
     externalIds: NewSingleOrMultiExternalId[],
     chunkSize: number = 100,
-  ): Promise<Dictionary<ProgramExternalId[]>> {
+  ): Dictionary<ProgramExternalId[]> {
     if (isEmpty(externalIds)) {
       return {};
     }
@@ -304,82 +304,71 @@ export class ProgramExternalIdRepository {
       (id) => id.type === 'single',
     );
 
-    let singleIdPromise: Promise<ProgramExternalId[]>;
-    if (!isEmpty(singles)) {
-      singleIdPromise = mapAsyncSeq(
-        chunk(singles, chunkSize),
-        (singleChunk) => {
-          return this.db.transaction().execute((tx) =>
-            tx
-              .insertInto('programExternalId')
-              .values(singleChunk.map(toInsertableProgramExternalId))
-              .onConflict((oc) =>
-                oc
-                  .columns(['programUuid', 'sourceType'])
-                  .where('mediaSourceId', 'is', null)
-                  .doUpdateSet((eb) => ({
-                    updatedAt: eb.ref('excluded.updatedAt'),
-                    externalFilePath: eb.ref('excluded.externalFilePath'),
-                    directFilePath: eb.ref('excluded.directFilePath'),
-                    programUuid: eb.ref('excluded.programUuid'),
-                  })),
-              )
-              .returningAll()
-              .execute(),
-          );
-        },
-      ).then(flatten);
-    } else {
-      singleIdPromise = Promise.resolve([]);
-    }
-
-    let multiIdPromise: Promise<ProgramExternalId[]>;
-    if (!isEmpty(multiples)) {
-      multiIdPromise = mapAsyncSeq(
-        chunk(multiples, chunkSize),
-        (multiChunk) => {
-          return this.db.transaction().execute((tx) =>
-            tx
-              .insertInto('programExternalId')
-              .values(multiChunk.map(toInsertableProgramExternalId))
-              .onConflict((oc) =>
-                oc
-                  .columns(['programUuid', 'sourceType', 'mediaSourceId'])
-                  .where('mediaSourceId', 'is not', null)
-                  .doUpdateSet((eb) => ({
-                    updatedAt: eb.ref('excluded.updatedAt'),
-                    externalFilePath: eb.ref('excluded.externalFilePath'),
-                    directFilePath: eb.ref('excluded.directFilePath'),
-                    programUuid: eb.ref('excluded.programUuid'),
-                  })),
-              )
-              .returningAll()
-              .execute(),
-          );
-        },
-      ).then(flatten);
-    } else {
-      multiIdPromise = Promise.resolve([]);
-    }
-
-    const [singleResult, multiResult] = await Promise.allSettled([
-      singleIdPromise,
-      multiIdPromise,
-    ]);
-
     const allExternalIds: ProgramExternalId[] = [];
-    if (singleResult.status === 'rejected') {
-      logger.error(singleResult.reason, 'Error saving external IDs');
-    } else {
-      logger.trace('Upserted %d external IDs', singleResult.value.length);
-      allExternalIds.push(...singleResult.value);
+
+    if (!isEmpty(singles)) {
+      try {
+        const singleResults = chunk(singles, chunkSize).flatMap(
+          (singleChunk) =>
+            this.drizzleDB.transaction((tx) =>
+              tx
+                .insert(ProgramExternalId)
+                .values(singleChunk.map(toInsertableProgramExternalId))
+                .onConflictDoUpdate({
+                  target: [
+                    ProgramExternalId.programUuid,
+                    ProgramExternalId.sourceType,
+                  ],
+                  targetWhere: dbIsNull(ProgramExternalId.mediaSourceId),
+                  set: {
+                    updatedAt: sql`excluded.updated_at`,
+                    externalFilePath: sql`excluded.external_file_path`,
+                    directFilePath: sql`excluded.direct_file_path`,
+                    programUuid: sql`excluded.program_uuid`,
+                  },
+                })
+                .returning()
+                .all(),
+            ),
+        );
+        logger.trace('Upserted %d external IDs', singleResults.length);
+        allExternalIds.push(...singleResults);
+      } catch (error) {
+        logger.error(error, 'Error saving external IDs');
+      }
     }
 
-    if (multiResult.status === 'rejected') {
-      logger.error(multiResult.reason, 'Error saving external IDs');
-    } else {
-      logger.trace('Upserted %d external IDs', multiResult.value.length);
-      allExternalIds.push(...multiResult.value);
+    if (!isEmpty(multiples)) {
+      try {
+        const multiResults = chunk(multiples, chunkSize).flatMap(
+          (multiChunk) =>
+            this.drizzleDB.transaction((tx) =>
+              tx
+                .insert(ProgramExternalId)
+                .values(multiChunk.map(toInsertableProgramExternalId))
+                .onConflictDoUpdate({
+                  target: [
+                    ProgramExternalId.programUuid,
+                    ProgramExternalId.sourceType,
+                    ProgramExternalId.mediaSourceId,
+                  ],
+                  targetWhere: isNotNull(ProgramExternalId.mediaSourceId),
+                  set: {
+                    updatedAt: sql`excluded.updated_at`,
+                    externalFilePath: sql`excluded.external_file_path`,
+                    directFilePath: sql`excluded.direct_file_path`,
+                    programUuid: sql`excluded.program_uuid`,
+                  },
+                })
+                .returning()
+                .all(),
+            ),
+        );
+        logger.trace('Upserted %d external IDs', multiResults.length);
+        allExternalIds.push(...multiResults);
+      } catch (error) {
+        logger.error(error, 'Error saving external IDs');
+      }
     }
 
     return groupBy(allExternalIds, (eid) => eid.programUuid);

--- a/server/src/db/program/ProgramGroupingUpsertRepository.ts
+++ b/server/src/db/program/ProgramGroupingUpsertRepository.ts
@@ -15,7 +15,6 @@ import type { InsertResult, Kysely } from 'kysely';
 import {
   chunk,
   compact,
-  head,
   isNil,
   keys,
   omit,
@@ -123,13 +122,13 @@ export class ProgramGroupingUpsertRepository {
       for (const externalId of newGroupingAndRelations.externalIds) {
         externalId.groupUuid = entity.uuid;
       }
-      entity = await this.drizzleDB.transaction(async (tx) => {
-        const updated = await this.updateProgramGrouping(
+      entity = this.drizzleDB.transaction((tx) => {
+        const updated = this.updateProgramGrouping(
           newGroupingAndRelations,
           entity!,
           tx,
         );
-        const upsertedExternalIds = await this.updateProgramGroupingExternalIds(
+        const upsertedExternalIds = this.updateProgramGroupingExternalIds(
           entity!.externalIds,
           externalIds,
           tx,
@@ -142,20 +141,19 @@ export class ProgramGroupingUpsertRepository {
 
       wasUpdated = true;
     } else if (!entity) {
-      entity = await this.drizzleDB.transaction(async (tx) => {
-        const grouping = head(
-          await tx
-            .insert(ProgramGrouping)
-            .values(omit(dao, 'externalIds'))
-            .returning(),
-        )!;
+      entity = this.drizzleDB.transaction((tx) => {
+        const grouping = tx
+          .insert(ProgramGrouping)
+          .values(omit(dao, 'externalIds'))
+          .returning()
+          .get();
         const insertedExternalIds: ProgramGroupingExternalIdOrm[] = [];
         if (externalIds.length > 0) {
           insertedExternalIds.push(
-            ...(await this.upsertProgramGroupingExternalIdsChunkOrm(
+            ...this.upsertProgramGroupingExternalIdsChunkOrm(
               externalIds,
               tx,
-            )),
+            ),
           );
         }
 
@@ -178,11 +176,11 @@ export class ProgramGroupingUpsertRepository {
         artwork.groupingId = entity.uuid;
       });
 
-      await this.metadataRepo.upsertCredits(
+      this.metadataRepo.upsertCredits(
         newGroupingAndRelations.credits.map(({ credit }) => credit),
       );
 
-      await this.metadataRepo.upsertArtwork(
+      this.metadataRepo.upsertArtwork(
         newGroupingAndRelations.artwork.concat(
           newGroupingAndRelations.credits.flatMap(({ artwork }) => artwork),
         ),
@@ -248,11 +246,11 @@ export class ProgramGroupingUpsertRepository {
       .then((result) => result?.grouping ?? undefined);
   }
 
-  private async updateProgramGrouping(
+  private updateProgramGrouping(
     { programGrouping: incoming }: NewProgramGroupingWithRelations,
     existing: ProgramGroupingOrmWithRelations,
     tx: BaseSQLiteDatabase<'sync', RunResult, typeof schema> = this.drizzleDB,
-  ): Promise<ProgramGroupingOrm> {
+  ): ProgramGroupingOrm {
     const update: NewProgramGroupingOrm = {
       ...omit(existing, 'externalIds'),
       index: incoming.index,
@@ -275,21 +273,20 @@ export class ProgramGroupingUpsertRepository {
       state: incoming.state,
     };
 
-    return head(
-      await tx
-        .update(ProgramGrouping)
-        .set(update)
-        .where(eq(ProgramGrouping.uuid, existing.uuid))
-        .limit(1)
-        .returning(),
-    )!;
+    return tx
+      .update(ProgramGrouping)
+      .set(update)
+      .where(eq(ProgramGrouping.uuid, existing.uuid))
+      .limit(1)
+      .returning()
+      .get();
   }
 
-  private async updateProgramGroupingExternalIds(
+  private updateProgramGroupingExternalIds(
     existingIds: ProgramGroupingExternalId[],
     newIds: NewSingleOrMultiProgramGroupingExternalId[],
     tx: BaseSQLiteDatabase<'sync', RunResult, typeof schema> = this.drizzleDB,
-  ): Promise<ProgramGroupingExternalIdOrm[]> {
+  ): ProgramGroupingExternalIdOrm[] {
     devAssert(
       uniq(seq.collect(existingIds, (id) => id.mediaSourceId)).length <= 1,
     );
@@ -326,52 +323,48 @@ export class ProgramGroupingUpsertRepository {
     const deletedIds = [...deletedUniqueKeys.values()].map(
       (key) => existingByUniqueId[key]!,
     );
-    await Promise.all(
-      chunk(deletedIds, 100).map((idChunk) => {
-        const clauses = idChunk.map((id) =>
-          and(
-            id.mediaSourceId
-              ? eq(ProgramGroupingExternalId.mediaSourceId, id.mediaSourceId)
-              : dbIsNull(ProgramGroupingExternalId.mediaSourceId),
-            id.libraryId
-              ? eq(ProgramGroupingExternalId.libraryId, id.libraryId)
-              : dbIsNull(ProgramGroupingExternalId.libraryId),
-            eq(ProgramGroupingExternalId.externalKey, id.externalKey),
-            id.externalSourceId
-              ? eq(
-                  ProgramGroupingExternalId.externalSourceId,
-                  id.externalSourceId,
-                )
-              : dbIsNull(ProgramGroupingExternalId.externalSourceId),
-            eq(ProgramGroupingExternalId.sourceType, id.sourceType),
-          ),
-        );
+    for (const idChunk of chunk(deletedIds, 100)) {
+      const clauses = idChunk.map((id) =>
+        and(
+          id.mediaSourceId
+            ? eq(ProgramGroupingExternalId.mediaSourceId, id.mediaSourceId)
+            : dbIsNull(ProgramGroupingExternalId.mediaSourceId),
+          id.libraryId
+            ? eq(ProgramGroupingExternalId.libraryId, id.libraryId)
+            : dbIsNull(ProgramGroupingExternalId.libraryId),
+          eq(ProgramGroupingExternalId.externalKey, id.externalKey),
+          id.externalSourceId
+            ? eq(
+                ProgramGroupingExternalId.externalSourceId,
+                id.externalSourceId,
+              )
+            : dbIsNull(ProgramGroupingExternalId.externalSourceId),
+          eq(ProgramGroupingExternalId.sourceType, id.sourceType),
+        ),
+      );
 
-        return tx
-          .delete(ProgramGroupingExternalId)
-          .where(or(...clauses))
-          .execute();
-      }),
-    );
+      tx
+        .delete(ProgramGroupingExternalId)
+        .where(or(...clauses))
+        .run();
+    }
 
     const addedIds = [...addedUniqueKeys.union(updatedKeys).values()].map(
       (key) => newByUniqueId[key]!,
     );
 
-    return await Promise.all(
-      chunk(addedIds, 100).map((idChunk) =>
-        this.upsertProgramGroupingExternalIdsChunkOrm(idChunk, tx),
-      ),
-    ).then((_) => _.flat());
+    return chunk(addedIds, 100).flatMap((idChunk) =>
+      this.upsertProgramGroupingExternalIdsChunkOrm(idChunk, tx),
+    );
   }
 
-  async upsertProgramGroupingExternalIdsChunkOrm(
+  upsertProgramGroupingExternalIdsChunkOrm(
     ids: (
       | NewSingleOrMultiProgramGroupingExternalId
       | NewProgramGroupingExternalId
     )[],
     tx: BaseSQLiteDatabase<'sync', RunResult, typeof schema> = this.drizzleDB,
-  ): Promise<ProgramGroupingExternalIdOrm[]> {
+  ): ProgramGroupingExternalIdOrm[] {
     if (ids.length === 0) {
       return [];
     }
@@ -380,11 +373,11 @@ export class ProgramGroupingUpsertRepository {
       isValidSingleExternalIdType(id.sourceType),
     );
 
-    const promises: Promise<ProgramGroupingExternalIdOrm[]>[] = [];
+    const results: ProgramGroupingExternalIdOrm[] = [];
 
     if (singles.length > 0) {
-      promises.push(
-        tx
+      results.push(
+        ...tx
           .insert(ProgramGroupingExternalId)
           .values(singles.map(toInsertableProgramGroupingExternalId))
           .onConflictDoUpdate({
@@ -401,13 +394,13 @@ export class ProgramGroupingUpsertRepository {
             },
           })
           .returning()
-          .execute(),
+          .all(),
       );
     }
 
     if (multiples.length > 0) {
-      promises.push(
-        tx
+      results.push(
+        ...tx
           .insert(ProgramGroupingExternalId)
           .values(multiples.map(toInsertableProgramGroupingExternalId))
           .onConflictDoUpdate({
@@ -425,11 +418,11 @@ export class ProgramGroupingUpsertRepository {
             },
           })
           .returning()
-          .execute(),
+          .all(),
       );
     }
 
-    return (await Promise.all(promises)).flat();
+    return results;
   }
 
   async upsertProgramGroupingExternalIdsChunk(

--- a/server/src/db/program/ProgramMetadataRepository.ts
+++ b/server/src/db/program/ProgramMetadataRepository.ts
@@ -30,7 +30,7 @@ import type { DrizzleDBAccess } from '../schema/index.ts';
 export class ProgramMetadataRepository {
   constructor(@inject(KEYS.DrizzleDB) private drizzleDB: DrizzleDBAccess) {}
 
-  async upsertArtwork(artwork: NewArtwork[]) {
+  upsertArtwork(artwork: NewArtwork[]) {
     if (artwork.length === 0) {
       return;
     }
@@ -48,19 +48,19 @@ export class ProgramMetadataRepository {
       (art) => art.creditId,
     );
 
-    return await this.drizzleDB.transaction(async (tx) => {
+    return this.drizzleDB.transaction((tx) => {
       for (const batch of chunk(keys(programArt), 50)) {
-        await tx.delete(Artwork).where(inArray(Artwork.programId, batch));
+        tx.delete(Artwork).where(inArray(Artwork.programId, batch)).run();
       }
       for (const batch of chunk(keys(groupArt), 50)) {
-        await tx.delete(Artwork).where(inArray(Artwork.groupingId, batch));
+        tx.delete(Artwork).where(inArray(Artwork.groupingId, batch)).run();
       }
       for (const batch of chunk(keys(creditArt), 50)) {
-        await tx.delete(Artwork).where(inArray(Artwork.creditId, batch));
+        tx.delete(Artwork).where(inArray(Artwork.creditId, batch)).run();
       }
       const inserted: Artwork[] = [];
       for (const batch of chunk(artwork, 50)) {
-        const batchResult = await this.drizzleDB
+        const batchResult = tx
           .insert(Artwork)
           .values(batch)
           .onConflictDoUpdate({
@@ -73,7 +73,8 @@ export class ProgramMetadataRepository {
               sourcePath: sql`excluded.source_path`,
             },
           })
-          .returning();
+          .returning()
+          .all();
         inserted.push(...batchResult);
       }
       return inserted;
@@ -126,20 +127,20 @@ export class ProgramMetadataRepository {
       });
     }
 
-    return this.drizzleDB.transaction(async (tx) => {
+    return this.drizzleDB.transaction((tx) => {
       const col =
         entityType === 'grouping' ? EntityGenre.groupId : EntityGenre.programId;
-      await tx.delete(EntityGenre).where(eq(col, joinId));
+      tx.delete(EntityGenre).where(eq(col, joinId)).run();
       if (newGenreNames.size > 0) {
-        await tx
-          .insert(Genre)
+        tx.insert(Genre)
           .values(
             [...newGenreNames.values()].map((name) => incomingByName[name]!),
           )
-          .onConflictDoNothing();
+          .onConflictDoNothing()
+          .run();
       }
       if (relations.length > 0) {
-        await tx.insert(EntityGenre).values(relations).onConflictDoNothing();
+        tx.insert(EntityGenre).values(relations).onConflictDoNothing().run();
       }
     });
   }
@@ -190,22 +191,22 @@ export class ProgramMetadataRepository {
       });
     }
 
-    return this.drizzleDB.transaction(async (tx) => {
+    return this.drizzleDB.transaction((tx) => {
       const col =
         entityType === 'grouping'
           ? StudioEntity.groupId
           : StudioEntity.programId;
-      await tx.delete(StudioEntity).where(eq(col, joinId));
+      tx.delete(StudioEntity).where(eq(col, joinId)).run();
       if (newStudioNames.size > 0) {
-        await tx
-          .insert(Studio)
+        tx.insert(Studio)
           .values(
             [...newStudioNames.values()].map((name) => incomingByName[name]!),
           )
-          .onConflictDoNothing();
+          .onConflictDoNothing()
+          .run();
       }
       if (relations.length > 0) {
-        await tx.insert(StudioEntity).values(relations).onConflictDoNothing();
+        tx.insert(StudioEntity).values(relations).onConflictDoNothing().run();
       }
     });
   }
@@ -257,24 +258,24 @@ export class ProgramMetadataRepository {
       });
     }
 
-    return this.drizzleDB.transaction(async (tx) => {
+    return this.drizzleDB.transaction((tx) => {
       const col =
         entityType === 'grouping'
           ? TagRelations.groupingId
           : TagRelations.programId;
-      await tx
-        .delete(TagRelations)
-        .where(and(eq(col, joinId), eq(TagRelations.source, 'media')));
+      tx.delete(TagRelations)
+        .where(and(eq(col, joinId), eq(TagRelations.source, 'media')))
+        .run();
       if (newTagNames.size > 0) {
-        await tx
-          .insert(Tag)
+        tx.insert(Tag)
           .values(
             [...newTagNames.values()].map((name) => incomingByName[name]!),
           )
-          .onConflictDoNothing();
+          .onConflictDoNothing()
+          .run();
       }
       if (relations.length > 0) {
-        await tx.insert(TagRelations).values(relations).onConflictDoNothing();
+        tx.insert(TagRelations).values(relations).onConflictDoNothing().run();
       }
     });
   }
@@ -371,45 +372,45 @@ export class ProgramMetadataRepository {
         updates.push(existing);
       }
 
-      await this.drizzleDB.transaction(async (tx) => {
+      this.drizzleDB.transaction((tx) => {
         if (inserts.length > 0) {
-          await tx.insert(ProgramSubtitles).values(inserts);
+          tx.insert(ProgramSubtitles).values(inserts).run();
         }
         if (removes.length > 0) {
-          await tx.delete(ProgramSubtitles).where(
+          tx.delete(ProgramSubtitles).where(
             inArray(
               ProgramSubtitles.uuid,
               removes.map((s) => s.uuid),
             ),
-          );
+          ).run();
         }
 
         if (updates.length > 0) {
           for (const update of updates) {
-            await tx
-              .update(ProgramSubtitles)
+            tx.update(ProgramSubtitles)
               .set(update)
-              .where(eq(ProgramSubtitles.uuid, update.uuid));
+              .where(eq(ProgramSubtitles.uuid, update.uuid))
+              .run();
           }
         }
 
-        await tx
-          .delete(ProgramSubtitles)
+        tx.delete(ProgramSubtitles)
           .where(
             and(
               eq(ProgramSubtitles.subtitleType, 'sidecar'),
               eq(ProgramSubtitles.programId, programId),
             ),
-          );
+          )
+          .run();
 
         if (incomingExternal.length > 0) {
-          await tx.insert(ProgramSubtitles).values(incomingExternal);
+          tx.insert(ProgramSubtitles).values(incomingExternal).run();
         }
       });
     }
   }
 
-  async upsertCredits(credits: NewCredit[]) {
+  upsertCredits(credits: NewCredit[]) {
     if (credits.length === 0) {
       return;
     }
@@ -423,19 +424,20 @@ export class ProgramMetadataRepository {
       (credit) => credit.groupingId,
     );
 
-    return await this.drizzleDB.transaction(async (tx) => {
+    return this.drizzleDB.transaction((tx) => {
       for (const batch of chunk(keys(programCredits), 50)) {
-        await tx.delete(Credit).where(inArray(Credit.programId, batch));
+        tx.delete(Credit).where(inArray(Credit.programId, batch)).run();
       }
       for (const batch of chunk(keys(groupCredits), 50)) {
-        await tx.delete(Credit).where(inArray(Credit.groupingId, batch));
+        tx.delete(Credit).where(inArray(Credit.groupingId, batch)).run();
       }
       const inserted: Credit[] = [];
       for (const batch of chunk(credits, 50)) {
-        const batchResult = await this.drizzleDB
+        const batchResult = tx
           .insert(Credit)
           .values(batch)
-          .returning();
+          .returning()
+          .all();
         inserted.push(...batchResult);
       }
       return inserted;

--- a/server/src/db/program/ProgramUpsertRepository.ts
+++ b/server/src/db/program/ProgramUpsertRepository.ts
@@ -25,9 +25,8 @@ import {
   untag,
 } from '@tunarr/types';
 import dayjs from 'dayjs';
+import { eq, inArray, sql } from 'drizzle-orm';
 import { inject, injectable, interfaces } from 'inversify';
-import type { CaseWhenBuilder, Kysely, NotNull } from 'kysely';
-import { UpdateResult } from 'kysely';
 import {
   chunk,
   concat,
@@ -47,7 +46,6 @@ import {
   omit,
   orderBy,
   partition,
-  reduce,
   reject,
   round,
   some,
@@ -62,7 +60,6 @@ import {
   groupByUniqProp,
   isNonEmptyString,
   mapAsyncSeq,
-  mapToObj,
   unzip as myUnzip,
   programExternalIdString,
   run,
@@ -70,32 +67,32 @@ import {
 import { ProgramGroupingMinter } from '../converters/ProgramGroupingMinter.ts';
 import { ProgramDaoMinter } from '../converters/ProgramMinter.ts';
 import { ProgramSourceType } from '../custom_types/ProgramSourceType.ts';
-import { ProgramUpsertFields } from '../programQueryHelpers.ts';
+import { caseWhen } from '../DrizzleSqlCaseWhen.ts';
+import { ProgramUpsertSetClause } from '../programQueryHelpers.ts';
 import type { NewArtwork } from '../schema/Artwork.ts';
 import type { NewCredit } from '../schema/Credit.ts';
 import type { NewGenre } from '../schema/Genre.ts';
 import type { MediaSourceOrm } from '../schema/MediaSource.ts';
-import type { MediaSourceLibraryOrm } from '../schema/MediaSourceLibrary.ts';
-import { type ProgramDao, ProgramType } from '../schema/Program.ts';
-import type {
-  NewProgramChapter,
+import type { MediaSourceLibrary } from '../schema/MediaSourceLibrary.ts';
+import { Program, type ProgramDao, ProgramType } from '../schema/Program.ts';
+import {
   ProgramChapter,
+  type NewProgramChapter,
 } from '../schema/ProgramChapter.ts';
 import type { NewSingleOrMultiExternalId } from '../schema/ProgramExternalId.ts';
 import { ProgramGroupingType } from '../schema/ProgramGrouping.ts';
-import type {
-  NewProgramMediaFile,
+import {
   ProgramMediaFile,
+  type NewProgramMediaFile,
 } from '../schema/ProgramMediaFile.ts';
-import type {
-  NewProgramMediaStream,
+import {
   ProgramMediaStream,
+  type NewProgramMediaStream,
 } from '../schema/ProgramMediaStream.ts';
 import type { NewProgramSubtitles } from '../schema/ProgramSubtitles.ts';
-import type { ProgramVersion } from '../schema/ProgramVersion.ts';
+import { ProgramVersion } from '../schema/ProgramVersion.ts';
 import type { NewStudio } from '../schema/Studio.ts';
 import type { NewTag } from '../schema/Tag.ts';
-import type { DB } from '../schema/db.ts';
 import type {
   MediaSourceWithLibraries,
   NewProgramGroupingWithRelations,
@@ -124,20 +121,12 @@ type RelevantProgramWithHierarchy = {
   parentKey: string;
 };
 
-type ProgramRelationCaseBuilder = CaseWhenBuilder<
-  DB,
-  'program',
-  unknown,
-  string | null
->;
-
 @injectable()
 export class ProgramUpsertRepository {
   private timer: Timer;
 
   constructor(
     @inject(KEYS.Logger) private logger: Logger,
-    @inject(KEYS.Database) private db: Kysely<DB>,
     @inject(KEYS.DrizzleDB) private drizzleDB: DrizzleDBAccess,
     @inject(autoFactoryKey(SavePlexProgramExternalIdsTask))
     private savePlexProgramExternalIdsTaskFactory: interfaces.AutoFactory<SavePlexProgramExternalIdsTask>,
@@ -267,7 +256,7 @@ export class ProgramUpsertRepository {
     this.logger.debug('Upserting %d programs', programsToPersist.length);
 
     const upsertedPrograms: MarkNonNullable<ProgramDao, 'mediaSourceId'>[] = [];
-    await this.timer.timeAsync('programUpsert', async () => {
+    this.timer.timeSync('programUpsert', () => {
       for (const chunkToInsert of chunk(
         programsToPersist,
         programUpsertBatchSize,
@@ -277,23 +266,21 @@ export class ProgramUpsertRepository {
         );
         try {
           upsertedPrograms.push(
-            ...(await this.db.transaction().execute((tx) =>
+            ...(this.drizzleDB.transaction((tx) =>
               tx
-                .insertInto('program')
+                .insert(Program)
                 .values(programsToUpsert)
-                .onConflict((oc) =>
-                  oc
-                    .columns(['sourceType', 'mediaSourceId', 'externalKey'])
-                    .doUpdateSet((eb) =>
-                      mapToObj(ProgramUpsertFields, (f) => ({
-                        [f.replace('excluded.', '')]: eb.ref(f),
-                      })),
-                    ),
-                )
-                .returningAll()
-                .$narrowType<{ mediaSourceId: NotNull }>()
-                .execute(),
-            )),
+                .onConflictDoUpdate({
+                  target: [
+                    Program.sourceType,
+                    Program.mediaSourceId,
+                    Program.externalKey,
+                  ],
+                  set: ProgramUpsertSetClause,
+                })
+                .returning()
+                .all(),
+            ) as MarkNonNullable<ProgramDao, 'mediaSourceId'>[]),
           );
         } catch (e) {
           this.logger.error(
@@ -328,7 +315,7 @@ export class ProgramUpsertRepository {
       (p) => p.sourceType === 'plex' || p.sourceType === 'jellyfin',
     );
 
-    await this.timer.timeAsync(
+    this.timer.timeSync(
       `upsert ${requiredExternalIds.length} external ids`,
       () =>
         this.externalIdRepo.upsertProgramExternalIds(requiredExternalIds, 200),
@@ -355,14 +342,16 @@ export class ProgramUpsertRepository {
         'UpsertExternalIds',
         dayjs().add(100),
         undefined,
-        AnonymousTask('UpsertExternalIds', () =>
-          this.timer.timeAsync(
+        AnonymousTask('UpsertExternalIds', () => {
+          this.timer.timeSync(
             `background external ID upsert (${backgroundExternalIds.length} ids)`,
             () =>
               this.externalIdRepo.upsertProgramExternalIds(
                 backgroundExternalIds,
               ),
-          ),
+          );
+          return Promise.resolve();
+        },
         ),
       );
     });
@@ -394,8 +383,6 @@ export class ProgramUpsertRepository {
       return [];
     }
 
-    const db = this.db;
-
     const requestsByCanonicalId = groupByUniq(
       requests,
       ({ program }) => program.canonicalId,
@@ -403,23 +390,21 @@ export class ProgramUpsertRepository {
 
     const result = await Promise.all(
       chunk(requests, programUpsertBatchSize).map(async (c) => {
-        const chunkResult = await db.transaction().execute((tx) =>
+        const chunkResult = this.drizzleDB.transaction((tx) =>
           tx
-            .insertInto('program')
+            .insert(Program)
             .values(c.map(({ program }) => program))
-            .onConflict((oc) =>
-              oc
-                .columns(['sourceType', 'mediaSourceId', 'externalKey'])
-                .doUpdateSet((eb) =>
-                  mapToObj(ProgramUpsertFields, (f) => ({
-                    [f.replace('excluded.', '')]: eb.ref(f),
-                  })),
-                ),
-            )
-            .returningAll()
-            .$narrowType<{ mediaSourceId: NotNull; canonicalId: NotNull }>()
-            .execute(),
-        );
+            .onConflictDoUpdate({
+              target: [
+                Program.sourceType,
+                Program.mediaSourceId,
+                Program.externalKey,
+              ],
+              set: ProgramUpsertSetClause,
+            })
+            .returning()
+            .all(),
+        ) as MarkNonNullable<ProgramDao, 'mediaSourceId' | 'canonicalId'>[];
 
         const allExternalIds = flatten(c.map((program) => program.externalIds));
         const versionsToInsert: NewProgramVersion[] = [];
@@ -476,13 +461,13 @@ export class ProgramUpsertRepository {
         }
 
         const externalIdsByProgramId =
-          await this.externalIdRepo.upsertProgramExternalIds(allExternalIds);
+          this.externalIdRepo.upsertProgramExternalIds(allExternalIds);
 
-        await this.upsertProgramVersions(versionsToInsert);
+        this.upsertProgramVersions(versionsToInsert);
 
-        await this.metadataRepo.upsertCredits(creditsToInsert);
+        this.metadataRepo.upsertCredits(creditsToInsert);
 
-        await this.metadataRepo.upsertArtwork(artworkToInsert);
+        this.metadataRepo.upsertArtwork(artworkToInsert);
 
         await this.metadataRepo.upsertSubtitles(subtitlesToInsert);
 
@@ -515,41 +500,40 @@ export class ProgramUpsertRepository {
     }
   }
 
-  private async upsertProgramVersions(versions: NewProgramVersion[]) {
+  private upsertProgramVersions(versions: NewProgramVersion[]) {
     if (versions.length === 0) {
       this.logger.warn('No program versions passed for item');
       return [];
     }
 
     const insertedVersions: ProgramVersion[] = [];
-    await this.db.transaction().execute(async (tx) => {
+    this.drizzleDB.transaction((tx) => {
       const byProgramId = groupByUniq(versions, (version) => version.programId);
       for (const batch of chunk(Object.entries(byProgramId), 50)) {
         const [programIds, versionBatch] = myUnzip(batch);
-        await tx
-          .deleteFrom('programVersion')
-          .where('programId', 'in', programIds)
-          .executeTakeFirstOrThrow();
+        tx.delete(ProgramVersion)
+          .where(inArray(ProgramVersion.programId, programIds))
+          .run();
 
-        const insertResult = await tx
-          .insertInto('programVersion')
+        const insertResult = tx
+          .insert(ProgramVersion)
           .values(
             versionBatch.map((version) =>
               omit(version, ['chapters', 'mediaStreams', 'mediaFiles']),
             ),
           )
-          .returningAll()
-          .execute();
+          .returning()
+          .all();
 
-        await this.upsertProgramMediaStreams(
+        this.upsertProgramMediaStreams(
           versionBatch.flatMap(({ mediaStreams }) => mediaStreams),
           tx,
         );
-        await this.upsertProgramChapters(
+        this.upsertProgramChapters(
           versionBatch.flatMap(({ chapters }) => chapters ?? []),
           tx,
         );
-        await this.upsertProgramMediaFiles(
+        this.upsertProgramMediaFiles(
           versionBatch.flatMap(({ mediaFiles }) => mediaFiles),
           tx,
         );
@@ -560,9 +544,9 @@ export class ProgramUpsertRepository {
     return insertedVersions;
   }
 
-  private async upsertProgramMediaStreams(
+  private upsertProgramMediaStreams(
     streams: NewProgramMediaStream[],
-    tx: Kysely<DB> = this.db,
+    tx: DrizzleDBAccess = this.drizzleDB,
   ) {
     if (streams.length === 0) {
       this.logger.warn('No media streams passed for version');
@@ -574,19 +558,19 @@ export class ProgramUpsertRepository {
     for (const batch of chunk(Object.entries(byVersionId), 50)) {
       const [_, streams] = myUnzip(batch);
       inserted.push(
-        ...(await tx
-          .insertInto('programMediaStream')
+        ...tx
+          .insert(ProgramMediaStream)
           .values(flatten(streams))
-          .returningAll()
-          .execute()),
+          .returning()
+          .all(),
       );
     }
     return inserted;
   }
 
-  private async upsertProgramChapters(
+  private upsertProgramChapters(
     chapters: NewProgramChapter[],
-    tx: Kysely<DB> = this.db,
+    tx: DrizzleDBAccess = this.drizzleDB,
   ) {
     if (chapters.length === 0) {
       return [];
@@ -597,19 +581,19 @@ export class ProgramUpsertRepository {
     for (const batch of chunk(Object.entries(byVersionId), 50)) {
       const [_, streams] = myUnzip(batch);
       inserted.push(
-        ...(await tx
-          .insertInto('programChapter')
+        ...tx
+          .insert(ProgramChapter)
           .values(flatten(streams))
-          .returningAll()
-          .execute()),
+          .returning()
+          .all(),
       );
     }
     return inserted;
   }
 
-  private async upsertProgramMediaFiles(
+  private upsertProgramMediaFiles(
     files: NewProgramMediaFile[],
-    tx: Kysely<DB> = this.db,
+    tx: DrizzleDBAccess = this.drizzleDB,
   ) {
     if (files.length === 0) {
       this.logger.warn('No media files passed for version');
@@ -621,11 +605,11 @@ export class ProgramUpsertRepository {
     for (const batch of chunk(Object.entries(byVersionId), 50)) {
       const [_, files] = myUnzip(batch);
       inserted.push(
-        ...(await tx
-          .insertInto('programMediaFile')
+        ...tx
+          .insert(ProgramMediaFile)
           .values(flatten(files))
-          .returningAll()
-          .execute()),
+          .returning()
+          .all(),
       );
     }
     return inserted;
@@ -675,7 +659,7 @@ export class ProgramUpsertRepository {
     upsertedPrograms: MarkNonNullable<ProgramDao, 'mediaSourceId'>[],
     programInfos: Record<string, MintedNewProgramInfo>,
     mediaSource: MediaSourceOrm,
-    library: MediaSourceLibraryOrm,
+    library: MediaSourceLibrary,
   ) {
     const grandparentRatingKeyToParentRatingKey: Record<
       string,
@@ -982,8 +966,8 @@ export class ProgramUpsertRepository {
     const hasUpdates = some(updatesByType, (updates) => updates.size > 0);
 
     if (hasUpdates) {
-      await this.timer.timeAsync('update program relations', () =>
-        this.db.transaction().execute(async (tx) => {
+      this.timer.timeSync('update program relations', () =>
+        this.drizzleDB.transaction((tx) => {
           const tvShowIdUpdates = [...updatesByType[ProgramGroupingType.Show]];
 
           const chunkSize = run(() => {
@@ -997,28 +981,28 @@ export class ProgramUpsertRepository {
             return DEFAULT_PROGRAM_GROUPING_UPDATE_CHUNK_SIZE;
           });
 
-          const updates: Promise<UpdateResult[]>[] = [];
-
           if (!isEmpty(tvShowIdUpdates)) {
             for (const idChunk of chunk(tvShowIdUpdates, chunkSize)) {
-              updates.push(
-                tx
-                  .updateTable('program')
-                  .set((eb) => ({
-                    tvShowUuid: reduce(
-                      idChunk,
-                      (acc, curr) =>
-                        acc
-                          .when('program.uuid', '=', curr)
-                          .then(upsertedProgramById[curr]!.tvShowUuid),
-                      eb.case() as unknown as ProgramRelationCaseBuilder,
-                    )
-                      .else(eb.ref('program.tvShowUuid'))
-                      .end(),
-                  }))
-                  .where('program.uuid', 'in', idChunk)
-                  .execute(),
-              );
+              const first = idChunk[0]!;
+              const caseExpr = idChunk
+                .slice(1)
+                .reduce(
+                  (acc, curr) =>
+                    acc.when(
+                      eq(Program.uuid, curr),
+                      sql`${upsertedProgramById[curr]!.tvShowUuid}`,
+                    ),
+                  caseWhen(
+                    eq(Program.uuid, first),
+                    sql`${upsertedProgramById[first]!.tvShowUuid}`,
+                  ),
+                )
+                .else(Program.tvShowUuid);
+
+              tx.update(Program)
+                .set({ tvShowUuid: caseExpr })
+                .where(inArray(Program.uuid, idChunk))
+                .run();
             }
           }
 
@@ -1028,24 +1012,26 @@ export class ProgramUpsertRepository {
 
           if (!isEmpty(seasonIdUpdates)) {
             for (const idChunk of chunk(seasonIdUpdates, chunkSize)) {
-              updates.push(
-                tx
-                  .updateTable('program')
-                  .set((eb) => ({
-                    seasonUuid: reduce(
-                      idChunk,
-                      (acc, curr) =>
-                        acc
-                          .when('program.uuid', '=', curr)
-                          .then(upsertedProgramById[curr]!.seasonUuid),
-                      eb.case() as unknown as ProgramRelationCaseBuilder,
-                    )
-                      .else(eb.ref('program.seasonUuid'))
-                      .end(),
-                  }))
-                  .where('program.uuid', 'in', idChunk)
-                  .execute(),
-              );
+              const first = idChunk[0]!;
+              const caseExpr = idChunk
+                .slice(1)
+                .reduce(
+                  (acc, curr) =>
+                    acc.when(
+                      eq(Program.uuid, curr),
+                      sql`${upsertedProgramById[curr]!.seasonUuid}`,
+                    ),
+                  caseWhen(
+                    eq(Program.uuid, first),
+                    sql`${upsertedProgramById[first]!.seasonUuid}`,
+                  ),
+                )
+                .else(Program.seasonUuid);
+
+              tx.update(Program)
+                .set({ seasonUuid: caseExpr })
+                .where(inArray(Program.uuid, idChunk))
+                .run();
             }
           }
 
@@ -1055,24 +1041,26 @@ export class ProgramUpsertRepository {
 
           if (!isEmpty(musicArtistUpdates)) {
             for (const idChunk of chunk(musicArtistUpdates, chunkSize)) {
-              updates.push(
-                tx
-                  .updateTable('program')
-                  .set((eb) => ({
-                    artistUuid: reduce(
-                      idChunk,
-                      (acc, curr) =>
-                        acc
-                          .when('program.uuid', '=', curr)
-                          .then(upsertedProgramById[curr]!.artistUuid),
-                      eb.case() as unknown as ProgramRelationCaseBuilder,
-                    )
-                      .else(eb.ref('program.artistUuid'))
-                      .end(),
-                  }))
-                  .where('program.uuid', 'in', idChunk)
-                  .execute(),
-              );
+              const first = idChunk[0]!;
+              const caseExpr = idChunk
+                .slice(1)
+                .reduce(
+                  (acc, curr) =>
+                    acc.when(
+                      eq(Program.uuid, curr),
+                      sql`${upsertedProgramById[curr]!.artistUuid}`,
+                    ),
+                  caseWhen(
+                    eq(Program.uuid, first),
+                    sql`${upsertedProgramById[first]!.artistUuid}`,
+                  ),
+                )
+                .else(Program.artistUuid);
+
+              tx.update(Program)
+                .set({ artistUuid: caseExpr })
+                .where(inArray(Program.uuid, idChunk))
+                .run();
             }
           }
 
@@ -1082,28 +1070,28 @@ export class ProgramUpsertRepository {
 
           if (!isEmpty(musicAlbumUpdates)) {
             for (const idChunk of chunk(musicAlbumUpdates, chunkSize)) {
-              updates.push(
-                tx
-                  .updateTable('program')
-                  .set((eb) => ({
-                    albumUuid: reduce(
-                      idChunk,
-                      (acc, curr) =>
-                        acc
-                          .when('program.uuid', '=', curr)
-                          .then(upsertedProgramById[curr]!.albumUuid),
-                      eb.case() as unknown as ProgramRelationCaseBuilder,
-                    )
-                      .else(eb.ref('program.albumUuid'))
-                      .end(),
-                  }))
-                  .where('program.uuid', 'in', idChunk)
-                  .execute(),
-              );
+              const first = idChunk[0]!;
+              const caseExpr = idChunk
+                .slice(1)
+                .reduce(
+                  (acc, curr) =>
+                    acc.when(
+                      eq(Program.uuid, curr),
+                      sql`${upsertedProgramById[curr]!.albumUuid}`,
+                    ),
+                  caseWhen(
+                    eq(Program.uuid, first),
+                    sql`${upsertedProgramById[first]!.albumUuid}`,
+                  ),
+                )
+                .else(Program.albumUuid);
+
+              tx.update(Program)
+                .set({ albumUuid: caseExpr })
+                .where(inArray(Program.uuid, idChunk))
+                .run();
             }
           }
-
-          await Promise.all(updates);
         }),
       );
     }

--- a/server/src/db/programQueryHelpers.ts
+++ b/server/src/db/programQueryHelpers.ts
@@ -1,5 +1,8 @@
+import { mapToObj } from '@/util/index.js';
 import { seq } from '@tunarr/shared/util';
 import { type TupleToUnion } from '@tunarr/types';
+import { sql } from 'drizzle-orm';
+import { toSnakeCase } from 'drizzle-orm/casing';
 import type {
   CaseWhenBuilder,
   ExpressionBuilder,
@@ -284,8 +287,8 @@ export const AllProgramFields = [
 ] as const;
 
 type ProgramUpsertFields = StrictExclude<
-  Replace<ProgramField, 'program', 'excluded'>,
-  'excluded.uuid' | 'excluded.createdAt'
+  Replace<ProgramField, 'program.', ''>,
+  'uuid' | 'createdAt'
 >;
 
 const ProgramUpsertIgnoreFields = [
@@ -306,14 +309,11 @@ export const ProgramUpsertFields: ProgramUpsertFields[] =
   AllProgramFields.filter(
     (f): f is KnownProgramUpsertFields =>
       !(ProgramUpsertIgnoreFields as ReadonlyArray<ProgramField>).includes(f),
-  ).map(
-    (v) =>
-      v.replace('program.', 'excluded.') as Replace<
-        typeof v,
-        'program',
-        'excluded'
-      >,
-  );
+  ).map((v) => v.replace('program.', '') as Replace<typeof v, 'program.', ''>);
+
+export const ProgramUpsertSetClause = mapToObj(ProgramUpsertFields, (f) => ({
+  [f]: sql`excluded.${sql.identifier(toSnakeCase(f))}`,
+}));
 
 type ProgramGroupingField = `programGrouping.${keyof ProgramGrouping}`;
 type ProgramGroupingUpsertFields = StrictExclude<

--- a/server/src/db/schema/Channel.ts
+++ b/server/src/db/schema/Channel.ts
@@ -1,4 +1,4 @@
-import type { InferSelectModel } from 'drizzle-orm';
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { inArray, relations } from 'drizzle-orm';
 import {
   check,
@@ -73,6 +73,7 @@ export type Channel = Selectable<ChannelTable>;
 export type NewChannel = Insertable<ChannelTable>;
 export type ChannelUpdate = Updateable<ChannelTable>;
 export type ChannelOrm = InferSelectModel<typeof Channel>;
+export type NewChannelOrm = InferInsertModel<typeof Channel>;
 
 export const ChannelRelations = relations(Channel, ({ many, one }) => ({
   channelPrograms: many(ChannelPrograms),

--- a/server/src/db/schema/MediaSourceLibrary.ts
+++ b/server/src/db/schema/MediaSourceLibrary.ts
@@ -1,6 +1,6 @@
+import type { InferInsertModel } from 'drizzle-orm';
 import { inArray, relations, type InferSelectModel } from 'drizzle-orm';
 import { check, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { Insertable, Selectable, Updateable } from 'kysely';
 import { MediaLibraryTypes, type MediaSourceId } from './base.ts';
 import type { KyselifyBetter } from './KyselifyBetter.ts';
 import { MediaSource } from './MediaSource.ts';
@@ -50,7 +50,6 @@ export const MediaSourceLibraryColumns: (keyof MediaSourceLibraryTable)[] = [
 ];
 
 export type MediaSourceLibraryTable = KyselifyBetter<typeof MediaSourceLibrary>;
-export type MediaSourceLibrary = Selectable<MediaSourceLibraryTable>;
-export type MediaSourceLibraryOrm = InferSelectModel<typeof MediaSourceLibrary>;
-export type NewMediaSourceLibrary = Insertable<MediaSourceLibraryTable>;
-export type MediaSourceLibraryUpdate = Updateable<MediaSourceLibraryTable>;
+export type MediaSourceLibrary = InferSelectModel<typeof MediaSourceLibrary>;
+export type NewMediaSourceLibrary = InferInsertModel<typeof MediaSourceLibrary>;
+export type MediaSourceLibraryUpdate = Partial<NewMediaSourceLibrary>;

--- a/server/src/db/schema/ProgramChapter.ts
+++ b/server/src/db/schema/ProgramChapter.ts
@@ -2,7 +2,7 @@ import type { TupleToUnion } from '@tunarr/types';
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { relations } from 'drizzle-orm';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { Insertable, Selectable } from 'kysely';
+import type { Insertable } from 'kysely';
 import type { KyselifyBetter } from './KyselifyBetter.ts';
 import { ProgramVersion } from './ProgramVersion.ts';
 
@@ -31,7 +31,6 @@ export const ProgramChapterRelations = relations(ProgramChapter, ({ one }) => ({
 }));
 
 export type ProgramChapterTable = KyselifyBetter<typeof ProgramChapter>;
-export type ProgramChapter = Selectable<ProgramChapterTable>;
-export type ProgramChapterOrm = InferSelectModel<typeof ProgramChapter>;
+export type ProgramChapter = InferSelectModel<typeof ProgramChapter>;
 export type NewProgramChapterOrm = InferInsertModel<typeof ProgramChapter>;
 export type NewProgramChapter = Insertable<ProgramChapterTable>;

--- a/server/src/db/schema/ProgramMediaFile.ts
+++ b/server/src/db/schema/ProgramMediaFile.ts
@@ -1,7 +1,6 @@
-import type { InferSelectModel } from 'drizzle-orm';
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { relations } from 'drizzle-orm';
 import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { Insertable } from 'kysely';
 import type { KyselifyBetter } from './KyselifyBetter.ts';
 import { LocalMediaFolder } from './LocalMediaFolder.ts';
 import { ProgramVersion } from './ProgramVersion.ts';
@@ -40,4 +39,4 @@ export const ProgramMediaFileRelations = relations(
 
 export type ProgramMediaFileTable = KyselifyBetter<typeof ProgramMediaFile>;
 export type ProgramMediaFile = InferSelectModel<typeof ProgramMediaFile>;
-export type NewProgramMediaFile = Insertable<ProgramMediaFileTable>;
+export type NewProgramMediaFile = InferInsertModel<typeof ProgramMediaFile>;

--- a/server/src/db/schema/ProgramMediaStream.ts
+++ b/server/src/db/schema/ProgramMediaStream.ts
@@ -1,7 +1,6 @@
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { relations } from 'drizzle-orm';
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { Insertable, Selectable } from 'kysely';
 import type { KyselifyBetter } from './KyselifyBetter.ts';
 import { ProgramVersion } from './ProgramVersion.ts';
 
@@ -56,9 +55,5 @@ export const ProgramMediaStreamRelations = relations(
 );
 
 export type ProgramMediaStreamTable = KyselifyBetter<typeof ProgramMediaStream>;
-export type ProgramMediaStream = Selectable<ProgramMediaStreamTable>;
-export type ProgramMediaStreamOrm = InferSelectModel<typeof ProgramMediaStream>;
-export type NewProgramMediaStream = Insertable<ProgramMediaStreamTable>;
-export type NewProgramMediaStreamOrm = InferInsertModel<
-  typeof ProgramMediaStream
->;
+export type ProgramMediaStream = InferSelectModel<typeof ProgramMediaStream>;
+export type NewProgramMediaStream = InferInsertModel<typeof ProgramMediaStream>;

--- a/server/src/db/schema/ProgramVersion.ts
+++ b/server/src/db/schema/ProgramVersion.ts
@@ -1,7 +1,7 @@
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { relations } from 'drizzle-orm';
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { Insertable, Selectable, Updateable } from 'kysely';
+import type { Insertable, Updateable } from 'kysely';
 import type { KyselifyBetter } from './KyselifyBetter.ts';
 import { Program } from './Program.ts';
 import { ProgramChapter } from './ProgramChapter.ts';
@@ -47,8 +47,7 @@ export const ProgramVersionRelations = relations(
 );
 
 export type ProgramVersionTable = KyselifyBetter<typeof ProgramVersion>;
-export type ProgramVersion = Selectable<ProgramVersionTable>;
-export type ProgramVersionOrm = InferSelectModel<typeof ProgramVersion>;
+export type ProgramVersion = InferSelectModel<typeof ProgramVersion>;
 export type NewProgramVersionDao = Insertable<ProgramVersionTable>;
 export type NewProgramVersionOrm = InferInsertModel<typeof ProgramVersion>;
 export type ProgramVersionUpdate = Updateable<ProgramVersionTable>;

--- a/server/src/db/schema/SubtitlePreferences.ts
+++ b/server/src/db/schema/SubtitlePreferences.ts
@@ -1,3 +1,4 @@
+import type { InferInsertModel } from 'drizzle-orm';
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import type { Insertable, Selectable } from 'kysely';
 import type { TupleToUnion } from '../../types/util.ts';
@@ -37,6 +38,9 @@ export type ChannelSubtitlePreferences =
   Selectable<ChannelSubtitlePreferencesTable>;
 export type NewChannelSubtitlePreference =
   Insertable<ChannelSubtitlePreferencesTable>;
+export type NewChannelSubtitlePreferenceOrm = InferInsertModel<
+  typeof ChannelSubtitlePreferences
+>;
 
 export const CustomShowSubtitlePreferences = sqliteTable(
   'custom_show_subtitle_preferences',

--- a/server/src/db/schema/derivedTypes.ts
+++ b/server/src/db/schema/derivedTypes.ts
@@ -3,7 +3,6 @@ import type {
   TranscodeConfigOrm,
 } from '@/db/schema/TranscodeConfig.js';
 import type { MarkNonNullable, Nullable } from '@/types/util.js';
-import type { Insertable } from 'kysely';
 import type { DeepNullable, MarkRequired, StrictOmit } from 'ts-essentials';
 import type { Artwork, NewArtwork } from './Artwork.ts';
 import type { MediaSourceType } from './base.ts';
@@ -20,10 +19,7 @@ import type {
   LocalMediaSourcePathOrm,
 } from './LocalMediaSourcePath.ts';
 import type { MediaSource, MediaSourceOrm } from './MediaSource.ts';
-import type {
-  MediaSourceLibrary,
-  MediaSourceLibraryOrm,
-} from './MediaSourceLibrary.ts';
+import type { MediaSourceLibrary } from './MediaSourceLibrary.ts';
 import type { MediaSourceLibraryReplacePath } from './MediaSourceLibraryReplacePath.ts';
 import type {
   NewProgramDao,
@@ -31,12 +27,7 @@ import type {
   ProgramOrm,
   ProgramType,
 } from './Program.ts';
-import type {
-  NewProgramChapterOrm,
-  ProgramChapter,
-  ProgramChapterOrm,
-  ProgramChapterTable,
-} from './ProgramChapter.ts';
+import type { NewProgramChapter, ProgramChapter } from './ProgramChapter.ts';
 import type {
   MinimalProgramExternalId,
   NewSingleOrMultiExternalId,
@@ -60,20 +51,13 @@ import type {
 } from './ProgramMediaFile.ts';
 import type {
   NewProgramMediaStream,
-  NewProgramMediaStreamOrm,
   ProgramMediaStream,
-  ProgramMediaStreamOrm,
 } from './ProgramMediaStream.ts';
 import type {
   NewProgramSubtitles,
   ProgramSubtitles,
 } from './ProgramSubtitles.ts';
-import type {
-  NewProgramVersionDao,
-  NewProgramVersionOrm,
-  ProgramVersion,
-  ProgramVersionOrm,
-} from './ProgramVersion.ts';
+import type { NewProgramVersionOrm, ProgramVersion } from './ProgramVersion.ts';
 import type { NewStudio, Studio, StudioEntity } from './Studio.ts';
 import type { ChannelSubtitlePreferences } from './SubtitlePreferences.ts';
 import type { NewTag, Tag, TagRelation } from './Tag.ts';
@@ -83,15 +67,15 @@ export type ProgramVersionWithRelations = ProgramVersion & {
   chapters?: ProgramChapter[];
 };
 
-export type ProgramVersionOrmWithRelations = ProgramVersionOrm & {
-  mediaStreams?: ProgramMediaStreamOrm[];
+export type ProgramVersionOrmWithRelations = ProgramVersion & {
+  mediaStreams?: ProgramMediaStream[];
   mediaFiles?: ProgramMediaFile[];
-  chapters?: ProgramChapterOrm[];
+  chapters?: ProgramChapter[];
 };
 
 export type NewProgramVersionOrmWithRelations = NewProgramVersionOrm & {
-  mediaStreams?: NewProgramMediaStreamOrm[];
-  chapters?: NewProgramChapterOrm[];
+  mediaStreams?: NewProgramMediaStream[];
+  chapters?: NewProgramChapter[];
 };
 
 export type ProgramWithRelations = ProgramDao & {
@@ -125,7 +109,7 @@ export type ProgramWithRelationsOrm = ProgramOrm & {
   // Require minimum data from externalId
   externalIds?: ProgramExternalIdOrm[];
   versions?: ProgramVersionOrmWithRelations[];
-  mediaLibrary?: Nullable<MediaSourceLibraryOrm>;
+  mediaLibrary?: Nullable<MediaSourceLibrary>;
   artwork?: Artwork[];
   subtitles?: ProgramSubtitles[];
   credits?: CreditWithArtwork[];
@@ -239,10 +223,10 @@ export type ProgramWithExternalIds = ProgramDao & {
   externalIds: MinimalProgramExternalId[];
 };
 
-export type NewProgramVersion = NewProgramVersionDao & {
+export type NewProgramVersion = NewProgramVersionOrm & {
   mediaStreams: NewProgramMediaStream[];
   mediaFiles: NewProgramMediaFile[];
-  chapters?: Insertable<ProgramChapterTable>[];
+  chapters?: NewProgramChapter[];
 };
 
 export type NewCreditWithArtwork = {
@@ -400,11 +384,11 @@ export type MediaSourceWithLibrariesDirect = MediaSource & {
 };
 
 export type MediaSourceWithLibraries = MediaSourceOrm & {
-  libraries: MediaSourceLibraryOrm[];
+  libraries: MediaSourceLibrary[];
 };
 
 export type MediaSourceWithRelations = MediaSourceOrm & {
-  libraries: MediaSourceLibraryOrm[];
+  libraries: MediaSourceLibrary[];
   paths: LocalMediaSourcePathOrm[];
   replacePaths: MediaSourceLibraryReplacePath[];
 };

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -1,4 +1,6 @@
+import type { RunResult } from 'better-sqlite3';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import { Artwork, ArtworkRelations } from './Artwork.ts';
 import { Channel, ChannelRelations } from './Channel.ts';
 
@@ -163,3 +165,8 @@ export const schema = {
 };
 
 export type DrizzleDBAccess = BetterSQLite3Database<typeof schema>;
+export type BaseDrizzleDBAccess = BaseSQLiteDatabase<
+  'sync',
+  RunResult,
+  typeof schema
+>;

--- a/server/src/external/plex/PlexApiClient.ts
+++ b/server/src/external/plex/PlexApiClient.ts
@@ -1,5 +1,5 @@
 import { MediaSourceType } from '@/db/schema/base.js';
-import type { MediaSourceLibraryOrm } from '@/db/schema/MediaSourceLibrary.js';
+import type { MediaSourceLibrary } from '@/db/schema/MediaSourceLibrary.js';
 import type { Nilable, Nullable } from '@/types/util.js';
 import { type Maybe } from '@/types/util.js';
 import dayjs from '@/util/dayjs.js';
@@ -396,7 +396,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
     schema: z.ZodType<PlexMetadataResponse<ItemType>>,
     converter: (
       item: ItemType,
-      libraryId: MediaSourceLibraryOrm,
+      libraryId: MediaSourceLibrary,
     ) => Result<OutType>,
     pageSize: number = 50,
     key: string = `/library/sections/${libraryId}/all`,
@@ -548,7 +548,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
   }
 
   private plexCollectionInject(
-    library: MediaSourceLibraryOrm,
+    library: MediaSourceLibrary,
     collection: PlexLibraryCollection,
   ): Collection {
     return {
@@ -764,7 +764,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
     schema: z.ZodType<PlexMetadataResponse<ItemType>>,
     converter: (
       plexItem: ItemType,
-      library: MediaSourceLibraryOrm,
+      library: MediaSourceLibrary,
     ) => Result<OutType>,
   ): Promise<QueryResult<OutType>> {
     const queryResult = await this.getItemMetadataInternal(externalKey, schema);
@@ -783,7 +783,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
   private findLibraryFromPlexMedia(
     media: PlexMedia,
     libraryId?: string,
-  ): QueryResult<MediaSourceLibraryOrm> {
+  ): QueryResult<MediaSourceLibrary> {
     libraryId ??= isPlexItemOrGrouping(media)
       ? media.librarySectionID?.toString()
       : undefined;
@@ -1164,7 +1164,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexShowInjection(
     plexShow: ApiPlexTvShow,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexShow> {
     const artwork: MediaArtwork[] = compact([
       this.plexArtworkInject(plexShow.thumb, 'poster'),
@@ -1223,7 +1223,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexSeasonInjection(
     plexSeason: ApiPlexTvSeason,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexSeason> {
     return Result.success({
       uuid: v4(),
@@ -1319,7 +1319,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexEpisodeInjection(
     plexEpisode: ApiPlexEpisode,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexEpisode> {
     if (isNil(plexEpisode.duration) || plexEpisode.duration <= 0) {
       return Result.forError(
@@ -1490,7 +1490,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexMovieInjection(
     plexMovie: ApiPlexMovie,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexMovie> {
     if (isNil(plexMovie.duration) || plexMovie.duration <= 0) {
       return Result.forError(
@@ -1573,7 +1573,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexOtherVideoInjection(
     plexClip: ApiPlexMovie,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexOtherVideo> {
     if (isNil(plexClip.duration) || plexClip.duration <= 0) {
       return Result.forError(
@@ -1654,7 +1654,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexMusicArtistInjection(
     plexArtist: ApiPlexMusicArtist,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexArtist> {
     return Result.success({
       uuid: v4(),
@@ -1699,7 +1699,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexAlbumInjection(
     plexAlbum: ApiPlexMusicAlbum,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexAlbum> {
     const releaseDate = parseReleaseDate(plexAlbum.originallyAvailableAt);
     return Result.success({
@@ -1789,7 +1789,7 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
 
   private plexTrackInjection(
     plexTrack: ApiPlexMusicTrack,
-    mediaLibrary: MediaSourceLibraryOrm,
+    mediaLibrary: MediaSourceLibrary,
   ): Result<PlexTrack, WrappedError> {
     if (isNil(plexTrack.duration) || plexTrack.duration <= 0) {
       return Result.forError(

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -1,7 +1,9 @@
+import type { BaseDrizzleDBAccess } from '@/db/schema/index.js';
 import Migration1735044379_AddHlsDirect from '@/migration/db/Migration1735044379_AddHlsDirect.js';
 import type { Migration, MigrationProvider } from 'kysely';
 import { CompiledQuery } from 'kysely';
 import { mapValues } from 'lodash-es';
+import { match } from 'ts-pattern';
 import LegacyMigration0 from './db/LegacyMigration0.ts';
 import LegacyMigration1 from './db/LegacyMigration1.ts';
 import LegacyMigration10 from './db/LegacyMigration10.ts';
@@ -33,9 +35,6 @@ import Migration1746123876_ReworkSubtitleFilter from './db/Migration1746123876_R
 import Migration1746128022_FixSubtitlePriorityType from './db/Migration1746128022_FixSubtitlePriorityType.ts';
 import Migration1748345299_AddMoreProgramTypes from './db/Migration1748345299_AddMoreProgramTypes.ts';
 import Migration1756312561_InitialAdvancedTranscodeConfig from './db/Migration1756312561_InitialAdvancedTranscodeConfig.ts';
-import Migration1756381281_AddLibraries from './db/Migration1756381281_AddLibraries.ts';
-import Migration1757704591_AddProgramMediaSourceIndex from './db/Migration1757704591_AddProgramMediaSourceIndex.ts';
-import Migration1758203109_AddProgramMedia from './db/Migration1758203109_AddProgramMedia.ts';
 import Migration1758570688_AddLocalLibraries from './db/Migration1758570688_AddLocalLibraries.ts';
 import Migration1758732083_FixLocalLibraryPath from './db/Migration1758732083_FixLocalLibraryPath.ts';
 import Migration1758903045_FixLocalLibraryPathAgain from './db/Migration1758903045_FixLocalLibraryPathAgain.ts';
@@ -53,7 +52,7 @@ import Migration1764022266_AddCreditGroupingIndex from './db/Migration1764022266
 import Migration1764022464_AddArtworkIndexes from './db/Migration1764022464_AddArtworkIndexes.ts';
 import Migration1767300603_AddExternalCollections from './db/Migration1767300603_AddExternalCollections.ts';
 import Migration1771271020_FixCustomShowContentKey from './db/Migration1771271020_FixCustomShowContentKey.ts';
-import { makeKyselyMigrationFromSqlFile } from './db/util.ts';
+import { makeMigrationFromSqlFile } from './db/util.ts';
 
 export const LegacyMigrationNameToNewMigrationName = [
   ['Migration20240124115044', '_Legacy_Migration00'],
@@ -79,165 +78,196 @@ export const LegacyMigrationNameToNewMigrationName = [
   ['cascade_channel_filler_show_deletes', '_Legacy_Migration16'],
 ] as const;
 
+const FirstMigration: TunarrDatabaseMigrationLegacy = {
+  async up(db) {
+    await db.executeQuery(CompiledQuery.raw('select 1;'));
+  },
+  kyselyOnly: true,
+};
+
 export class DirectMigrationProvider implements MigrationProvider {
+  getMigrations(): Promise<Record<string, TunarrDatabaseMigration>> {
+    return Promise.resolve(this.getMigrationsSync());
+  }
   // Kysely migrations are strictly run in alphanumeric asc order
   // We need to ensure migrations pre-kyesely (from mikro-orm)
   // are run FIRST and in the correct order, in order to have a smooth
   // transition away. Legacy migrations are thus prefixed with '_'
   // to ensure they are always run first
-  getMigrations(): Promise<Record<string, Migration>> {
-    return Promise.resolve(
-      mapValues(
-        {
-          _ALWAYS_FIRST: {
-            async up(db) {
-              await db.executeQuery(CompiledQuery.raw('select 1;'));
-            },
-          } satisfies Migration,
-          _Legacy_Migration00: LegacyMigration0,
-          _Legacy_Migration01: LegacyMigration1,
-          _Legacy_Migration02: LegacyMigration2,
-          _Legacy_Migration03: LegacyMigration3,
-          _Legacy_Migration04: LegacyMigration4,
-          _Legacy_Migration05: LegacyMigration5,
-          _Legacy_Migration06: LegacyMigration6,
-          _Legacy_Migration07: LegacyMigration7,
-          _Legacy_Migration08: LegacyMigration8,
-          _Legacy_Migration08_dupe: {
-            async up() {
-              // NO-OP
-            },
+  getMigrationsSync(): Record<string, TunarrDatabaseMigration> {
+    return mapValues(
+      {
+        _ALWAYS_FIRST: FirstMigration,
+        _Legacy_Migration00: LegacyMigration0,
+        _Legacy_Migration01: LegacyMigration1,
+        _Legacy_Migration02: LegacyMigration2,
+        _Legacy_Migration03: LegacyMigration3,
+        _Legacy_Migration04: LegacyMigration4,
+        _Legacy_Migration05: LegacyMigration5,
+        _Legacy_Migration06: LegacyMigration6,
+        _Legacy_Migration07: LegacyMigration7,
+        _Legacy_Migration08: LegacyMigration8,
+        _Legacy_Migration08_dupe: {
+          async up() {
+            // NO-OP
           },
-          _Legacy_Migration09: LegacyMigration9,
-          _Legacy_Migration10: LegacyMigration10,
-          _Legacy_Migration11: LegacyMigration11,
-          _Legacy_Migration12: LegacyMigration12,
-          _Legacy_Migration13: LegacyMigration13,
-          _Legacy_Migration14: LegacyMigration14,
-          _Legacy_Migration15: LegacyMigration15,
-          _Legacy_Migration16: LegacyMigration16,
-          migration1730806741: Migration1730806741,
-          migration1731982492: Migration1731982492,
-          migration1732969335: Migration1732969335_AddTranscodeConfig,
-          migration1735044379: Migration1735044379_AddHlsDirect,
-          migration1738604866: Migration1738604866_AddEmby,
-          migration1740691984: Migration1740691984_ProgramMediaSourceId,
-          migration1741297998: Migration1741297998_AddProgramIndexes,
-          migration1741658292: Migration1741658292_MediaSourceIndex,
-          migration1744918641: Migration1744918641_AddMediaSourceUserInfo,
-          migration1745007030:
-            Migration1745007030_ReaddMissingProgramExternalIdIndexes,
+          kyselyOnly: true,
+        } satisfies TunarrDatabaseMigrationLegacy,
+        _Legacy_Migration09: LegacyMigration9,
+        _Legacy_Migration10: LegacyMigration10,
+        _Legacy_Migration11: LegacyMigration11,
+        _Legacy_Migration12: LegacyMigration12,
+        _Legacy_Migration13: LegacyMigration13,
+        _Legacy_Migration14: LegacyMigration14,
+        _Legacy_Migration15: LegacyMigration15,
+        _Legacy_Migration16: LegacyMigration16,
+        migration1730806741: Migration1730806741,
+        migration1731982492: Migration1731982492,
+        migration1732969335: Migration1732969335_AddTranscodeConfig,
+        migration1735044379: Migration1735044379_AddHlsDirect,
+        migration1738604866: Migration1738604866_AddEmby,
+        migration1740691984: Migration1740691984_ProgramMediaSourceId,
+        migration1741297998: Migration1741297998_AddProgramIndexes,
+        migration1741658292: Migration1741658292_MediaSourceIndex,
+        migration1744918641: Migration1744918641_AddMediaSourceUserInfo,
+        migration1745007030:
+          Migration1745007030_ReaddMissingProgramExternalIdIndexes,
 
-          migration1746042667: Migration1746042667_AddSubtitles,
-          migration1746123876: Migration1746123876_ReworkSubtitleFilter,
-          migration1746128022: Migration1746128022_FixSubtitlePriorityType,
-          migration1748345299: Migration1748345299_AddMoreProgramTypes,
-          migration1756312561:
-            Migration1756312561_InitialAdvancedTranscodeConfig,
-          migration1756381281: Migration1756381281_AddLibraries,
-          migration1757704591: Migration1757704591_AddProgramMediaSourceIndex,
-          migration1758203109: Migration1758203109_AddProgramMedia,
-          migration1758570688: Migration1758570688_AddLocalLibraries,
-          migration1758732083_FixLocalLibraryPath:
-            Migration1758732083_FixLocalLibraryPath,
-          migration1758903045_FixLocalLibraryPathAgain:
-            Migration1758903045_FixLocalLibraryPathAgain,
-          migration1759170884_AddArtworkAndMore:
-            Migration1759170884_AddArtworkAndMore,
-          migration1759518565_AddProgramSubtitles:
-            Migration1759518565_AddProgramSubtitles,
-          migration1760129429_AddProgramGroupingSourceType:
-            Migration1760129429_AddProgramGroupingSourceType,
-          migration1760213210_AddMoreProgramGroupingFields:
-            Migration1760213210_AddMoreProgramGroupingFields,
-          migration1760455673_UpdateForeignKeyCasacades:
-            Migration1760455673_UpdateForeignKeyCasacades,
-          migration1761309919_AddSmartCollections:
-            makeKyselyMigrationFromSqlFile(
-              './sql/0021_stormy_victor_mancha.sql',
-            ),
-          migration1762205138_AddCredits: Migration1762205138_AddCredits,
-          migration1762205207_ArtworkCachePathNullable:
-            Migration1762205207_ArtworkCachePathNullable,
-          migration1763585155_AddProgramForeignKeys:
-            Migration1763585155_AddProgramForeignKeys,
-          migration1763673215_MoreProgramForeignKeys:
-            Migration1763673215_MoreProgramForeignKeys,
-          migration1763749592_AddProgramState:
-            Migration1763749592_AddProgramState,
-          migration1764022266_AddCreditGroupingIndex:
-            Migration1764022266_AddCreditGroupingIndex,
-          migration1764022464_AddArtworkIndexes:
-            Migration1764022464_AddArtworkIndexes,
-          migration1764695284_AddProgramGroupingMetadata:
-            makeKyselyMigrationFromSqlFile('./sql/0029_hard_arachne.sql'),
-          migration1764710105_AddGenreAndStudios:
-            makeKyselyMigrationFromSqlFile('./sql/0030_redundant_glorian.sql'),
-          migration1764773318: makeKyselyMigrationFromSqlFile(
-            './sql/0031_bitter_dormammu.sql',
-          ),
-          // Add program grouping state,
-          migration1764870206: makeKyselyMigrationFromSqlFile(
-            './sql/0032_vengeful_network.sql',
-          ),
-          migration1767300603: Migration1767300603_AddExternalCollections,
-          migration1767374284: makeKyselyMigrationFromSqlFile(
-            './sql/0036_smooth_vanisher.sql',
-          ),
-          migration1768825617: makeKyselyMigrationFromSqlFile(
-            './sql/0037_orange_bromley.sql',
-          ),
-          migration1768876318: makeKyselyMigrationFromSqlFile(
-            './sql/0038_boring_maginty.sql',
-          ),
-          migration1769099084: makeKyselyMigrationFromSqlFile(
-            './sql/0039_famous_bloodscream.sql',
-          ),
-          migration1769361518: makeKyselyMigrationFromSqlFile(
-            './sql/0040_daffy_bishop.sql',
-            true,
-          ),
-          migration1770236998: makeKyselyMigrationFromSqlFile(
-            './sql/0041_easy_firebird.sql',
-          ),
-          migration1771271020: Migration1771271020_FixCustomShowContentKey,
-          migration1773603770: makeKyselyMigrationFromSqlFile(
-            './sql/0042_supreme_medusa.sql',
-          ),
-          migration1775060606: makeKyselyMigrationFromSqlFile(
-            './sql/0043_common_zzzax.sql',
-          ),
-        },
-        wrapWithTransaction,
-      ),
+        migration1746042667: Migration1746042667_AddSubtitles,
+        migration1746123876: Migration1746123876_ReworkSubtitleFilter,
+        migration1746128022: Migration1746128022_FixSubtitlePriorityType,
+        migration1748345299: Migration1748345299_AddMoreProgramTypes,
+        migration1756312561: Migration1756312561_InitialAdvancedTranscodeConfig,
+        // Migration1756381281_AddLibraries.ts
+        migration1756381281: makeMigrationFromSqlFile(
+          './sql/0010_lazy_nova.sql',
+        ),
+        // AddProgramMediaSources
+        migration1757704591: makeMigrationFromSqlFile(
+          './sql/0011_stormy_stark_industries.sql',
+        ),
+        // AddProgramMedia
+        migration1758203109: makeMigrationFromSqlFile(
+          './sql/0012_yielding_ben_grimm.sql',
+        ),
+        migration1758570688: Migration1758570688_AddLocalLibraries,
+        migration1758732083_FixLocalLibraryPath:
+          Migration1758732083_FixLocalLibraryPath,
+        migration1758903045_FixLocalLibraryPathAgain:
+          Migration1758903045_FixLocalLibraryPathAgain,
+        migration1759170884_AddArtworkAndMore:
+          Migration1759170884_AddArtworkAndMore,
+        migration1759518565_AddProgramSubtitles:
+          Migration1759518565_AddProgramSubtitles,
+        migration1760129429_AddProgramGroupingSourceType:
+          Migration1760129429_AddProgramGroupingSourceType,
+        migration1760213210_AddMoreProgramGroupingFields:
+          Migration1760213210_AddMoreProgramGroupingFields,
+        migration1760455673_UpdateForeignKeyCasacades:
+          Migration1760455673_UpdateForeignKeyCasacades,
+        migration1761309919_AddSmartCollections: makeMigrationFromSqlFile(
+          './sql/0021_stormy_victor_mancha.sql',
+        ),
+        migration1762205138_AddCredits: Migration1762205138_AddCredits,
+        migration1762205207_ArtworkCachePathNullable:
+          Migration1762205207_ArtworkCachePathNullable,
+        migration1763585155_AddProgramForeignKeys:
+          Migration1763585155_AddProgramForeignKeys,
+        migration1763673215_MoreProgramForeignKeys:
+          Migration1763673215_MoreProgramForeignKeys,
+        migration1763749592_AddProgramState:
+          Migration1763749592_AddProgramState,
+        migration1764022266_AddCreditGroupingIndex:
+          Migration1764022266_AddCreditGroupingIndex,
+        migration1764022464_AddArtworkIndexes:
+          Migration1764022464_AddArtworkIndexes,
+        migration1764695284_AddProgramGroupingMetadata:
+          makeMigrationFromSqlFile('./sql/0029_hard_arachne.sql'),
+        migration1764710105_AddGenreAndStudios: makeMigrationFromSqlFile(
+          './sql/0030_redundant_glorian.sql',
+        ),
+        migration1764773318: makeMigrationFromSqlFile(
+          './sql/0031_bitter_dormammu.sql',
+        ),
+        // Add program grouping state,
+        migration1764870206: makeMigrationFromSqlFile(
+          './sql/0032_vengeful_network.sql',
+        ),
+        migration1767300603: Migration1767300603_AddExternalCollections,
+        migration1767374284: makeMigrationFromSqlFile(
+          './sql/0036_smooth_vanisher.sql',
+        ),
+        migration1768825617: makeMigrationFromSqlFile(
+          './sql/0037_orange_bromley.sql',
+        ),
+        migration1768876318: makeMigrationFromSqlFile(
+          './sql/0038_boring_maginty.sql',
+        ),
+        migration1769099084: makeMigrationFromSqlFile(
+          './sql/0039_famous_bloodscream.sql',
+        ),
+        migration1769361518: makeMigrationFromSqlFile(
+          './sql/0040_daffy_bishop.sql',
+          true,
+        ),
+        migration1770236998: makeMigrationFromSqlFile(
+          './sql/0041_easy_firebird.sql',
+        ),
+        migration1771271020: Migration1771271020_FixCustomShowContentKey,
+        migration1773603770: makeMigrationFromSqlFile(
+          './sql/0042_supreme_medusa.sql',
+        ),
+        migration1775060606: makeMigrationFromSqlFile(
+          './sql/0043_common_zzzax.sql',
+        ),
+      } satisfies Record<string, TunarrDatabaseMigration>,
+      wrapWithTransaction,
     );
   }
 }
 
-function wrapWithTransaction(m: TunarrDatabaseMigration): Migration {
-  return {
-    ...m,
-    up(db) {
-      if (m.noTransaction) {
-        return m.up(db);
-      }
-      return db.transaction().execute((tx) => {
-        return m.up(tx);
-      });
-    },
-    down(db) {
-      if (m.noTransaction) {
-        return m.down?.(db) ?? Promise.resolve(void 0);
-      }
-      return db.transaction().execute((tx) => {
-        return m.down?.(tx) ?? Promise.resolve(void 0);
-      });
-    },
-  } satisfies Migration;
+function wrapWithTransaction(
+  m: TunarrDatabaseMigration,
+): TunarrDatabaseMigration {
+  return (
+    match(m)
+      .returnType<TunarrDatabaseMigration>()
+      // Kysely only migrations can never run in transactions because they
+      // have no synchronous option
+      .with({ kyselyOnly: true }, (m) => m)
+      .with({ kyselyOnly: false, noTransaction: true }, (m) => m)
+      .with(
+        { kyselyOnly: false },
+        (m) =>
+          ({
+            ...m,
+            upDrizzle(db) {
+              return db.transaction((tx) => {
+                return m.upDrizzle(tx);
+              });
+            },
+          }) satisfies TunarrDatabaseMigrationWithDrizzle,
+      )
+      .exhaustive()
+  );
 }
 
-export interface TunarrDatabaseMigration extends Migration {
-  inPlace?: boolean;
+type BaseTunarrDatabaseMigration = Migration & {
   fullCopy?: boolean;
   noTransaction?: boolean;
-}
+  kyselyOnly: boolean;
+};
+
+export type TunarrDatabaseMigrationWithDrizzle = BaseTunarrDatabaseMigration & {
+  kyselyOnly: false;
+  upDrizzle: (db: BaseDrizzleDBAccess) => void;
+};
+
+export type TunarrDatabaseMigrationLegacy = BaseTunarrDatabaseMigration & {
+  kyselyOnly: true;
+  upDrizzle?: never;
+};
+
+export type TunarrDatabaseMigration =
+  | TunarrDatabaseMigrationWithDrizzle
+  | TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/DrizzleMigrator.ts
+++ b/server/src/migration/DrizzleMigrator.ts
@@ -1,0 +1,159 @@
+import { MigrationLockTableName, MigrationTableName } from '@/db/DBAccess.js';
+import type { DB } from '@/db/schema/db.js';
+import type { BaseDrizzleDBAccess } from '@/db/schema/index.js';
+import dayjs from 'dayjs';
+import { sql } from 'drizzle-orm';
+import type { MigrationResultSet } from 'kysely';
+import {
+  type Kysely,
+  type MigrationInfo,
+  type MigrationResult,
+  Migrator,
+} from 'kysely';
+import { head, last } from 'lodash-es';
+import type { Logger } from '../util/logging/LoggerFactory.ts';
+import { LoggerFactory } from '../util/logging/LoggerFactory.ts';
+import type { TunarrDatabaseMigration } from './DirectMigrationProvider.ts';
+import { DirectMigrationProvider } from './DirectMigrationProvider.ts';
+
+export interface TunarrMigrationInfo extends MigrationInfo {
+  migration: TunarrDatabaseMigration;
+}
+
+/**
+ * A hacky custom migrator that uses the backing kysely migration
+ * tables to run generated Drizzle migrations. Eventually we will
+ * consolidate :)
+ */
+export class DrizzleMigrator {
+  private logger: Logger;
+  private migrationProvider: DirectMigrationProvider =
+    new DirectMigrationProvider();
+  private kyselyMigrator: Migrator;
+
+  constructor(
+    private db: BaseDrizzleDBAccess,
+    private kysely: Kysely<DB>,
+  ) {
+    this.logger = LoggerFactory.child({ className: DrizzleMigrator.name });
+    this.kyselyMigrator = new Migrator({
+      db: this.kysely,
+      provider: this.migrationProvider,
+      migrationTableName: MigrationTableName,
+      migrationLockTableName: MigrationLockTableName,
+    });
+  }
+
+  getMigrations(): TunarrMigrationInfo[] {
+    const migrationsByName = this.migrationProvider.getMigrationsSync();
+
+    const existingMigrations = this.getExistingMigrations();
+
+    return Object.keys(migrationsByName)
+      .sort()
+      .map((key) => {
+        const existingMigration = existingMigrations.find(
+          ([name]) => name === key,
+        );
+        return {
+          name: key,
+          migration: migrationsByName[key]!,
+          executedAt: existingMigration
+            ? dayjs(existingMigration[1]).toDate()
+            : undefined,
+        } satisfies TunarrMigrationInfo;
+      });
+  }
+
+  async migrateToLatest(): Promise<MigrationResultSet> {
+    const migrations = this.getMigrations();
+    const migration = last(migrations);
+    if (!migration) {
+      return { results: [] };
+    }
+    return this.migrateTo(migration.name);
+  }
+
+  async migrateTo(name: string): Promise<MigrationResultSet> {
+    const migrations = this.getMigrations();
+    const migrationIndex = migrations.findIndex((m) => m.name === name);
+    if (migrationIndex === -1) {
+      this.logger.warn(
+        `Could not find migration with name %s to migrate to`,
+        name,
+      );
+      return { results: [] };
+    }
+    const migration = migrations[migrationIndex]!;
+    if (migration.executedAt) {
+      this.logger.info(
+        'Already migrated to %s at %s, skipping',
+        name,
+        migration.executedAt.toISOString(),
+      );
+      return { results: [] };
+    }
+
+    // Find the pending migrations between the target and last migration, including the target
+    const pendingMigrations = migrations
+      .slice(0, migrationIndex + 1)
+      .filter((migration) => !migration.executedAt);
+
+    const results: MigrationResult[] = pendingMigrations.map((migration) => ({
+      migrationName: migration.name,
+      direction: 'Up',
+      status: 'NotExecuted',
+    }));
+    for (let i = 0; i < pendingMigrations.length; i++) {
+      const pendingMigration = pendingMigrations[i]!;
+      try {
+        if (pendingMigration.migration.kyselyOnly) {
+          const migrateResult = await this.kyselyMigrator.migrateTo(
+            pendingMigration.name,
+          );
+          const result = head(migrateResult.results);
+          if (result) {
+            results[i] = result;
+          }
+          if (migrateResult.error) {
+            return {
+              error: migrateResult.error,
+              results,
+            };
+          }
+          continue;
+        }
+
+        pendingMigration.migration.upDrizzle(this.db);
+        this.db.run(
+          sql`INSERT INTO ${sql.identifier(MigrationTableName)} (name, timestamp) VALUES (${pendingMigration.name}, ${new Date().toISOString()})`,
+        );
+        results[i] = {
+          direction: 'Up',
+          migrationName: pendingMigration.name,
+          status: 'Success',
+        };
+      } catch (e) {
+        results[i] = {
+          direction: 'Up',
+          migrationName: pendingMigration.name,
+          status: 'Error',
+        };
+        this.logger.error(
+          e,
+          'Error while migrating to %s',
+          pendingMigration.name,
+        );
+        return { error: e, results };
+      }
+    }
+
+    return { results };
+  }
+
+  private getExistingMigrations() {
+    return this.db.values<[string, string]>(
+      sql`SELECT name, timestamp FROM ${sql.identifier(MigrationTableName)} ORDER BY timestamp ASC`,
+    );
+  }
+}

--- a/server/src/migration/db/LegacyMigration0.ts
+++ b/server/src/migration/db/LegacyMigration0.ts
@@ -1,5 +1,6 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -593,4 +594,5 @@ export default {
       .ifExists()
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration1.ts
+++ b/server/src/migration/db/LegacyMigration1.ts
@@ -1,4 +1,5 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 import { columnExists } from './util.ts';
 
 export default {
@@ -42,4 +43,5 @@ export default {
       .ifExists()
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration10.ts
+++ b/server/src/migration/db/LegacyMigration10.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -22,4 +23,5 @@ export default {
       .where(sql`\`external_source_id\``, 'is', null)
       .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration11.ts
+++ b/server/src/migration/db/LegacyMigration11.ts
@@ -6,6 +6,7 @@ import type {
   WithUpdatedAt,
   WithUuid,
 } from '../../db/schema/base.js';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 interface CurrentProgramExternalIdTable
   extends WithUuid,
@@ -136,4 +137,5 @@ export default {
       .where(sql`\`external_source_id\``, 'is', null)
       .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration12.ts
+++ b/server/src/migration/db/LegacyMigration12.ts
@@ -6,6 +6,7 @@ import type {
   WithUpdatedAt,
   WithUuid,
 } from '../../db/schema/base.js';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 interface CurrentProgramExternalIdTable
   extends WithUuid,
@@ -145,4 +146,5 @@ export default {
       .where(sql`\`external_source_id\``, 'is', null)
       .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration13.ts
+++ b/server/src/migration/db/LegacyMigration13.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -49,4 +50,5 @@ export default {
   //   'CREATE UNIQUE INDEX `plex_server_settings_name_uri_unique` on `plex_server_settings` (`name`, `uri`);',
   // );
   // }
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration14.ts
+++ b/server/src/migration/db/LegacyMigration14.ts
@@ -8,6 +8,7 @@ import type {
   WithUpdatedAt,
   WithUuid,
 } from '../../db/schema/base.js';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 interface ProgramGroupingInMigration
   extends WithUuid,
@@ -712,4 +713,5 @@ export default {
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration15.ts
+++ b/server/src/migration/db/LegacyMigration15.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -21,4 +22,5 @@ export default {
     // this.addSql('alter table `channel` drop column `stream_mode`;');
     await db.schema.alterTable('channel').dropColumn('stream_mode').execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration16.ts
+++ b/server/src/migration/db/LegacyMigration16.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from 'kysely';
 import { CompiledQuery } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -63,4 +64,5 @@ export default {
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration2.ts
+++ b/server/src/migration/db/LegacyMigration2.ts
@@ -1,3 +1,5 @@
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
+
 export default {
   async up(): Promise<void> {
     // DROP INDEX IF EXISTS `filler_show_content_filler_show_uuid_program_uuid_index_unique`;
@@ -48,4 +50,5 @@ export default {
     //   .addColumn('index', 'integer', (col) => col.notNull())
     //   .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration3.ts
+++ b/server/src/migration/db/LegacyMigration3.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -14,4 +15,5 @@ export default {
       .dropColumn('client_identifier')
       .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration4.ts
+++ b/server/src/migration/db/LegacyMigration4.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 import { columnExists } from './util.ts';
 
 export default {
@@ -29,4 +30,5 @@ export default {
       await db.schema.alterTable('program').dropColumn('album_name').execute();
     }
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration5.ts
+++ b/server/src/migration/db/LegacyMigration5.ts
@@ -1,5 +1,6 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 import { columnExists } from './util.ts';
 
 export default {
@@ -231,4 +232,5 @@ export default {
     await db.schema.dropIndex('program_album_uuid_index').ifExists().execute();
     await db.schema.dropIndex('program_artist_uuid_index').ifExists().execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration6.ts
+++ b/server/src/migration/db/LegacyMigration6.ts
@@ -1,5 +1,6 @@
 import type { DB } from '@/db/schema/db.js';
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<DB>): Promise<void> {
@@ -12,4 +13,5 @@ export default {
       .where('plexRatingKey', 'is not', null)
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration7.ts
+++ b/server/src/migration/db/LegacyMigration7.ts
@@ -1,4 +1,5 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 import { columnExists } from './util.ts';
 
 export default {
@@ -16,4 +17,5 @@ export default {
         .execute();
     }
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration8.ts
+++ b/server/src/migration/db/LegacyMigration8.ts
@@ -1,4 +1,5 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -13,4 +14,5 @@ export default {
       .renameColumn('season_number', 'season')
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/LegacyMigration9.ts
+++ b/server/src/migration/db/LegacyMigration9.ts
@@ -1,5 +1,6 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>): Promise<void> {
@@ -65,4 +66,5 @@ export default {
       .ifNotExists()
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1730806741.ts
+++ b/server/src/migration/db/Migration1730806741.ts
@@ -1,6 +1,7 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
 import { CompiledQuery } from 'kysely';
 import type { ChannelFillerShowTable } from '../../db/schema/ChannelFillerShow.ts';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 type DBTemp = {
   channelFillerShowTmp: ChannelFillerShowTable;
@@ -61,4 +62,5 @@ export default {
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1731982492.ts
+++ b/server/src/migration/db/Migration1731982492.ts
@@ -1,6 +1,7 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
 import { CompiledQuery } from 'kysely';
 import type { CustomShowContent } from '../../db/schema/CustomShowContent.ts';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 type DBTemp = {
   customShowContentTmp: CustomShowContent;
@@ -91,4 +92,5 @@ export default {
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1732969335_AddTranscodeConfig.ts
+++ b/server/src/migration/db/Migration1732969335_AddTranscodeConfig.ts
@@ -7,6 +7,7 @@ import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
 import { isEmpty } from 'lodash-es';
 import { v4 } from 'uuid';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<DB>) {
@@ -147,4 +148,5 @@ export default {
       .execute();
     await db.schema.dropTable('transcode_config').ifExists().execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1735044379_AddHlsDirect.ts
+++ b/server/src/migration/db/Migration1735044379_AddHlsDirect.ts
@@ -1,6 +1,7 @@
 import type { Channel } from '@/db/schema/Channel.js';
 import type { Kysely } from 'kysely';
 import { CompiledQuery, sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 interface ChannelProgramsInMigration {
   channelUuid: string;
@@ -290,4 +291,5 @@ export default {
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1738604866_AddEmby.ts
+++ b/server/src/migration/db/Migration1738604866_AddEmby.ts
@@ -1,5 +1,6 @@
 import { CompiledQuery, sql, type Kysely } from 'kysely';
 import { copyTable, swapTables } from '../../db/migrationUtil.ts';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   fullCopy: true,
@@ -278,4 +279,5 @@ CREATE TABLE IF NOT EXISTS "program_grouping_tmp" (
   },
 
   async down() {},
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1740691984_ProgramMediaSourceId.ts
+++ b/server/src/migration/db/Migration1740691984_ProgramMediaSourceId.ts
@@ -1,4 +1,5 @@
 import { type Kysely, CompiledQuery, sql } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   fullCopy: true,
@@ -134,4 +135,5 @@ CREATE TABLE IF NOT EXISTS "program_grouping_external_id_tmp" (
     await db.executeQuery(CompiledQuery.raw('PRAGMA foreign_keys = ON'));
     await db.executeQuery(CompiledQuery.raw('PRAGMA defer_foreign_keys = OFF'));
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1741297998_AddProgramIndexes.ts
+++ b/server/src/migration/db/Migration1741297998_AddProgramIndexes.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>) {
@@ -15,4 +16,5 @@ export default {
       .column('group_uuid')
       .execute();
   },
-};
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1741658292_MediaSourceIndex.ts
+++ b/server/src/migration/db/Migration1741658292_MediaSourceIndex.ts
@@ -1,4 +1,5 @@
-import type { Kysely, Migration } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { TunarrDatabaseMigrationLegacy } from '../DirectMigrationProvider.ts';
 
 export default {
   async up(db: Kysely<unknown>) {
@@ -10,4 +11,5 @@ export default {
       .unique()
       .execute();
   },
-} satisfies Migration;
+  kyselyOnly: true,
+} satisfies TunarrDatabaseMigrationLegacy;

--- a/server/src/migration/db/Migration1744918641_AddMediaSourceUserInfo.ts
+++ b/server/src/migration/db/Migration1744918641_AddMediaSourceUserInfo.ts
@@ -1,10 +1,8 @@
-import { CompiledQuery, type Kysely } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 // low-fi ... copied from the generated one by drizzle
 
-export const expr = String.raw`
+const expr = String.raw`
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE "__new_program_external_id" (
 	"uuid" text PRIMARY KEY NOT NULL,
@@ -35,17 +33,4 @@ ALTER TABLE "media_source" ADD "user_id" text;--> statement-breakpoint
 
 // ALTER TABLE "program" ADD "media_source_id" text REFERENCES media_source(uuid);--> statement-breakpoint
 // ALTER TABLE "program_grouping_external_id" ADD "media_source_id" text REFERENCES media_source(uuid);
-export default {
-  up: async (db: Kysely<unknown>) => {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-  fullCopy: true,
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1745007030_ReaddMissingProgramExternalIdIndexes.ts
+++ b/server/src/migration/db/Migration1745007030_ReaddMissingProgramExternalIdIndexes.ts
@@ -1,6 +1,4 @@
-import { type Kysely, CompiledQuery } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 const expr = String.raw`
 DROP INDEX "unique_program_single_external_id";--> statement-breakpoint
@@ -9,17 +7,4 @@ CREATE UNIQUE INDEX "unique_program_single_external_id_media_source" ON "program
 CREATE UNIQUE INDEX "unique_program_single_external_id" ON "program_external_id" ("program_uuid","source_type") WHERE "external_source_id" is null;--> statement-breakpoint
 `;
 
-export default {
-  up: async (db: Kysely<unknown>) => {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-  fullCopy: true,
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1746042667_AddSubtitles.ts
+++ b/server/src/migration/db/Migration1746042667_AddSubtitles.ts
@@ -1,9 +1,6 @@
-import type { Kysely } from 'kysely';
-import { CompiledQuery } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
-export const expr = String.raw`
+const expr = String.raw`
 ALTER TABLE "channel" ADD COLUMN "subtitle_filter" text DEFAULT 'any' NOT NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "channel_number_unique" ON "channel" ("number");--> statement-breakpoint
 CREATE TABLE "channel_subtitle_preferences" (
@@ -30,17 +27,4 @@ CREATE TABLE "custom_show_subtitle_preferences" (
 CREATE INDEX "custom_show_priority_index" ON "custom_show_subtitle_preferences" ("custom_show_id","priority");
 `;
 
-export default {
-  fullCopy: true,
-  up: async (db: Kysely<unknown>) => {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1746123876_ReworkSubtitleFilter.ts
+++ b/server/src/migration/db/Migration1746123876_ReworkSubtitleFilter.ts
@@ -1,5 +1,4 @@
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
-import { applyDrizzleMigrationExpression } from './util.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 const expr = String.raw`
 ALTER TABLE "channel" ADD "subtitles_enabled" integer DEFAULT false;--> statement-breakpoint
@@ -8,9 +7,4 @@ ALTER TABLE "channel_subtitle_preferences" ADD "filter_type" text DEFAULT 'any';
 ALTER TABLE "custom_show_subtitle_preferences" ADD "filter_type" text NOT NULL DEFAULT 'any';
 `;
 
-export default {
-  fullCopy: true,
-  async up(db) {
-    await applyDrizzleMigrationExpression(db, expr);
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1746128022_FixSubtitlePriorityType.ts
+++ b/server/src/migration/db/Migration1746128022_FixSubtitlePriorityType.ts
@@ -1,6 +1,4 @@
-import { type Kysely, CompiledQuery } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 const expr = String.raw`
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
@@ -36,17 +34,4 @@ DROP TABLE "custom_show_subtitle_preferences";--> statement-breakpoint
 ALTER TABLE "__new_custom_show_subtitle_preferences" RENAME TO "custom_show_subtitle_preferences";--> statement-breakpoint
 CREATE INDEX "custom_show_priority_index" ON "custom_show_subtitle_preferences" ("custom_show_id","priority");
 `;
-export default {
-  fullCopy: true,
-  up: async (db: Kysely<unknown>) => {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1747248401_ChangeSubtitlePriorityType.ts
+++ b/server/src/migration/db/Migration1747248401_ChangeSubtitlePriorityType.ts
@@ -1,8 +1,6 @@
-import { CompiledQuery } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
-export const expr = String.raw`
+const expr = String.raw`
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE "__new_channel_subtitle_preferences" (
 	"uuid" text PRIMARY KEY NOT NULL,
@@ -37,17 +35,4 @@ ALTER TABLE "__new_custom_show_subtitle_preferences" RENAME TO "custom_show_subt
 CREATE INDEX "custom_show_priority_index" ON "custom_show_subtitle_preferences" ("custom_show_id","priority");
 `;
 
-export default {
-  fullCopy: true,
-  async up(db) {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1748345299_AddMoreProgramTypes.ts
+++ b/server/src/migration/db/Migration1748345299_AddMoreProgramTypes.ts
@@ -1,6 +1,4 @@
-import { CompiledQuery } from 'kysely';
-import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 const expr = String.raw`
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
@@ -57,17 +55,4 @@ CREATE INDEX "program_artist_uuid_index" ON "program" ("artist_uuid");--> statem
 CREATE UNIQUE INDEX "program_source_type_external_source_id_external_key_unique" ON "program" ("source_type","external_source_id","external_key");
 `;
 
-export default {
-  fullCopy: true,
-  async up(db) {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr, true);

--- a/server/src/migration/db/Migration1756312561_InitialAdvancedTranscodeConfig.ts
+++ b/server/src/migration/db/Migration1756312561_InitialAdvancedTranscodeConfig.ts
@@ -1,6 +1,4 @@
-import { isNonEmptyString } from '@tunarr/shared/util';
-import { CompiledQuery } from 'kysely';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlString } from './util.ts';
 
 const expr = String.raw`
 ALTER TABLE "transcode_config" ADD "disable_hardware_decoder" integer DEFAULT false;--> statement-breakpoint
@@ -8,16 +6,4 @@ ALTER TABLE "transcode_config" ADD "disable_hardware_encoding" integer DEFAULT f
 ALTER TABLE "transcode_config" ADD "disable_hardware_filters" integer DEFAULT false;
 `;
 
-export default {
-  async up(db) {
-    const queries = expr
-      .split('--> statement-breakpoint')
-      .map((s) => s.trim())
-      .filter(isNonEmptyString)
-      .map((s) => CompiledQuery.raw(s));
-
-    for (const query of queries) {
-      await db.executeQuery(query);
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlString(expr);

--- a/server/src/migration/db/Migration1758203109_AddProgramMedia.ts
+++ b/server/src/migration/db/Migration1758203109_AddProgramMedia.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0012_yielding_ben_grimm.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0012_yielding_ben_grimm.sql');

--- a/server/src/migration/db/Migration1758570688_AddLocalLibraries.ts
+++ b/server/src/migration/db/Migration1758570688_AddLocalLibraries.ts
@@ -1,6 +1,6 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
+export default makeMigrationFromSqlFile(
   './sql/0013_silent_the_anarchist.sql',
   true,
 );

--- a/server/src/migration/db/Migration1758732083_FixLocalLibraryPath.ts
+++ b/server/src/migration/db/Migration1758732083_FixLocalLibraryPath.ts
@@ -1,3 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile('./sql/0014_gray_mongu.sql');
+export default makeMigrationFromSqlFile('./sql/0014_gray_mongu.sql');

--- a/server/src/migration/db/Migration1758903045_FixLocalLibraryPathAgain.ts
+++ b/server/src/migration/db/Migration1758903045_FixLocalLibraryPathAgain.ts
@@ -1,3 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile('./sql/0015_cuddly_midnight.sql');
+export default makeMigrationFromSqlFile('./sql/0015_cuddly_midnight.sql');

--- a/server/src/migration/db/Migration1759170884_AddArtworkAndMore.ts
+++ b/server/src/migration/db/Migration1759170884_AddArtworkAndMore.ts
@@ -1,6 +1,6 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
+export default makeMigrationFromSqlFile(
   './sql/0016_wealthy_dragon_lord.sql',
   true,
 );

--- a/server/src/migration/db/Migration1759518565_AddProgramSubtitles.ts
+++ b/server/src/migration/db/Migration1759518565_AddProgramSubtitles.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0017_glossy_lorna_dane.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0017_glossy_lorna_dane.sql');

--- a/server/src/migration/db/Migration1760129429_AddProgramGroupingSourceType.ts
+++ b/server/src/migration/db/Migration1760129429_AddProgramGroupingSourceType.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0018_lumpy_rick_jones.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0018_lumpy_rick_jones.sql');

--- a/server/src/migration/db/Migration1760213210_AddMoreProgramGroupingFields.ts
+++ b/server/src/migration/db/Migration1760213210_AddMoreProgramGroupingFields.ts
@@ -1,3 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile('./sql/0019_purple_thanos.sql');
+export default makeMigrationFromSqlFile('./sql/0019_purple_thanos.sql');

--- a/server/src/migration/db/Migration1760455673_UpdateForeignKeyCasacades.ts
+++ b/server/src/migration/db/Migration1760455673_UpdateForeignKeyCasacades.ts
@@ -1,6 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0020_whole_the_hand.sql',
-  true,
-);
+export default makeMigrationFromSqlFile('./sql/0020_whole_the_hand.sql', true);

--- a/server/src/migration/db/Migration1762205138_AddCredits.ts
+++ b/server/src/migration/db/Migration1762205138_AddCredits.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0022_marvelous_lila_cheney.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0022_marvelous_lila_cheney.sql');

--- a/server/src/migration/db/Migration1762205207_ArtworkCachePathNullable.ts
+++ b/server/src/migration/db/Migration1762205207_ArtworkCachePathNullable.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0023_powerful_silvermane.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0023_powerful_silvermane.sql');

--- a/server/src/migration/db/Migration1763585155_AddProgramForeignKeys.ts
+++ b/server/src/migration/db/Migration1763585155_AddProgramForeignKeys.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0024_messy_hammerhead.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0024_messy_hammerhead.sql');

--- a/server/src/migration/db/Migration1763673215_MoreProgramForeignKeys.ts
+++ b/server/src/migration/db/Migration1763673215_MoreProgramForeignKeys.ts
@@ -1,7 +1,7 @@
 import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
 export default {
-  ...makeKyselyMigrationFromSqlFile('./sql/0025_wakeful_gressill.sql', true),
+  ...makeMigrationFromSqlFile('./sql/0025_wakeful_gressill.sql', true),
   noTransaction: true,
 } satisfies TunarrDatabaseMigration;

--- a/server/src/migration/db/Migration1763749592_AddProgramState.ts
+++ b/server/src/migration/db/Migration1763749592_AddProgramState.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0026_old_the_renegades.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0026_old_the_renegades.sql');

--- a/server/src/migration/db/Migration1764022266_AddCreditGroupingIndex.ts
+++ b/server/src/migration/db/Migration1764022266_AddCreditGroupingIndex.ts
@@ -1,5 +1,3 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
-  './sql/0027_loud_golden_guardian.sql',
-);
+export default makeMigrationFromSqlFile('./sql/0027_loud_golden_guardian.sql');

--- a/server/src/migration/db/Migration1764022464_AddArtworkIndexes.ts
+++ b/server/src/migration/db/Migration1764022464_AddArtworkIndexes.ts
@@ -1,5 +1,5 @@
-import { makeKyselyMigrationFromSqlFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default makeKyselyMigrationFromSqlFile(
+export default makeMigrationFromSqlFile(
   './sql/0028_omniscient_blockbuster.sql',
 );

--- a/server/src/migration/db/Migration1767300603_AddExternalCollections.ts
+++ b/server/src/migration/db/Migration1767300603_AddExternalCollections.ts
@@ -1,25 +1,7 @@
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
-import { processSqlMigrationFile } from './util.ts';
+import { makeMigrationFromSqlFile } from './util.ts';
 
-export default {
-  up: async (db) => {
-    for (const statement of await processSqlMigrationFile(
-      './sql/0033_free_nekra.sql',
-    )) {
-      await db.executeQuery(statement);
-    }
-
-    for (const statement of await processSqlMigrationFile(
-      './sql/0034_cooing_bloodscream.sql',
-    )) {
-      await db.executeQuery(statement);
-    }
-
-    for (const statement of await processSqlMigrationFile(
-      './sql/0035_military_ben_grimm.sql',
-    )) {
-      await db.executeQuery(statement);
-    }
-  },
-  fullCopy: false,
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlFile([
+  './sql/0033_free_nekra.sql',
+  './sql/0034_cooing_bloodscream.sql',
+  './sql/0035_military_ben_grimm.sql',
+]);

--- a/server/src/migration/db/Migration1771271020_FixCustomShowContentKey.ts
+++ b/server/src/migration/db/Migration1771271020_FixCustomShowContentKey.ts
@@ -1,13 +1,9 @@
-import { CompiledQuery } from 'kysely';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import { makeMigrationFromSqlStatements } from './util.ts';
 
-export default {
-  fullCopy: true,
-  async up(db) {
-    const statements = [
-      'PRAGMA foreign_keys = OFF',
-      'ALTER TABLE `custom_show_content` RENAME TO `old_custom_show_content`',
-      `
+const statements = [
+  'PRAGMA foreign_keys = OFF',
+  'ALTER TABLE `custom_show_content` RENAME TO `old_custom_show_content`',
+  `
       CREATE TABLE IF NOT EXISTS "custom_show_content" (
         "custom_show_uuid" text not null,
         "content_uuid" text not null,
@@ -17,13 +13,9 @@ export default {
         constraint "primary_key" primary key ("custom_show_uuid", "content_uuid", "index")
       )
       `,
-      'INSERT INTO `custom_show_content`(custom_show_uuid, content_uuid, "index") SELECT custom_show_uuid, content_uuid, "index" FROM `old_custom_show_content`',
-      'DROP TABLE `old_custom_show_content`',
-      'PRAGMA foreign_keys = ON',
-    ];
+  'INSERT INTO `custom_show_content`(custom_show_uuid, content_uuid, "index") SELECT custom_show_uuid, content_uuid, "index" FROM `old_custom_show_content`',
+  'DROP TABLE `old_custom_show_content`',
+  'PRAGMA foreign_keys = ON',
+];
 
-    for (const statement of statements) {
-      await db.executeQuery(CompiledQuery.raw(statement.trim()));
-    }
-  },
-} satisfies TunarrDatabaseMigration;
+export default makeMigrationFromSqlStatements(statements, true);

--- a/server/src/migration/db/util.ts
+++ b/server/src/migration/db/util.ts
@@ -1,11 +1,13 @@
+import { sql } from 'drizzle-orm';
 import { CompiledQuery, type Kysely } from 'kysely';
-import { castArray } from 'lodash-es';
+import { castArray, identity } from 'lodash-es';
+import { readFileSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { isNonEmptyString } from '../../util/index.ts';
-import type { TunarrDatabaseMigration } from '../DirectMigrationProvider.ts';
+import type { TunarrDatabaseMigrationWithDrizzle } from '../DirectMigrationProvider.ts';
 
 export async function columnExists(
   db: Kysely<unknown>,
@@ -20,22 +22,6 @@ export async function columnExists(
   );
 }
 
-export async function applyDrizzleMigrationExpression(
-  db: Kysely<unknown>,
-  exprString: string,
-  breakpoint: string = '--> statement-breakpoint',
-) {
-  const queries = exprString
-    .split(breakpoint)
-    .map((s) => s.trim())
-    .filter(isNonEmptyString)
-    .map((s) => CompiledQuery.raw(s));
-
-  for (const query of queries) {
-    await db.executeQuery(query);
-  }
-}
-
 export async function processSqlMigrationFile(
   filePath: string,
   statementBreakpoint: string = '--> statement-breakpoint',
@@ -44,27 +30,78 @@ export async function processSqlMigrationFile(
     path.join(dirname(fileURLToPath(import.meta.url)), filePath),
     'utf-8',
   );
+  return processSqlMigrationString(
+    contents,
+    (statement) => CompiledQuery.raw(statement),
+    statementBreakpoint,
+  );
+}
 
-  return contents
+export function processSqlMigrationString<OutType>(
+  queryString: string,
+  processor: (singleStatement: string) => OutType,
+  statementBreakpoint: string = '--> statement-breakpoint',
+) {
+  return queryString
     .split(statementBreakpoint)
     .map((s) => s.trim())
     .filter(isNonEmptyString)
-    .map((s) => CompiledQuery.raw(s));
+    .map((s) => processor(s));
 }
 
-export function makeKyselyMigrationFromSqlFile(
+function processSqlMigrationFileForDrizzle(
+  filePath: string,
+  statementBreakpoint: string = '--> statement-breakpoint',
+) {
+  const contents = readFileSync(
+    path.join(dirname(fileURLToPath(import.meta.url)), filePath),
+    'utf-8',
+  );
+
+  return processSqlMigrationString(
+    contents,
+    identity<string>,
+    statementBreakpoint,
+  );
+}
+
+export function makeMigrationFromSqlFile(
   filePaths: string | Array<string>,
   fullCopy: boolean = false,
-): TunarrDatabaseMigration {
+): TunarrDatabaseMigrationWithDrizzle {
+  filePaths = castArray(filePaths);
+  const allStatements = filePaths.flatMap((path) =>
+    processSqlMigrationFileForDrizzle(path),
+  );
+  return makeMigrationFromSqlStatements(allStatements, fullCopy);
+}
+
+export function makeMigrationFromSqlString(
+  queryString: string,
+  fullCopy: boolean = false,
+): TunarrDatabaseMigrationWithDrizzle {
+  return makeMigrationFromSqlStatements(
+    processSqlMigrationString(queryString, identity<string>),
+    fullCopy,
+  );
+}
+
+export function makeMigrationFromSqlStatements(
+  allStatements: string[],
+  fullCopy: boolean,
+) {
   return {
     fullCopy,
     async up(db) {
-      filePaths = castArray(filePaths);
-      for (const path of filePaths) {
-        for (const statement of await processSqlMigrationFile(path)) {
-          await db.executeQuery(statement);
-        }
+      for (const statement of allStatements) {
+        await db.executeQuery(CompiledQuery.raw(statement));
       }
     },
-  };
+    upDrizzle(db) {
+      for (const statement of allStatements) {
+        db.run(sql.raw(statement));
+      }
+    },
+    kyselyOnly: false,
+  } satisfies TunarrDatabaseMigrationWithDrizzle;
 }

--- a/server/src/services/EntityMutex.ts
+++ b/server/src/services/EntityMutex.ts
@@ -1,7 +1,4 @@
-import {
-  MediaSourceLibrary,
-  MediaSourceLibraryOrm,
-} from '@/db/schema/MediaSourceLibrary.js';
+import { MediaSourceLibrary } from '@/db/schema/MediaSourceLibrary.js';
 import { inject, injectable } from 'inversify';
 import { MediaSource, MediaSourceOrm } from '../db/schema/MediaSource.ts';
 import { KEYS } from '../types/inject.ts';
@@ -23,7 +20,7 @@ export class EntityMutex {
     return this.lock(this.libraryKey(library.mediaSourceId, library.uuid));
   }
 
-  isLibraryLocked(library: MediaSourceLibrary | MediaSourceLibraryOrm) {
+  isLibraryLocked(library: MediaSourceLibrary) {
     return (
       this.mutexMap
         .getLockSync(this.libraryKey(library.mediaSourceId, library.uuid))
@@ -39,7 +36,7 @@ export class EntityMutex {
     );
   }
 
-  getLockForLibrary(library: MediaSourceLibrary | MediaSourceLibraryOrm) {
+  getLockForLibrary(library: MediaSourceLibrary) {
     return this.lock(this.libraryKey(library.mediaSourceId, library.uuid));
   }
 

--- a/server/src/services/MediaSourceLibraryRefresher.ts
+++ b/server/src/services/MediaSourceLibraryRefresher.ts
@@ -17,7 +17,6 @@ import { KEYS } from '../types/inject.ts';
 import { Maybe } from '../types/util.ts';
 import { groupByUniq, isDefined } from '../util/index.ts';
 import { Logger } from '../util/logging/LoggerFactory.ts';
-import { booleanToNumber } from '../util/sqliteUtil.ts';
 
 @injectable()
 export class MediaSourceLibraryRefresher {
@@ -117,7 +116,7 @@ export class MediaSourceLibraryRefresher {
         // Checked above
         mediaType: this.plexLibraryTypeToTunarrType(plexLibrary)!,
         uuid: v4(),
-        enabled: booleanToNumber(false),
+        enabled: false,
         name: plexLibrary.title,
       } satisfies NewMediaSourceLibrary);
     }
@@ -147,7 +146,7 @@ export class MediaSourceLibraryRefresher {
       mediaSource.uuid,
     );
 
-    await this.mediaSourceDB.updateLibraries({
+    this.mediaSourceDB.updateLibraries({
       addedLibraries: librariesToAdd,
       deletedLibraries: librariesToRemove.map(({ uuid }) => uuid),
       updatedLibraries: librariesToUpdate,
@@ -225,7 +224,7 @@ export class MediaSourceLibraryRefresher {
           jellyfinLibrary.CollectionType,
         )!,
         uuid: v4(),
-        enabled: booleanToNumber(false),
+        enabled: false,
         name: jellyfinLibrary.Name ?? '',
       } satisfies NewMediaSourceLibrary);
     }
@@ -253,7 +252,7 @@ export class MediaSourceLibraryRefresher {
       mediaSource.uuid,
     );
 
-    await this.mediaSourceDB.updateLibraries({
+    this.mediaSourceDB.updateLibraries({
       addedLibraries: librariesToAdd,
       deletedLibraries: librariesToRemove.map(({ uuid }) => uuid),
       updatedLibraries: [],
@@ -315,7 +314,7 @@ export class MediaSourceLibraryRefresher {
           embyLibrary.CollectionType,
         )!,
         uuid: v4(),
-        enabled: booleanToNumber(false),
+        enabled: false,
         name: embyLibrary.Name ?? '',
       } satisfies NewMediaSourceLibrary);
     }
@@ -331,7 +330,7 @@ export class MediaSourceLibraryRefresher {
       mediaSource.uuid,
     );
 
-    await this.mediaSourceDB.updateLibraries({
+    this.mediaSourceDB.updateLibraries({
       addedLibraries: librariesToAdd,
       deletedLibraries: librariesToRemove.map(({ uuid }) => uuid),
       updatedLibraries: [],

--- a/server/src/services/scanner/FileSystemScanner.ts
+++ b/server/src/services/scanner/FileSystemScanner.ts
@@ -1,4 +1,4 @@
-import type { MediaSourceLibraryOrm } from '@/db/schema/MediaSourceLibrary.js';
+import type { MediaSourceLibrary } from '@/db/schema/MediaSourceLibrary.js';
 import { seq } from '@tunarr/shared/util';
 import type { MediaItem, MediaStream } from '@tunarr/types';
 import dayjs from 'dayjs';
@@ -553,7 +553,7 @@ export abstract class FileSystemScanner {
 
 export type LocalScanContext = {
   mediaSource: MediaSourceWithRelations;
-  library: MediaSourceLibraryOrm;
+  library: MediaSourceLibrary;
   force: boolean;
   percentMin: number;
   percentCompleteMultiplier: number;

--- a/server/src/services/scanner/MediaSourceScanner.ts
+++ b/server/src/services/scanner/MediaSourceScanner.ts
@@ -1,4 +1,4 @@
-import type { MediaSourceLibraryOrm } from '@/db/schema/MediaSourceLibrary.js';
+import type { MediaSourceLibrary } from '@/db/schema/MediaSourceLibrary.js';
 import dayjs from 'dayjs';
 import type { MediaSourceDB } from '../../db/mediaSourceDB.ts';
 import type { MediaSourceWithRelations } from '../../db/schema/derivedTypes.js';
@@ -11,13 +11,13 @@ import { devAssert } from '../../util/debug.ts';
 import type { Logger } from '../../util/logging/LoggerFactory.ts';
 
 export type ScanRequest = {
-  library: MediaSourceLibraryOrm;
+  library: MediaSourceLibrary;
   force?: boolean;
   pathFilter?: string;
 };
 
 export type ScanContext<ApiClientTypeT> = {
-  library: MediaSourceLibraryOrm;
+  library: MediaSourceLibrary;
   mediaSource: MediaSourceOrm;
   apiClient: ApiClientTypeT;
   force: boolean;

--- a/server/src/services/scanner/PlexCollectionScanner.ts
+++ b/server/src/services/scanner/PlexCollectionScanner.ts
@@ -23,7 +23,7 @@ import type {
 } from '../../db/schema/derivedTypes.ts';
 import { ExternalCollection } from '../../db/schema/ExternalCollection.ts';
 import { MediaSourceOrm } from '../../db/schema/MediaSource.ts';
-import { MediaSourceLibraryOrm } from '../../db/schema/MediaSourceLibrary.ts';
+import { MediaSourceLibrary } from '../../db/schema/MediaSourceLibrary.ts';
 import { ProgramGroupingType } from '../../db/schema/ProgramGrouping.ts';
 import { Tag } from '../../db/schema/Tag.ts';
 import { TagRepo } from '../../db/TagRepo.ts';
@@ -45,7 +45,7 @@ import {
 
 type Context = {
   mediaSource: MediaSourceOrm;
-  library: MediaSourceLibraryOrm;
+  library: MediaSourceLibrary;
   apiClient: PlexApiClient;
 };
 

--- a/server/src/services/search/LibraryNameSearchMutator.ts
+++ b/server/src/services/search/LibraryNameSearchMutator.ts
@@ -1,14 +1,14 @@
 import { seq } from '@tunarr/shared/util';
 import type { SearchFilterValueNode } from '@tunarr/types/schemas';
 import type { Dictionary } from 'ts-essentials';
-import type { MediaSourceLibraryOrm } from '../../db/schema/MediaSourceLibrary.ts';
+import type { MediaSourceLibrary } from '../../db/schema/MediaSourceLibrary.ts';
 import { groupByUniq } from '../../util/index.ts';
 import type { SearchFilterValueMutator } from './SearchFilterValueMutator.ts';
 
 export class LibraryNameSearchMutator implements SearchFilterValueMutator {
-  private byName!: Dictionary<MediaSourceLibraryOrm>;
+  private byName!: Dictionary<MediaSourceLibrary>;
 
-  constructor(libraries: MediaSourceLibraryOrm[]) {
+  constructor(libraries: MediaSourceLibrary[]) {
     this.byName = groupByUniq(libraries, (lib) => lib.name);
   }
 

--- a/server/src/testing/fakes/FakeChannelDB.ts
+++ b/server/src/testing/fakes/FakeChannelDB.ts
@@ -19,7 +19,7 @@ import type {
   PageParams,
   UpdateChannelLineupRequest,
 } from '../../db/interfaces/IChannelDB.ts';
-import type { Channel } from '../../db/schema/Channel.ts';
+import type { Channel, ChannelOrm } from '../../db/schema/Channel.ts';
 import type {
   ChannelWithPrograms,
   ChannelWithRelations,
@@ -165,75 +165,17 @@ export class FakeChannelDB implements IChannelDB {
   setChannelPrograms(
     channel: Channel,
     lineup: readonly LineupItem[],
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   setChannelPrograms(
     channel: string | Channel,
     lineup: readonly LineupItem[],
     startTime?: number,
-  ): Promise<Channel | null>;
+  ): Promise<ChannelOrm | null>;
   setChannelPrograms(
     channel: unknown,
     lineup: unknown,
     startTime?: unknown,
-  ): Promise<{
-    number: number;
-    duration: number;
-    uuid: string;
-    offline: {
-      mode: 'pic' | 'clip';
-      picture?: string | undefined;
-      soundtrack?: string | undefined;
-    };
-    createdAt: number | null;
-    updatedAt: number | null;
-    name: string;
-    disableFillerOverlay: number;
-    fillerRepeatCooldown: number | null;
-    groupTitle: string | null;
-    guideFlexTitle: string | null;
-    guideMinimumDuration: number;
-    icon: {
-      path: string;
-      width: number;
-      duration: number;
-      position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-    };
-    startTime: number;
-    stealth: number;
-    streamMode: 'hls' | 'hls_slower' | 'mpegts' | 'hls_direct';
-    transcoding: {
-      targetResolution?: { widthPx: number; heightPx: number } | undefined;
-      videoBitrate?: number | undefined;
-      videoBufferSize?: number | undefined;
-    } | null;
-    transcodeConfigId: string;
-    watermark: {
-      enabled: boolean;
-      position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-      width: number;
-      verticalMargin: number;
-      horizontalMargin: number;
-      duration: number;
-      opacity: number;
-      url?: string | undefined;
-      fixedSize?: boolean | undefined;
-      animated?: boolean | undefined;
-      fadeConfig?:
-        | {
-            periodMins: number;
-            programType?:
-              | 'movie'
-              | 'episode'
-              | 'track'
-              | 'music_video'
-              | 'other_video'
-              | undefined;
-            leadingEdge?: boolean | undefined;
-          }[]
-        | undefined;
-    } | null;
-    subtitlesEnabled: number;
-  } | null> {
+  ): Promise<ChannelOrm> {
     throw new Error('Method not implemented.');
   }
   updateChannelStartTime(id: string, newTime: number): Promise<void> {


### PR DESCRIPTION
This is a large scale refactor to run all DB transaction code
asynchronsouly. At it's core, better-sqlite3 is a synchronous DB
library. Newer versions disallow transaction code that returns Promises
completely. As such, we've been stuck on older code (and this is
blocking other things, like NodeJS version bumps because of binary
interface changes).

Here we translate all kysely transaction code to Drizzle, because only
the latter supports synchronous execution of queries. This includes a
ton of DB migration code, since changing that completely to something
Drizzle-first is a much larger undertaking that will be tackled in a
follow-up.

This change should unblock the following:
1. Bumping better-sqlite3
2. Bumping nodejs version bumps
3. Paves the way towards Drizzle-only migrations
4. Will allow us to switch over from sync => async results using Drizzle
   builders more easily in the future, should we decide to change the
underlying sqlite driver.
