### PR TITLE
hls fixes dev

### DIFF
--- a/server/src/stream/ConnectionTracker.test.ts
+++ b/server/src/stream/ConnectionTracker.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionTracker } from './ConnectionTracker.ts';
+
+vi.mock('@/util/logging/LoggerFactory.js', () => ({
+  LoggerFactory: {
+    child: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trace: vi.fn(),
+      warn: vi.fn(),
+      setBindings: vi.fn(),
+    }),
+  },
+}));
+
+describe('ConnectionTracker', () => {
+  let tracker: ConnectionTracker<any>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tracker = new ConnectionTracker('test-id', 'test-tracker');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('cancelCleanup', () => {
+    it('cancels a pending cleanup timer', () => {
+      const cleanupHandler = vi.fn();
+      tracker.on('cleanup', cleanupHandler);
+
+      tracker.scheduleCleanup(5000);
+      tracker.cancelCleanup();
+
+      // Advance past the scheduled delay — handler should NOT fire
+      vi.advanceTimersByTime(10_000);
+
+      expect(cleanupHandler).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no cleanup is scheduled', () => {
+      // Should not throw
+      expect(() => tracker.cancelCleanup()).not.toThrow();
+    });
+
+    it('allows a new cleanup to be scheduled after cancellation', () => {
+      const cleanupHandler = vi.fn();
+      tracker.on('cleanup', cleanupHandler);
+
+      tracker.scheduleCleanup(5000);
+      tracker.cancelCleanup();
+
+      // Schedule again
+      tracker.scheduleCleanup(3000);
+      vi.advanceTimersByTime(3000);
+
+      expect(cleanupHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('scheduleCleanup', () => {
+    it('emits cleanup after delay when no connections exist', () => {
+      const cleanupHandler = vi.fn();
+      tracker.on('cleanup', cleanupHandler);
+
+      tracker.scheduleCleanup(5000);
+      vi.advanceTimersByTime(5000);
+
+      expect(cleanupHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit cleanup if a connection was added during the delay', () => {
+      const cleanupHandler = vi.fn();
+      tracker.on('cleanup', cleanupHandler);
+
+      tracker.scheduleCleanup(5000);
+
+      // Add connection during grace period — this clears the timer
+      tracker.addConnection('token-1', { ip: '1.2.3.4' });
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(cleanupHandler).not.toHaveBeenCalled();
+    });
+
+    it('returns false when cleanup is already scheduled', () => {
+      tracker.scheduleCleanup(5000);
+      const result = tracker.scheduleCleanup(5000);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('session replacement race condition', () => {
+    it('cancelCleanup prevents stale timer from firing after session replacement', () => {
+      // Simulates the race condition from the bug:
+      // 1. Session A schedules cleanup (via scheduleCleanup)
+      // 2. Session A is stopped and replaced by Session B
+      // 3. Session A's timer fires and would delete Session B
+      //
+      // Fix: Session.stop() calls cancelCleanup() before stopping,
+      // preventing the stale timer from ever firing.
+
+      const cleanupA = vi.fn();
+      const trackerA = new ConnectionTracker('chan-1', 'session-A');
+      trackerA.on('cleanup', cleanupA);
+
+      // Step 1: Session A has no connections, schedules cleanup
+      trackerA.scheduleCleanup(15_000);
+
+      // Step 2: Session A is stopped — cancel its cleanup timer
+      trackerA.cancelCleanup();
+
+      // Step 3: Advance time past the original delay
+      vi.advanceTimersByTime(20_000);
+
+      // The stale timer must NOT have fired
+      expect(cleanupA).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/stream/ConnectionTracker.ts
+++ b/server/src/stream/ConnectionTracker.ts
@@ -63,6 +63,13 @@ export class ConnectionTracker<
     return this.#heartbeats[token];
   }
 
+  cancelCleanup() {
+    if (this.#cleanupFunc) {
+      clearTimeout(this.#cleanupFunc);
+      this.#cleanupFunc = null;
+    }
+  }
+
   scheduleCleanup(delay: number) {
     if (this.#cleanupFunc) {
       this.#logger.debug('Cleanup already scheduled');

--- a/server/src/stream/Session.ts
+++ b/server/src/stream/Session.ts
@@ -155,6 +155,10 @@ export abstract class Session<
    * participants.
    */
   async stop() {
+    // Cancel any pending delayed cleanup so it cannot fire after this
+    // session has been replaced by a new one at the same key.
+    this.connectionTracker.cancelCleanup();
+
     await this.lock.runExclusive(async () => {
       switch (this.state) {
         case 'starting':

--- a/server/src/stream/SessionManager.test.ts
+++ b/server/src/stream/SessionManager.test.ts
@@ -1,0 +1,271 @@
+import type { IChannelDB } from '@/db/interfaces/IChannelDB.js';
+import type { ISettingsDB } from '@/db/interfaces/ISettingsDB.js';
+import type { ChannelOrmWithTranscodeConfig } from '@/db/schema/derivedTypes.js';
+import type { HlsOptions } from '@/ffmpeg/builder/constants.js';
+import type { EventService } from '@/services/EventService.js';
+import type { OnDemandChannelService } from '@/services/OnDemandChannelService.js';
+import type { Logger } from '@/util/logging/LoggerFactory.js';
+import type { DeepRequired } from 'ts-essentials';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HlsSessionOptions } from './hls/HlsSession.ts';
+
+// Mock modules that create circular dependency chains through Inversify
+vi.mock('@/services/EventService.js', () => ({
+  EventService: vi.fn(),
+}));
+
+vi.mock('@/services/OnDemandChannelService.js', () => ({
+  OnDemandChannelService: vi.fn(),
+}));
+
+// Must be imported after the mocks are set up
+const { SessionManager } = await import('./SessionManager.ts');
+const { BaseHlsSession } = await import('./hls/BaseHlsSession.ts');
+
+// ---------------------------------------------------------------------------
+// Stub session: a minimal HlsSession-like object that lets us control
+// start/stop behaviour and manually emit events.
+// ---------------------------------------------------------------------------
+
+class StubHlsSession extends BaseHlsSession<HlsSessionOptions> {
+  public readonly sessionType: 'hls' | 'hls_direct_v2';
+
+  constructor(
+    channel: ChannelOrmWithTranscodeConfig,
+    options: HlsSessionOptions,
+  ) {
+    super(channel, options);
+    this.sessionType = options.streamMode;
+  }
+
+  protected getHlsOptions(): DeepRequired<HlsOptions> {
+    return {
+      hlsDeleteThreshold: 3,
+      streamNameFormat: 'stream.m3u8',
+      subtitleStreamNameFormat: 'subs.m3u8',
+      segmentNameFormat: 'data%06d.ts',
+      segmentBaseDirectory: '/tmp/test-sessions',
+      streamBasePath: 'test',
+      streamBaseUrl: '/test/',
+      hlsTime: 4,
+      hlsListSize: 0,
+      deleteThreshold: null,
+      appendSegments: true,
+    };
+  }
+
+  // Skip all real startup work — just mark as started
+  protected override async startInternal() {
+    this.state = 'started';
+  }
+
+  protected override async stopInternal() {
+    this.state = 'stopped';
+  }
+
+  // Skip waiting for stream files
+  protected override async waitForStreamReady() {
+    const { Result } = await import('@/types/result.js');
+    return Result.success(void 0);
+  }
+
+  isStale() {
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+const noopLogger: Logger = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  trace: vi.fn(),
+  warn: vi.fn(),
+  setBindings: vi.fn(),
+  child: () => noopLogger,
+  bindings: () => ({}),
+} as unknown as Logger;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const channelUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function makeChannel(): ChannelOrmWithTranscodeConfig {
+  return {
+    uuid: channelUuid,
+    number: 1,
+    transcodeConfig: {},
+  } as unknown as ChannelOrmWithTranscodeConfig;
+}
+
+function makeSessionManager(
+  hlsFactory: (
+    channel: ChannelOrmWithTranscodeConfig,
+    options: HlsSessionOptions,
+  ) => StubHlsSession,
+) {
+  const channelDB: Partial<IChannelDB> = {
+    getChannelOrm: vi.fn().mockResolvedValue(makeChannel()),
+  };
+
+  const onDemandService: Partial<OnDemandChannelService> = {
+    resumeChannel: vi.fn().mockResolvedValue(undefined),
+    pauseChannel: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const eventService: Partial<EventService> = {
+    push: vi.fn(),
+  };
+
+  const settingsDB: Partial<ISettingsDB> = {
+    ffmpegSettings: vi.fn().mockReturnValue({
+      transcodeDirectory: '/tmp/test-sessions',
+    }),
+  };
+
+  // Construct SessionManager directly, bypassing Inversify
+  const manager = new (SessionManager as any)(
+    noopLogger,
+    channelDB,
+    onDemandService,
+    hlsFactory,
+    vi.fn(), // hlsSlowerSessionFactory — not used in these tests
+    vi.fn(), // concatSessionFactory
+    eventService,
+    settingsDB,
+  ) as SessionManager;
+
+  return manager;
+}
+
+const connection = { ip: '127.0.0.1' };
+
+describe('SessionManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('session replacement race condition', () => {
+    it('stop event from Session A does not delete Session B at the same key', async () => {
+      // Track which sessions the factory creates so we can reference them
+      const sessions: StubHlsSession[] = [];
+      const manager = makeSessionManager((channel, options) => {
+        const s = new StubHlsSession(channel, options);
+        sessions.push(s);
+        return s;
+      });
+
+      // Create Session A
+      const resultA = await manager.getOrCreateHlsSession(
+        channelUuid,
+        'token-a',
+        connection,
+        { streamMode: 'hls' },
+      );
+      expect(resultA.isSuccess()).toBe(true);
+      const sessionA = sessions[0]!;
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionA);
+
+      // End Session A through the manager (simulates user stopping stream)
+      await manager.endSession(channelUuid, 'hls');
+      expect(manager.getHlsSession(channelUuid)).toBeUndefined();
+
+      // Create Session B at the same key (user starts stream again)
+      const resultB = await manager.getOrCreateHlsSession(
+        channelUuid,
+        'token-b',
+        connection,
+        { streamMode: 'hls' },
+      );
+      expect(resultB.isSuccess()).toBe(true);
+      const sessionB = sessions[1]!;
+      expect(sessionB).not.toBe(sessionA);
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionB);
+
+      // Session A's delayed 'stop' event fires (stale event from the old session)
+      sessionA.emit('stop');
+
+      // Session B must still be in the map — the identity guard prevents deletion
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionB);
+    });
+
+    it('cleanup event from Session A does not delete Session B at the same key', async () => {
+      const sessions: StubHlsSession[] = [];
+      const manager = makeSessionManager((channel, options) => {
+        const s = new StubHlsSession(channel, options);
+        sessions.push(s);
+        return s;
+      });
+
+      // Create Session A
+      await manager.getOrCreateHlsSession(channelUuid, 'token-a', connection, {
+        streamMode: 'hls',
+      });
+      const sessionA = sessions[0]!;
+
+      // End Session A
+      await manager.endSession(channelUuid, 'hls');
+
+      // Create Session B
+      await manager.getOrCreateHlsSession(channelUuid, 'token-b', connection, {
+        streamMode: 'hls',
+      });
+      const sessionB = sessions[1]!;
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionB);
+
+      // Session A's delayed 'cleanup' event fires
+      sessionA.emit('cleanup');
+
+      // Session B must still be in the map
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionB);
+    });
+
+    it('stop event from the current session DOES remove it from the map', async () => {
+      const sessions: StubHlsSession[] = [];
+      const manager = makeSessionManager((channel, options) => {
+        const s = new StubHlsSession(channel, options);
+        sessions.push(s);
+        return s;
+      });
+
+      await manager.getOrCreateHlsSession(channelUuid, 'token-a', connection, {
+        streamMode: 'hls',
+      });
+      const sessionA = sessions[0]!;
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionA);
+
+      // The session's own stop event should still clean up normally
+      sessionA.emit('stop');
+
+      expect(manager.getHlsSession(channelUuid)).toBeUndefined();
+    });
+
+    it('cleanup event from the current session DOES remove it from the map', async () => {
+      const sessions: StubHlsSession[] = [];
+      const manager = makeSessionManager((channel, options) => {
+        const s = new StubHlsSession(channel, options);
+        sessions.push(s);
+        return s;
+      });
+
+      await manager.getOrCreateHlsSession(channelUuid, 'token-a', connection, {
+        streamMode: 'hls',
+      });
+      const sessionA = sessions[0]!;
+      expect(manager.getHlsSession(channelUuid)).toBe(sessionA);
+
+      sessionA.emit('cleanup');
+
+      expect(manager.getHlsSession(channelUuid)).toBeUndefined();
+    });
+  });
+});

--- a/server/src/stream/SessionManager.ts
+++ b/server/src/stream/SessionManager.ts
@@ -303,8 +303,10 @@ export class SessionManager {
           });
 
           session.on('stop', () => {
-            this.deleteSession(channelId, sessionType);
-            this.shutdownChildSessions(channelId, sessionType);
+            if (this.getSession(channelId, sessionType) === session) {
+              this.deleteSession(channelId, sessionType);
+              this.shutdownChildSessions(channelId, sessionType);
+            }
             if (session) {
               this.pauseChannelIfNecessary(session, connection).catch(() => {});
             }
@@ -320,8 +322,13 @@ export class SessionManager {
           });
 
           session.on('cleanup', () => {
-            this.deleteSession(channelId, sessionType);
-            this.shutdownChildSessions(channelId, sessionType);
+            // Verify the session in the map is the same instance. A delayed
+            // cleanup timer from a previous session must not delete a
+            // replacement session that was created at the same key.
+            if (this.getSession(channelId, sessionType) === session) {
+              this.deleteSession(channelId, sessionType);
+              this.shutdownChildSessions(channelId, sessionType);
+            }
           });
 
           session.on('removeConnection', (_, connection) => {

--- a/server/src/stream/hls/BaseHlsSession.test.ts
+++ b/server/src/stream/hls/BaseHlsSession.test.ts
@@ -151,6 +151,32 @@ describe('BaseHlsSession', () => {
       expect(session.minSegment).toBe(10);
     });
 
+    it('stop() cancels a pending cleanup timer so it cannot fire on a replacement session', async () => {
+      // This test covers the session lifecycle race condition:
+      // 1. Session A loses all connections → scheduleCleanup() sets a 15s timer
+      // 2. User starts a new stream → endSession() calls stop() on Session A
+      // 3. Session B is created at the same cache key
+      // 4. Session A's timer fires → would delete Session B from the map
+      //
+      // Fix: stop() calls connectionTracker.cancelCleanup() before
+      // acquiring the lock, so the timer never fires.
+
+      const cleanupHandler = vi.fn();
+      session.on('cleanup', cleanupHandler);
+
+      // Schedule cleanup as would happen when all connections go stale
+      session.scheduleCleanup(15_000);
+
+      // stop() should cancel the pending timer
+      await session.stop();
+
+      // Advance past the scheduled delay
+      vi.advanceTimersByTime(20_000);
+
+      // The stale cleanup timer must not have fired
+      expect(cleanupHandler).not.toHaveBeenCalled();
+    });
+
     it('keeps a connection alive if heartbeat is refreshed within staleness window', () => {
       session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
       session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));

--- a/server/src/stream/hls/BaseHlsSession.ts
+++ b/server/src/stream/hls/BaseHlsSession.ts
@@ -135,14 +135,11 @@ export abstract class BaseHlsSession<
         'Cleaning up existing working directory: %s',
         this._workingDirectory,
       );
-      await fs.rmdir(this._workingDirectory, { recursive: true });
+      await fs.rm(this._workingDirectory, { recursive: true, force: true });
       await fs.mkdir(this._workingDirectory);
     } catch (err) {
-      return this.logger.error(
-        err,
-        'Failed to cleanup stream: %s',
-        this.channel.uuid,
-      );
+      this.logger.error(err, 'Failed to cleanup stream: %s', this.channel.uuid);
+      throw err;
     }
   }
 

--- a/server/src/stream/hls/HlsPlaylistMutator.test.ts
+++ b/server/src/stream/hls/HlsPlaylistMutator.test.ts
@@ -921,18 +921,17 @@ describe('HlsPlaylistMutator', () => {
   });
 
   describe('high-water mark floor protection', () => {
-    // These tests verify the invariant that HlsSession's #highestDeletedBelow
-    // relies on: the before_segment_number filter acts as a hard floor, so the
-    // playlist never references segments below (segmentNumber - segmentsToKeepBefore).
+    // These tests verify that the segmentFloor option prevents the playlist
+    // from referencing segments that have been deleted from disk. Without it,
+    // segmentsToKeepBefore can extend the window below the deletion threshold.
 
     const start = dayjs('2024-10-18T14:00:00.000-0400');
     const largeOpts = { ...defaultOpts, maxSegmentsToKeep: 20 };
 
-    it('Scenario B: segmentNumber=0 (empty _minByIp) selects segments from the start', () => {
-      // Without the high-water mark fix, stale cleanup empties _minByIp and
-      // minSegmentRequested returns 0. This causes trimPlaylist to serve segments
-      // from the very beginning of the playlist — all of which have been deleted.
-      // This test documents the behavior that #highestDeletedBelow prevents.
+    it('without segmentFloor, segmentNumber=0 selects segments from the start', () => {
+      // Without segmentFloor, stale cleanup empties _minByIp and
+      // minSegmentRequested returns 0, causing the playlist to serve
+      // segments from the very beginning — all of which may be deleted.
       const lines = createPlaylist(100);
 
       const result = mutator.trimPlaylist(
@@ -946,17 +945,17 @@ describe('HlsPlaylistMutator', () => {
         largeOpts,
       );
 
-      // minSeg = max(0-10, 0) = 0 → all 100 segments pass the filter (≥20) → take first 20 = segs 0..19
+      // minSeg = max(0-10, 0) = 0 → all 100 pass filter → take first 20
       expect(result.playlist).toContain('data000000.ts');
       expect(result.playlist).toContain('data000019.ts');
       expect(result.playlist).not.toContain('data000020.ts');
     });
 
-    it('Scenario B fix: high-water mark as segmentNumber floors the playlist above deleted range', () => {
+    it('segmentFloor prevents playlist from referencing deleted segments', () => {
       // After deleteOldSegments(190), #highestDeletedBelow = 190.
-      // Math.max(minSegmentRequested=0, highestDeletedBelow=190) = 190 is used
-      // as segmentNumber, so the playlist starts at 180 (190 - keepBefore:10)
-      // rather than 0, avoiding any reference to deleted segments.
+      // segmentNumber = max(minSegmentRequested=0, 190) = 190
+      // Without segmentFloor: minSeg = max(190-10, 0) = 180 → refs 180-189 which are deleted!
+      // With segmentFloor=190: minSeg = max(180, 190) = 190 → starts at 190, all exist.
       const lines = createPlaylist(300);
 
       const result = mutator.trimPlaylist(
@@ -965,23 +964,23 @@ describe('HlsPlaylistMutator', () => {
           type: 'before_segment_number',
           segmentNumber: 190,
           segmentsToKeepBefore: 10,
+          segmentFloor: 190,
         },
         lines,
         largeOpts,
       );
 
-      // minSeg = max(190-10, 0) = 180; segs 180..299 (120 ≥ 20) → take first 20 = segs 180..199
-      expect(result.playlist).toContain('data000180.ts');
-      expect(result.playlist).toContain('data000199.ts');
-      expect(result.playlist).not.toContain('data000179.ts');
-      expect(result.playlist).not.toContain('data000000.ts');
+      // segs 190..299 (110 ≥ 20) → take first 20 = segs 190..209
+      expect(result.playlist).toContain('data000190.ts');
+      expect(result.playlist).toContain('data000209.ts');
+      expect(result.playlist).not.toContain('data000189.ts');
+      expect(result.playlist).not.toContain('data000180.ts');
     });
 
-    it('Scenario A: stale client removal jump still floors above deleted range', () => {
-      // Client A was at seg 100, stale cleanup removes it, leaving Client B at seg 200.
-      // deleteOldSegments(190) ran, so #highestDeletedBelow = 190.
-      // Math.max(minSegmentRequested=200, highestDeletedBelow=190) = 200.
-      // Playlist must not include segments below 190 (200 - keepBefore:10).
+    it('segmentFloor does not affect segments above the floor', () => {
+      // Client B at seg 200, #highestDeletedBelow = 190.
+      // segmentNumber = max(200, 190) = 200, segmentFloor = 190
+      // minSeg = max(200-10, 190) = 190 → keeps 190..209
       const lines = createPlaylist(300);
 
       const result = mutator.trimPlaylist(
@@ -990,21 +989,18 @@ describe('HlsPlaylistMutator', () => {
           type: 'before_segment_number',
           segmentNumber: 200,
           segmentsToKeepBefore: 10,
+          segmentFloor: 190,
         },
         lines,
         largeOpts,
       );
 
-      // minSeg = max(200-10, 0) = 190; segs 190..299 (110 ≥ 20) → take first 20 = segs 190..209
       expect(result.playlist).toContain('data000190.ts');
       expect(result.playlist).toContain('data000209.ts');
       expect(result.playlist).not.toContain('data000189.ts');
-      expect(result.playlist).not.toContain('data000100.ts');
     });
 
-    it('floor does not over-trim when segmentNumber equals the live edge', () => {
-      // When #highestDeletedBelow and minSegmentRequested agree (normal single-client case),
-      // the playlist should include the last keepBefore segments before the current position.
+    it('segmentFloor=0 behaves the same as no floor', () => {
       const lines = createPlaylist(50);
 
       const result = mutator.trimPlaylist(
@@ -1013,12 +1009,13 @@ describe('HlsPlaylistMutator', () => {
           type: 'before_segment_number',
           segmentNumber: 30,
           segmentsToKeepBefore: 10,
+          segmentFloor: 0,
         },
         lines,
         largeOpts,
       );
 
-      // minSeg = max(30-10, 0) = 20; segs 20..49 (30 ≥ 20) → take first 20 = segs 20..39
+      // minSeg = max(30-10, 0) = 20; segs 20..49 (30 ≥ 20) → take first 20
       expect(result.playlist).toContain('data000020.ts');
       expect(result.playlist).toContain('data000039.ts');
       expect(result.playlist).not.toContain('data000019.ts');

--- a/server/src/stream/hls/HlsPlaylistMutator.ts
+++ b/server/src/stream/hls/HlsPlaylistMutator.ts
@@ -33,6 +33,9 @@ type FilterBeforeSegmentNumber = {
   type: 'before_segment_number';
   segmentNumber: number;
   segmentsToKeepBefore: number;
+  // Hard floor: never include segments below this number. Prevents the
+  // playlist from referencing segments that have been deleted from disk.
+  segmentFloor?: number;
 };
 
 export type HlsPlaylistFilterOptions =
@@ -155,7 +158,7 @@ export class HlsPlaylistMutator {
           (beforeSeg) => {
             const minSeg = Math.max(
               beforeSeg.segmentNumber - beforeSeg.segmentsToKeepBefore,
-              0,
+              beforeSeg.segmentFloor ?? 0,
             );
             return seq.collect(allSegments, (segment) => {
               const fileName = basename(segment.line);

--- a/server/src/stream/hls/HlsSession.ts
+++ b/server/src/stream/hls/HlsSession.ts
@@ -113,6 +113,7 @@ export class HlsSession extends BaseHlsSession<HlsSessionOptions> {
         this.#highestDeletedBelow,
       ),
       segmentsToKeepBefore: 10,
+      segmentFloor: this.#highestDeletedBelow,
     };
     return Result.attemptAsync(async () => {
       return await this.lock.runExclusive(async () => {

--- a/server/src/stream/hls/HlsSession.ts
+++ b/server/src/stream/hls/HlsSession.ts
@@ -188,12 +188,15 @@ export class HlsSession extends BaseHlsSession<HlsSessionOptions> {
       }
     }
 
-    this.logger.debug(
-      'HLS worker ended main loop with state = %s. Scheduling cleanup',
-      this.state,
-    );
+    this.logger.debug('HLS worker ended main loop with state = %s', this.state);
 
-    this.scheduleCleanup();
+    // Only schedule cleanup if the session wasn't already explicitly stopped
+    // (e.g. via endSession). If the session is already stopped, its cleanup
+    // has been handled and scheduling another timer would risk deleting a
+    // replacement session that now occupies the same map key.
+    if (this.state !== 'stopped') {
+      this.scheduleCleanup();
+    }
   }
 
   protected async stopInternal(): Promise<void> {


### PR DESCRIPTION
- **fix: prevent delayed cleanup timer from deleting replacement HLS sessions**
- **fix: prevent playlist from referencing segments deleted by high-water mark**
- **fix: do not silently fail when cleaning up previous stream direcvtory**
