### PR TITLE
fix: improve AddMediaSourceButton appearance in light mode

### DIFF
--- a/web/src/components/channel_config/ProgrammingSelector.tsx
+++ b/web/src/components/channel_config/ProgrammingSelector.tsx
@@ -241,7 +241,7 @@ export const ProgrammingSelector = ({
           <Alert
             variant="filled"
             severity="error"
-            action={<AddMediaSourceButton />}
+            action={<AddMediaSourceButton ButtonProps={{ color: 'inherit', variant: 'outlined' }} />}
           >
             No Media Sources detected.
           </Alert>

--- a/web/src/components/settings/media_source/AddMediaSourceButton.tsx
+++ b/web/src/components/settings/media_source/AddMediaSourceButton.tsx
@@ -73,7 +73,7 @@ export function AddMediaSourceButton({ ButtonProps }: Props) {
   return (
     <Box>
       <Button
-        color="inherit"
+        color="primary"
         onClick={openManualAddButtonMenu}
         variant="contained"
         startIcon={<Add />}


### PR DESCRIPTION
Use color="primary" as the default button color so it renders correctly on light backgrounds. In the error alert context in ProgrammingSelector, override to color="inherit" variant="outlined" so it fits the filled red alert styling.

Fixes #1284.

<img width="768" height="485" alt="light" src="https://github.com/user-attachments/assets/6d75a3ac-a948-4575-899a-0cd3003239d4" />
<img width="764" height="472" alt="dark" src="https://github.com/user-attachments/assets/577102ba-9c46-47c0-9304-c757262aa646" />
