### PR TITLE
feat: expose language helper funcs in CEL context

### DIFF
--- a/server/src/services/CelEvaluationService.test.ts
+++ b/server/src/services/CelEvaluationService.test.ts
@@ -154,6 +154,171 @@ describe('CelEvaluationService', () => {
     });
   });
 
+  describe('custom functions', () => {
+    describe('hasAudioLang', () => {
+      it('matches ISO 639-2/T code directly', () => {
+        const ctx = makeContext();
+        expect(service.evaluate('hasAudioLang("eng")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("jpn")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("fra")', ctx)).toBe(false);
+      });
+
+      it('matches ISO 639-1 code via normalization', () => {
+        const ctx = makeContext();
+        expect(service.evaluate('hasAudioLang("en")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("ja")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("fr")', ctx)).toBe(false);
+      });
+
+      it('matches English language name', () => {
+        const ctx = makeContext();
+        expect(service.evaluate('hasAudioLang("English")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("Japanese")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("French")', ctx)).toBe(false);
+      });
+
+      it('falls back to case-insensitive match for unknown inputs', () => {
+        const ctx = makeContext({
+          audio: {
+            streams: [
+              {
+                index: 0,
+                language: 'und',
+                codec: 'aac',
+                channels: 2,
+                title: '',
+                default: true,
+                selected: true,
+              },
+            ],
+            languages: ['und'],
+          },
+        });
+        expect(service.evaluate('hasAudioLang("und")', ctx)).toBe(true);
+        expect(service.evaluate('hasAudioLang("UND")', ctx)).toBe(true);
+      });
+    });
+
+    describe('hasSubtitleLang', () => {
+      it('matches subtitle languages with normalization', () => {
+        const ctx = makeContext();
+        expect(service.evaluate('hasSubtitleLang("eng")', ctx)).toBe(true);
+        expect(service.evaluate('hasSubtitleLang("en")', ctx)).toBe(true);
+        expect(service.evaluate('hasSubtitleLang("English")', ctx)).toBe(true);
+        expect(service.evaluate('hasSubtitleLang("jpn")', ctx)).toBe(false);
+      });
+    });
+
+    describe('hasLang', () => {
+      it('matches audio or subtitle languages', () => {
+        const ctx = makeContext();
+        // "eng" is in both audio and subtitle
+        expect(service.evaluate('hasLang("eng")', ctx)).toBe(true);
+        // "jpn" is only in audio
+        expect(service.evaluate('hasLang("jpn")', ctx)).toBe(true);
+        // "fra" is in neither
+        expect(service.evaluate('hasLang("fra")', ctx)).toBe(false);
+      });
+
+      it('matches when only subtitles have the language', () => {
+        const ctx = makeContext({
+          audio: {
+            streams: [
+              {
+                index: 0,
+                language: 'jpn',
+                codec: 'aac',
+                channels: 2,
+                title: '',
+                default: true,
+                selected: true,
+              },
+            ],
+            languages: ['jpn'],
+          },
+        });
+        // "eng" only exists in subtitle.languages
+        expect(service.evaluate('hasLang("eng")', ctx)).toBe(true);
+      });
+    });
+
+    describe('isMultiLanguage', () => {
+      it('returns true when audio has multiple languages', () => {
+        const ctx = makeContext();
+        expect(service.evaluate('isMultiLanguage()', ctx)).toBe(true);
+      });
+
+      it('returns false when audio has one language', () => {
+        const ctx = makeContext({
+          audio: {
+            streams: [
+              {
+                index: 0,
+                language: 'eng',
+                codec: 'aac',
+                channels: 6,
+                title: 'Surround',
+                default: true,
+                selected: true,
+              },
+              {
+                index: 1,
+                language: 'eng',
+                codec: 'aac',
+                channels: 2,
+                title: 'Stereo',
+                default: false,
+                selected: false,
+              },
+            ],
+            languages: ['eng'],
+          },
+        });
+        expect(service.evaluate('isMultiLanguage()', ctx)).toBe(false);
+      });
+
+      it('returns false when audio has no languages', () => {
+        const ctx = makeContext({
+          audio: { streams: [], languages: [] },
+        });
+        expect(service.evaluate('isMultiLanguage()', ctx)).toBe(false);
+      });
+
+      it('deduplicates equivalent codes', () => {
+        // "eng" and "en" should normalize to the same code
+        const ctx = makeContext({
+          audio: {
+            streams: [],
+            languages: ['eng', 'en'],
+          },
+        });
+        expect(service.evaluate('isMultiLanguage()', ctx)).toBe(false);
+      });
+    });
+
+    describe('composability', () => {
+      it('combines custom functions with standard CEL operators', () => {
+        const ctx = makeContext();
+        expect(
+          service.evaluate('isMultiLanguage() && hasAudioLang("jpn")', ctx),
+        ).toBe(true);
+        expect(
+          service.evaluate('isMultiLanguage() && hasAudioLang("fra")', ctx),
+        ).toBe(false);
+      });
+
+      it('combines custom functions with context fields', () => {
+        const ctx = makeContext();
+        expect(
+          service.evaluate(
+            'hasAudioLang("jpn") && program.type == "movie"',
+            ctx,
+          ),
+        ).toBe(true);
+      });
+    });
+  });
+
   describe('validate', () => {
     it('returns undefined for valid expressions', () => {
       expect(service.validate('true')).toBeUndefined();

--- a/server/src/services/CelEvaluationService.ts
+++ b/server/src/services/CelEvaluationService.ts
@@ -1,11 +1,12 @@
-import { evaluate, parse } from '@marcbachmann/cel-js';
+import { Environment } from '@marcbachmann/cel-js';
 import { injectable } from 'inversify';
 import { isNativeError } from 'node:util/types';
 import { z } from 'zod';
 import { BadRequestError } from '../types/errors.ts';
-import { Maybe } from '../types/util.ts';
+import type { Maybe } from '../types/util.ts';
 import { InjectLogger } from '../util/inject.ts';
 import { Logger } from '../util/logging/LoggerFactory.ts';
+import { LanguageService } from './LanguageService.ts';
 
 export type StreamSelectionCelContext = {
   audio: {
@@ -41,9 +42,17 @@ export type StreamSelectionCelContext = {
 export class CelEvaluationService {
   @InjectLogger() declare private readonly logger: Logger;
 
+  private currentContext!: StreamSelectionCelContext;
+  private env: Environment;
+
+  constructor() {
+    this.env = this.buildEnvironment();
+  }
+
   evaluate(expression: string, context: StreamSelectionCelContext): boolean {
     try {
-      const result = evaluate(expression, context) as unknown;
+      this.currentContext = context;
+      const result = this.env.evaluate(expression, context) as unknown;
       return z.boolean().parse(result);
     } catch (err) {
       this.logger.warn(
@@ -56,7 +65,7 @@ export class CelEvaluationService {
 
   validate(expression: string): Maybe<CelEvaluationError> {
     try {
-      parse(expression);
+      this.env.parse(expression);
       return;
     } catch (err) {
       const errorMessage = isNativeError(err)
@@ -64,6 +73,57 @@ export class CelEvaluationService {
         : JSON.stringify(err);
       return new CelEvaluationError(errorMessage);
     }
+  }
+
+  private buildEnvironment(): Environment {
+    return new Environment({ unlistedVariablesAreDyn: true })
+      .registerFunction('hasAudioLang(string): bool', (lang) =>
+        this.matchLanguageInList(
+          lang as string,
+          this.currentContext.audio.languages,
+        ),
+      )
+      .registerFunction('hasSubtitleLang(string): bool', (lang) =>
+        this.matchLanguageInList(
+          lang as string,
+          this.currentContext.subtitle.languages,
+        ),
+      )
+      .registerFunction('hasLang(string): bool', (lang) => {
+        const langStr = lang as string;
+        return (
+          this.matchLanguageInList(
+            langStr,
+            this.currentContext.audio.languages,
+          ) ||
+          this.matchLanguageInList(
+            langStr,
+            this.currentContext.subtitle.languages,
+          )
+        );
+      })
+      .registerFunction('isMultiLanguage(): bool', () => {
+        const normalized = new Set<string>();
+        for (const lang of this.currentContext.audio.languages) {
+          const n = LanguageService.normalizeToAlpha3T(lang);
+          normalized.add(n ?? lang.toLowerCase());
+        }
+        return normalized.size >= 2;
+      });
+  }
+
+  private matchLanguageInList(input: string, languages: string[]): boolean {
+    const normalizedInput = LanguageService.normalizeToAlpha3T(input);
+    if (normalizedInput === undefined) {
+      // Can't normalize the input — fall back to case-insensitive exact match
+      const inputLower = input.toLowerCase();
+      return languages.some((lang) => lang.toLowerCase() === inputLower);
+    }
+
+    return languages.some((lang) => {
+      const normalizedLang = LanguageService.normalizeToAlpha3T(lang);
+      return normalizedLang === normalizedInput;
+    });
   }
 }
 

--- a/server/src/services/LanguageService.ts
+++ b/server/src/services/LanguageService.ts
@@ -36,4 +36,26 @@ export class LanguageService {
 
     return;
   }
+
+  /**
+   * Normalize any language identifier (ISO 639-1, 639-2/B, 639-2/T, or
+   * English name) to its ISO 639-2/T (Alpha-3 T) code.
+   *
+   * Returns undefined when the input cannot be resolved.
+   */
+  static normalizeToAlpha3T(input: string): string | undefined {
+    // Try as ISO code first (2-letter, 3-letter B/T)
+    const fromCode = this.getAlpha3TCode(input);
+    if (fromCode !== undefined) {
+      return fromCode;
+    }
+
+    // Try as English language name (e.g., "Japanese" → "jpn")
+    const fromName = languages.getAlpha3TCode(input, 'en');
+    if (fromName) {
+      return fromName;
+    }
+
+    return undefined;
+  }
 }


### PR DESCRIPTION
Defines custom functions which are exposed in the CEL context for use in expressions for stream selection.

* `hasAudioLang(string): bool` - takes in a various "language" code strings and returns true if the media item has an audio stream with that language. Accepts 2-char, 3-char, and full English languages as input
* `hasSubtitleLang(string): bool` same as above but for subtitles
* `hasLang(string): bool` same as above but for audio OR subtitles
* `isMultiLanguage(): bool` returns true if the item has more than 1 audio language available 