### PR TITLE
fix: improve random selection in filler picker

### DIFF
--- a/server/src/db/ProgramPlayHistoryDB.ts
+++ b/server/src/db/ProgramPlayHistoryDB.ts
@@ -1,8 +1,9 @@
 import { KEYS } from '@/types/inject.js';
 import { isNonEmptyString } from '@tunarr/shared/util';
-import { and, eq, gt } from 'drizzle-orm';
+import { and, eq, gt, gte, lt, lte } from 'drizzle-orm';
 import { inject, injectable } from 'inversify';
 import { v4 } from 'uuid';
+import { OpenDateTimeRange } from '../types/OpenDateTimeRange.ts';
 import {
   NewProgramPlayHistoryDrizzle,
   ProgramPlayHistory,
@@ -152,10 +153,23 @@ export class ProgramPlayHistoryDB {
     });
   }
 
-  async getFillerHistory(channelId: string) {
+  async getFillerHistory(
+    channelId: string,
+    range?: OpenDateTimeRange,
+    inclusive = true,
+  ) {
     return await this.drizzle.query.programPlayHistory.findMany({
       where: (fields, { isNotNull, and }) =>
-        and(eq(fields.channelUuid, channelId), isNotNull(fields.fillerListId)),
+        and(
+          eq(fields.channelUuid, channelId),
+          isNotNull(fields.fillerListId),
+          range?.from
+            ? (inclusive ? gte : gt)(fields.playedAt, range.from.toDate())
+            : undefined,
+          range?.to
+            ? (inclusive ? lte : lt)(fields.playedAt, range.to.toDate())
+            : undefined,
+        ),
       orderBy: (fields, { desc }) => desc(fields.playedAt),
     });
   }

--- a/server/src/services/scheduling/FillerPickerV2.test.ts
+++ b/server/src/services/scheduling/FillerPickerV2.test.ts
@@ -140,6 +140,7 @@ describe('FillerPickerV2', () => {
       expect(mockPlayHistoryDB.getFillerHistory).toHaveBeenCalledTimes(1);
       expect(mockPlayHistoryDB.getFillerHistory).toHaveBeenCalledWith(
         mockChannel.uuid,
+        expect.anything(),
       );
     });
 
@@ -543,18 +544,18 @@ describe('FillerPickerV2', () => {
       const filler = createFiller();
       filler.fillerContent = [program1, program2];
 
-      // random.bool returning true selects the list (phase 1), then the
-      // first eligible program from the shuffled list (phase 2).
+      // random.bool returning true selects the list (phase 1), then in
+      // phase 2 reservoir sampling replaces the pick on each iteration,
+      // so the last eligible program wins when bool always returns true.
       vi.mocked(random.bool).mockReturnValue(true);
 
       const result = await picker.pickFiller(mockChannel, [filler], 60000);
 
-      // Should pick the first program (shuffle is mocked as identity)
       expect(result.filler).not.toBeNull();
-      expect(result.filler?.uuid).toBe(program1.uuid);
+      expect(result.filler?.uuid).toBe(program2.uuid);
     });
 
-    it('normalizes time since played to max of FiveMinutesMillis', async () => {
+    it('normalizes time since played to max of cooldown * 1.2', async () => {
       const now = Date.now();
       const program1 = createProgram();
       const program2 = createProgram();
@@ -584,8 +585,8 @@ describe('FillerPickerV2', () => {
 
       await picker.pickFiller(mockChannel, [filler], 60000, now);
 
-      // Weights for programs should be similar since timeSince is capped
-      // (difference would only be from duration normalization if durations differ)
+      // Both programs are past the cooldown, so timeSince is capped at
+      // fillerRepeatCooldownMs * 1.2. Weights differ only by duration.
     });
   });
 

--- a/server/src/services/scheduling/FillerPickerV2.ts
+++ b/server/src/services/scheduling/FillerPickerV2.ts
@@ -3,12 +3,13 @@ import { inject, injectable } from 'inversify';
 import { groupBy, isEmpty, maxBy, sumBy } from 'lodash-es';
 import { ProgramPlayHistoryDB } from '../../db/ProgramPlayHistoryDB.ts';
 import { ChannelOrm } from '../../db/schema/Channel.ts';
-import { ChannelFillerShowWithContent } from '../../db/schema/derivedTypes.ts';
 import {
-  FiveMinutesMillis,
-  OneDayMillis,
-} from '../../ffmpeg/builder/constants.ts';
+  ChannelFillerShowWithContent,
+  ProgramWithRelations,
+} from '../../db/schema/derivedTypes.ts';
+import { OneDayMillis } from '../../ffmpeg/builder/constants.ts';
 import { KEYS } from '../../types/inject.ts';
+import { OpenDateTimeRange } from '../../types/OpenDateTimeRange.ts';
 import { Maybe } from '../../types/util.ts';
 import { Logger } from '../../util/logging/LoggerFactory.ts';
 import { loggingDef } from '../../util/logging/loggingDef.ts';
@@ -37,7 +38,7 @@ export class FillerPickerV2 implements IFillerPicker {
     channel: ChannelOrm,
     fillers: ChannelFillerShowWithContent[],
     maxDuration: number,
-    now = +dayjs(),
+    now: number = +dayjs(),
   ): Promise<FillerPickResult> {
     if (isEmpty(fillers)) {
       return Promise.resolve(EmptyFillerPickResult);
@@ -47,7 +48,11 @@ export class FillerPickerV2 implements IFillerPicker {
       channel.fillerRepeatCooldown ?? DefaultFillerCooldownMillis;
 
     const channelHistoryForFiller =
-      await this.programPlayHistoryDB.getFillerHistory(channel.uuid);
+      await this.programPlayHistoryDB.getFillerHistory(
+        channel.uuid,
+        OpenDateTimeRange.create(dayjs(now).subtract(2, 'days'), undefined) ??
+          undefined,
+      );
 
     const fillerPlayHistoryById = groupBy(
       channelHistoryForFiller,
@@ -163,6 +168,7 @@ export class FillerPickerV2 implements IFillerPicker {
     const fillerHistory = fillerPlayHistoryById[pickedFiller.fillerShow.uuid];
     const shuffledPrograms = random.shuffle([...pickedFiller.fillerContent]);
     let programTotalWeight = 0;
+    let pickedProgram: Maybe<ProgramWithRelations>;
 
     for (const program of shuffledPrograms) {
       if (program.duration > maxDuration) {
@@ -204,20 +210,27 @@ export class FillerPickerV2 implements IFillerPicker {
       }
 
       const normalizedSince = normalizeSince(
-        timeSincePlayed >= FiveMinutesMillis
-          ? FiveMinutesMillis
-          : timeSincePlayed,
+        // Cap input at the cooldown to treat all programs past the
+        // cooldown with equal staleness. Apply a slight factor
+        // increase to that to spread evenness a bit more among the
+        // other programs too.
+        Math.min(timeSincePlayed, fillerRepeatCooldownMs * 1.2),
       );
       const normalizedDuration = normalizeDuration(program.duration);
       const programWeight = normalizedSince + normalizedDuration;
       programTotalWeight += programWeight;
       if (this.weightedPick('program', programWeight, programTotalWeight)) {
-        return {
-          filler: program,
-          fillerListId: pickedFiller.fillerShowUuid,
-          minimumWait: 0,
-        };
+        pickedProgram = program;
       }
+      // Continue iterating — reservoir sampling requires seeing all candidates.
+    }
+
+    if (pickedProgram) {
+      return {
+        filler: pickedProgram,
+        fillerListId: pickedFiller.fillerShowUuid,
+        minimumWait: 0,
+      };
     }
 
     return {
@@ -237,11 +250,11 @@ export class FillerPickerV2 implements IFillerPicker {
 // Moving old DTV normalizer functions here. Slightly changing them to make them
 // more readable and less verbose
 function normalizeDuration(durationMs: number) {
-  let durationSeconds = durationMs / (60 * 1000);
-  if (durationSeconds >= 3.0) {
-    durationSeconds = 3.0 + Math.log(durationSeconds);
+  let durationMins = durationMs / (60 * 1000);
+  if (durationMins >= 3.0) {
+    durationMins = 3.0 + Math.log(durationMins);
   }
-  const y = 10000 * (Math.ceil(durationSeconds * 1000) + 1);
+  const y = 10000 * (Math.ceil(durationMins * 1000) + 1);
   return Math.ceil(y / 1000000) + 1;
 }
 


### PR DESCRIPTION
also includes a fix to properly implement reservior sampling for program selection after selecting a list.

The change fixes weighting for "last seen" to properly dampen weight for recently seens shows up to the filler's cooldown point, at which point all unseen shows >= 1.2 * filler list cooldown are considered equally stale. This number is scaled similarly to the duration component so both have a relatively equal contribution to the program's overall weight for random choice.