### PR TITLE
feat(server): add program_extra table and scanner hooks (Phase 0)

### DIFF
--- a/server/src/db/DBModule.ts
+++ b/server/src/db/DBModule.ts
@@ -13,10 +13,12 @@ import { BasicChannelRepository } from './channel/BasicChannelRepository.ts';
 import { ChannelConfigRepository } from './channel/ChannelConfigRepository.ts';
 import { ChannelProgramRepository } from './channel/ChannelProgramRepository.ts';
 import { LineupRepository } from './channel/LineupRepository.ts';
+import { ProgramExtraMinter } from './converters/ProgramExtraMinter.ts';
 import { ProgramGroupingMinter } from './converters/ProgramGroupingMinter.ts';
 import { ProgramDaoMinter } from './converters/ProgramMinter.ts';
 import { BasicProgramRepository } from './program/BasicProgramRepository.ts';
 import { ProgramExternalIdRepository } from './program/ProgramExternalIdRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { ProgramGroupingRepository } from './program/ProgramGroupingRepository.ts';
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.ts';
@@ -85,6 +87,10 @@ const DBModule = new ContainerModule(({ bind }) => {
   bind(KEYS.FillerListDB).to(FillerDB).inSingletonScope();
   bind(ProgramPlayHistoryDB).toSelf().inSingletonScope();
 
+  bind(KEYS.ProgramExtraRepository)
+    .to(ProgramExtraRepository)
+    .inSingletonScope();
+  bind(ProgramExtraMinter).toSelf().inSingletonScope();
   bind(ProgramGroupingMinter).toSelf().inSingletonScope();
   bind(ProgramDaoMinter).toSelf();
   bind<Factory<ProgramDaoMinter>>(KEYS.ProgramDaoMinterFactory).toFactory(

--- a/server/src/db/DBModule.ts
+++ b/server/src/db/DBModule.ts
@@ -14,10 +14,12 @@ import { ChannelConfigRepository } from './channel/ChannelConfigRepository.ts';
 import { ChannelProgramRepository } from './channel/ChannelProgramRepository.ts';
 import { ChannelReadOpsRepository } from './channel/ChannelReadOpsRepository.ts';
 import { LineupRepository } from './channel/LineupRepository.ts';
+import { ProgramExtraMinter } from './converters/ProgramExtraMinter.ts';
 import { ProgramGroupingMinter } from './converters/ProgramGroupingMinter.ts';
 import { ProgramDaoMinter } from './converters/ProgramMinter.ts';
 import { BasicProgramRepository } from './program/BasicProgramRepository.ts';
 import { ProgramExternalIdRepository } from './program/ProgramExternalIdRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { ProgramGroupingRepository } from './program/ProgramGroupingRepository.ts';
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.ts';
@@ -89,6 +91,10 @@ const DBModule = new ContainerModule(({ bind }) => {
   bind(KEYS.FillerListDB).to(FillerDB).inSingletonScope();
   bind(ProgramPlayHistoryDB).toSelf().inSingletonScope();
 
+  bind(KEYS.ProgramExtraRepository)
+    .to(ProgramExtraRepository)
+    .inSingletonScope();
+  bind(ProgramExtraMinter).toSelf().inSingletonScope();
   bind(ProgramGroupingMinter).toSelf().inSingletonScope();
   bind(ProgramDaoMinter).toSelf();
   bind<Factory<ProgramDaoMinter>>(KEYS.ProgramDaoMinterFactory).toFactory(

--- a/server/src/db/ProgramDB.test.ts
+++ b/server/src/db/ProgramDB.test.ts
@@ -22,6 +22,7 @@ import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.t
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramSearchRepository } from './program/ProgramSearchRepository.ts';
 import { ProgramStateRepository } from './program/ProgramStateRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { NewArtwork } from './schema/Artwork.ts';
 import {
   MediaSourceId,
@@ -130,6 +131,7 @@ const test = baseTest.extend<Fixture>({
       groupingUpsertRepo,
       new ProgramSearchRepository(dbAccess.db!, dbAccess.drizzle!),
       new ProgramStateRepository(dbAccess.drizzle!),
+      new ProgramExtraRepository(dbAccess.drizzle!, metadataRepo),
     );
 
     await use(programDb);

--- a/server/src/db/ProgramDB.test.ts
+++ b/server/src/db/ProgramDB.test.ts
@@ -21,6 +21,7 @@ import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.t
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramSearchRepository } from './program/ProgramSearchRepository.ts';
 import { ProgramStateRepository } from './program/ProgramStateRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { NewArtwork } from './schema/Artwork.ts';
 import {
   MediaSourceId,
@@ -128,6 +129,7 @@ const test = baseTest.extend<Fixture>({
       groupingUpsertRepo,
       new ProgramSearchRepository(dbAccess.db!, dbAccess.drizzle!),
       new ProgramStateRepository(dbAccess.drizzle!),
+      new ProgramExtraRepository(dbAccess.drizzle!, metadataRepo),
     );
 
     await use(programDb);

--- a/server/src/db/ProgramDB.ts
+++ b/server/src/db/ProgramDB.ts
@@ -20,6 +20,7 @@ import type { ProgramExternalIdType } from './custom_types/ProgramExternalIdType
 import type { PageParams } from './interfaces/IChannelDB.js';
 import { BasicProgramRepository } from './program/BasicProgramRepository.ts';
 import { ProgramExternalIdRepository } from './program/ProgramExternalIdRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { ProgramGroupingRepository } from './program/ProgramGroupingRepository.ts';
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.ts';
@@ -45,6 +46,7 @@ import type {
 } from './schema/base.js';
 import type {
   MusicAlbumOrm,
+  NewProgramExtraWithRelations,
   NewProgramGroupingWithRelations,
   NewProgramWithRelations,
   ProgramGroupingOrmWithRelations,
@@ -73,6 +75,8 @@ export class ProgramDB implements IProgramDB {
     private readonly searchRepo: ProgramSearchRepository,
     @inject(KEYS.ProgramStateRepository)
     private readonly stateRepo: ProgramStateRepository,
+    @inject(KEYS.ProgramExtraRepository)
+    private readonly extraRepo: ProgramExtraRepository,
   ) {}
 
   getProgramById(
@@ -381,5 +385,9 @@ export class ProgramDB implements IProgramDB {
 
   emptyTrashPrograms(): Promise<void> {
     return this.stateRepo.emptyTrashPrograms();
+  }
+
+  upsertProgramExtras(extras: NewProgramExtraWithRelations[]) {
+    return this.extraRepo.upsertProgramExtras(extras);
   }
 }

--- a/server/src/db/ProgramDB.ts
+++ b/server/src/db/ProgramDB.ts
@@ -20,6 +20,7 @@ import type { ProgramExternalIdType } from './custom_types/ProgramExternalIdType
 import type { PageParams } from './interfaces/IChannelDB.js';
 import { BasicProgramRepository } from './program/BasicProgramRepository.ts';
 import { ProgramExternalIdRepository } from './program/ProgramExternalIdRepository.ts';
+import { ProgramExtraRepository } from './program/ProgramExtraRepository.ts';
 import { ProgramGroupingRepository } from './program/ProgramGroupingRepository.ts';
 import { ProgramGroupingUpsertRepository } from './program/ProgramGroupingUpsertRepository.ts';
 import { ProgramMetadataRepository } from './program/ProgramMetadataRepository.ts';
@@ -45,6 +46,7 @@ import type {
 } from './schema/base.js';
 import type {
   MusicAlbumOrm,
+  NewProgramExtraWithRelations,
   NewProgramGroupingWithRelations,
   NewProgramWithRelations,
   ProgramGroupingOrmWithRelations,
@@ -73,6 +75,8 @@ export class ProgramDB implements IProgramDB {
     private readonly searchRepo: ProgramSearchRepository,
     @inject(KEYS.ProgramStateRepository)
     private readonly stateRepo: ProgramStateRepository,
+    @inject(KEYS.ProgramExtraRepository)
+    private readonly extraRepo: ProgramExtraRepository,
   ) {}
 
   getProgramById(
@@ -377,5 +381,9 @@ export class ProgramDB implements IProgramDB {
 
   emptyTrashPrograms(): Promise<void> {
     return this.stateRepo.emptyTrashPrograms();
+  }
+
+  upsertProgramExtras(extras: NewProgramExtraWithRelations[]) {
+    return this.extraRepo.upsertProgramExtras(extras);
   }
 }

--- a/server/src/db/converters/ProgramExtraMinter.ts
+++ b/server/src/db/converters/ProgramExtraMinter.ts
@@ -8,6 +8,7 @@ import type { MediaSourceOrm } from '../schema/MediaSource.ts';
 import type { MediaSourceLibrary } from '../schema/MediaSourceLibrary.ts';
 import type { NewProgramExtra } from '../schema/ProgramExtra.ts';
 import type { NewProgramExtraWithRelations } from '../schema/derivedTypes.ts';
+import { MarkRequired } from 'ts-essentials';
 
 @injectable()
 export class ProgramExtraMinter {
@@ -40,14 +41,18 @@ export class ProgramExtraMinter {
       updatedAt: new Date(now),
     };
 
+    const mintedArtwork = extra.artwork.filter((art) =>
+      art.path !== undefined,
+    ) as MarkRequired<MediaArtwork, 'path'>[];
+
     return {
       extra: newExtra,
-      artwork: extra.artwork.map((art) => this.mintArtwork(art, uuid, now)),
+      artwork: mintedArtwork.map((art) => this.mintArtwork(art, uuid, now)),
     };
   }
 
   private mintArtwork(
-    artwork: MediaArtwork,
+    artwork: MarkRequired<MediaArtwork, 'path'>,
     programExtraId: string,
     now: number,
   ): NewArtwork {

--- a/server/src/db/converters/ProgramExtraMinter.ts
+++ b/server/src/db/converters/ProgramExtraMinter.ts
@@ -1,0 +1,63 @@
+import type { MediaArtwork } from '@tunarr/types';
+import dayjs from 'dayjs';
+import { injectable } from 'inversify';
+import { v4 } from 'uuid';
+import type { MediaSourceExtra } from '../../types/Media.ts';
+import type { NewArtwork } from '../schema/Artwork.ts';
+import type { MediaSourceOrm } from '../schema/MediaSource.ts';
+import type { MediaSourceLibrary } from '../schema/MediaSourceLibrary.ts';
+import type { NewProgramExtra } from '../schema/ProgramExtra.ts';
+import type { NewProgramExtraWithRelations } from '../schema/derivedTypes.ts';
+
+@injectable()
+export class ProgramExtraMinter {
+  mintExtra(
+    mediaSource: MediaSourceOrm,
+    library: MediaSourceLibrary,
+    extra: MediaSourceExtra,
+    parentProgramUuid: string | null,
+    parentGroupingUuid: string | null,
+    now: number = +dayjs(),
+  ): NewProgramExtraWithRelations {
+    const uuid = v4();
+
+    const newExtra: NewProgramExtra = {
+      uuid,
+      parentProgramUuid,
+      parentGroupingUuid,
+      extraType: extra.extraType,
+      title: extra.title,
+      summary: extra.summary ?? null,
+      duration: extra.duration,
+      externalKey: extra.externalId,
+      sourceType: extra.sourceType,
+      mediaSourceId: mediaSource.uuid,
+      libraryId: library.uuid,
+      filePath: extra.filePath ?? null,
+      canonicalId: extra.canonicalId ?? null,
+      state: 'ok',
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    };
+
+    return {
+      extra: newExtra,
+      artwork: extra.artwork.map((art) => this.mintArtwork(art, uuid, now)),
+    };
+  }
+
+  private mintArtwork(
+    artwork: MediaArtwork,
+    programExtraId: string,
+    now: number,
+  ): NewArtwork {
+    return {
+      uuid: v4(),
+      programExtraId,
+      artworkType: artwork.type,
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+      sourcePath: artwork.path!,
+    };
+  }
+}

--- a/server/src/db/interfaces/IProgramDB.ts
+++ b/server/src/db/interfaces/IProgramDB.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/db/schema/base.js';
 import type {
   MusicAlbumOrm,
+  NewProgramExtraWithRelations,
   NewProgramGroupingWithRelations,
   NewProgramVersion,
   NewProgramWithRelations,
@@ -238,6 +239,8 @@ export interface IProgramDB {
     groupingId: string,
     genres: NewGenre[],
   ): Promise<void>;
+
+  upsertProgramExtras(extras: NewProgramExtraWithRelations[]);
 }
 
 export type WithChannelIdFilter<T> = T & {

--- a/server/src/db/interfaces/IProgramDB.ts
+++ b/server/src/db/interfaces/IProgramDB.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/db/schema/base.js';
 import type {
   MusicAlbumOrm,
+  NewProgramExtraWithRelations,
   NewProgramGroupingWithRelations,
   NewProgramVersion,
   NewProgramWithRelations,
@@ -240,6 +241,8 @@ export interface IProgramDB {
     groupingId: string,
     genres: NewGenre[],
   ): Promise<void>;
+
+  upsertProgramExtras(extras: NewProgramExtraWithRelations[]);
 }
 
 export type WithChannelIdFilter<T> = T & {

--- a/server/src/db/program/ProgramExtraRepository.ts
+++ b/server/src/db/program/ProgramExtraRepository.ts
@@ -1,0 +1,67 @@
+import { KEYS } from '@/types/inject.js';
+import { sql } from 'drizzle-orm';
+import { inject, injectable } from 'inversify';
+import { chunk } from 'lodash-es';
+import type { NewArtwork } from '../schema/Artwork.ts';
+import { ProgramExtra } from '../schema/ProgramExtra.ts';
+import type { NewProgramExtraWithRelations } from '../schema/derivedTypes.ts';
+import type { DrizzleDBAccess } from '../schema/index.ts';
+import { ProgramMetadataRepository } from './ProgramMetadataRepository.ts';
+import { isNonEmptyString } from '@/util/index.js';
+
+@injectable()
+export class ProgramExtraRepository {
+  constructor(
+    @inject(KEYS.DrizzleDB) private drizzleDB: DrizzleDBAccess,
+    @inject(KEYS.ProgramMetadataRepository)
+    private metadataRepo: ProgramMetadataRepository,
+  ) {}
+
+  upsertProgramExtras(
+    extras: NewProgramExtraWithRelations[],
+  ) {
+    if (extras.length === 0) {
+      return;
+    }
+
+    const allArtwork: NewArtwork[] = [];
+
+    for (const batch of chunk(extras, 100)) {
+      const upserted = this.drizzleDB
+        .insert(ProgramExtra)
+        .values(batch.map(({ extra }) => extra))
+        .onConflictDoUpdate({
+          target: [
+            ProgramExtra.sourceType,
+            ProgramExtra.mediaSourceId,
+            ProgramExtra.externalKey,
+          ],
+          set: {
+            extraType: sql`excluded.extra_type`,
+            title: sql`excluded.title`,
+            summary: sql`excluded.summary`,
+            duration: sql`excluded.duration`,
+            filePath: sql`excluded.file_path`,
+            canonicalId: sql`excluded.canonical_id`,
+            state: sql`excluded.state`,
+            updatedAt: sql`excluded.updated_at`,
+          },
+        })
+        .returning({ uuid: ProgramExtra.uuid })
+        .all();
+
+      for (let i = 0; i < batch.length; i++) {
+        const persistedUuid = upserted[i]?.uuid;
+        if (isNonEmptyString(persistedUuid)) {
+          const artwork = batch[i]!.artwork.map((art) => ({
+            ...art,
+            programExtraId: persistedUuid,
+          }));
+          allArtwork.push(...artwork);
+        }
+      }
+    }
+
+    this.metadataRepo.upsertArtwork(allArtwork);
+  }
+}

--- a/server/src/db/program/ProgramMetadataRepository.ts
+++ b/server/src/db/program/ProgramMetadataRepository.ts
@@ -47,6 +47,10 @@ export class ProgramMetadataRepository {
       artwork.filter((art) => isNonEmptyString(art.creditId)),
       (art) => art.creditId,
     );
+    const extraArt = groupBy(
+      artwork.filter((art) => isNonEmptyString(art.programExtraId)),
+      (art) => art.programExtraId,
+    );
 
     return this.drizzleDB.transaction((tx) => {
       for (const batch of chunk(keys(programArt), 50)) {
@@ -57,6 +61,9 @@ export class ProgramMetadataRepository {
       }
       for (const batch of chunk(keys(creditArt), 50)) {
         tx.delete(Artwork).where(inArray(Artwork.creditId, batch)).run();
+      }
+      for (const batch of chunk(keys(extraArt), 50)) {
+        tx.delete(Artwork).where(inArray(Artwork.programExtraId, batch)).run();
       }
       const inserted: Artwork[] = [];
       for (const batch of chunk(artwork, 50)) {

--- a/server/src/db/schema/Artwork.ts
+++ b/server/src/db/schema/Artwork.ts
@@ -7,6 +7,7 @@ import {
 import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { Credit } from './Credit.ts';
 import { Program } from './Program.ts';
+import { ProgramExtra } from './ProgramExtra.ts';
 import { ProgramGrouping } from './ProgramGrouping.ts';
 
 export const ArtworkTypes = [
@@ -49,6 +50,9 @@ export const Artwork = sqliteTable(
       onDelete: 'cascade',
     }),
     creditId: text().references(() => Credit.uuid, { onDelete: 'cascade' }),
+    programExtraId: text().references(() => ProgramExtra.uuid, {
+      onDelete: 'cascade',
+    }),
     createdAt: integer({ mode: 'timestamp_ms' }),
     updatedAt: integer({ mode: 'timestamp_ms' }),
   },
@@ -56,6 +60,7 @@ export const Artwork = sqliteTable(
     index('artwork_program_idx').on(table.programId),
     index('artwork_grouping_idx').on(table.groupingId),
     index('artwork_credit_idx').on(table.creditId),
+    index('artwork_program_extra_idx').on(table.programExtraId),
   ],
 );
 
@@ -71,6 +76,10 @@ export const ArtworkRelations = relations(Artwork, ({ one }) => ({
   credit: one(Credit, {
     fields: [Artwork.creditId],
     references: [Credit.uuid],
+  }),
+  programExtra: one(ProgramExtra, {
+    fields: [Artwork.programExtraId],
+    references: [ProgramExtra.uuid],
   }),
 }));
 

--- a/server/src/db/schema/ProgramExtra.ts
+++ b/server/src/db/schema/ProgramExtra.ts
@@ -1,0 +1,95 @@
+import {
+  relations,
+  sql,
+  type InferInsertModel,
+  type InferSelectModel,
+} from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
+import { Artwork } from './Artwork.ts';
+import { MediaSource } from './MediaSource.ts';
+import { MediaSourceLibrary } from './MediaSourceLibrary.ts';
+import { Program } from './Program.ts';
+import { ProgramGrouping } from './ProgramGrouping.ts';
+import { RemoteSourceTypes } from './base.ts';
+
+export const ExtraTypes = [
+  'clip',
+  'trailer',
+  'behind_the_scenes',
+  'deleted_scene',
+  'interview',
+  'scene',
+  'sample',
+  'featurette',
+  'short',
+  'theme_song',
+  'theme_video',
+] as const;
+
+export type ExtraType = (typeof ExtraTypes)[number];
+
+export const ProgramExtra = sqliteTable(
+  'program_extra',
+  {
+    uuid: text().primaryKey(),
+    parentProgramUuid: text().references(() => Program.uuid, {
+      onDelete: 'cascade',
+    }),
+    parentGroupingUuid: text().references(() => ProgramGrouping.uuid, {
+      onDelete: 'cascade',
+    }),
+    extraType: text({ enum: ExtraTypes }).notNull(),
+    title: text().notNull(),
+    summary: text(),
+    duration: integer().notNull(),
+    externalKey: text().notNull(),
+    sourceType: text({ enum: RemoteSourceTypes }).notNull(),
+    mediaSourceId: text()
+      .notNull()
+      .references(() => MediaSource.uuid, { onDelete: 'cascade' }),
+    libraryId: text().references(() => MediaSourceLibrary.uuid, {
+      onDelete: 'cascade',
+    }),
+    filePath: text(),
+    canonicalId: text(),
+    state: text({ enum: ['ok', 'missing'] }).notNull().default('ok'),
+    createdAt: integer({ mode: 'timestamp_ms' }),
+    updatedAt: integer({ mode: 'timestamp_ms' }),
+  },
+  (table) => [
+    uniqueIndex('unique_program_extra').on(
+      table.sourceType,
+      table.mediaSourceId,
+      table.externalKey,
+    ),
+    index('program_extra_program_idx').on(table.parentProgramUuid, table.extraType),
+    index('program_extra_grouping_idx').on(table.parentGroupingUuid, table.extraType),
+    check(
+      'one_parent_required',
+      sql`(${table.parentProgramUuid} IS NOT NULL AND ${table.parentGroupingUuid} IS NULL)
+          OR (${table.parentProgramUuid} IS NULL AND ${table.parentGroupingUuid} IS NOT NULL)`,
+    ),
+  ],
+);
+
+export const ProgramExtraRelations = relations(ProgramExtra, ({ one, many }) => ({
+  parentProgram: one(Program, {
+    fields: [ProgramExtra.parentProgramUuid],
+    references: [Program.uuid],
+  }),
+  parentGrouping: one(ProgramGrouping, {
+    fields: [ProgramExtra.parentGroupingUuid],
+    references: [ProgramGrouping.uuid],
+  }),
+  artwork: many(Artwork),
+}));
+
+export type ProgramExtraOrm = InferSelectModel<typeof ProgramExtra>;
+export type NewProgramExtra = InferInsertModel<typeof ProgramExtra>;

--- a/server/src/db/schema/derivedTypes.ts
+++ b/server/src/db/schema/derivedTypes.ts
@@ -5,6 +5,7 @@ import type {
 import type { MarkNonNullable, Nullable } from '@/types/util.js';
 import type { DeepNullable, MarkRequired, StrictOmit } from 'ts-essentials';
 import type { Artwork, NewArtwork } from './Artwork.ts';
+import type { NewProgramExtra } from './ProgramExtra.ts';
 import type { MediaSourceType } from './base.ts';
 import type { Channel, ChannelOrm } from './Channel.ts';
 import type {
@@ -231,6 +232,11 @@ export type NewProgramVersion = NewProgramVersionOrm & {
 
 export type NewCreditWithArtwork = {
   credit: NewCredit;
+  artwork: NewArtwork[];
+};
+
+export type NewProgramExtraWithRelations = {
+  extra: NewProgramExtra;
   artwork: NewArtwork[];
 };
 

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -52,6 +52,10 @@ import {
   MediaSourceLibraryReplacePathRelations,
 } from './MediaSourceLibraryReplacePath.ts';
 import { Program, ProgramRelations } from './Program.ts';
+import {
+  ProgramExtra,
+  ProgramExtraRelations,
+} from './ProgramExtra.ts';
 import { ProgramChapter, ProgramChapterRelations } from './ProgramChapter.ts';
 import {
   ProgramExternalId,
@@ -143,6 +147,8 @@ export const schema = {
   programMediaFileRelations: ProgramMediaFileRelations,
   artwork: Artwork,
   artworkRelations: ArtworkRelations,
+  programExtra: ProgramExtra,
+  programExtraRelations: ProgramExtraRelations,
   programSubtitles: ProgramSubtitles,
   programSubtitlesRelations: ProgramSubtitlesRelations,
   smartCollection: SmartCollection,

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -230,6 +230,9 @@ export class DirectMigrationProvider implements MigrationProvider {
         migration1779655043: makeMigrationFromSqlFile(
           './sql/0045_lean_violations.sql',
         ),
+        migration1780154220: makeMigrationFromSqlFile(
+          './sql/0046_add-program-extras-table.sql',
+        ),
       } satisfies Record<string, TunarrDatabaseMigration>,
       wrapWithTransaction,
     );

--- a/server/src/migration/DirectMigrationProvider.ts
+++ b/server/src/migration/DirectMigrationProvider.ts
@@ -233,6 +233,9 @@ export class DirectMigrationProvider implements MigrationProvider {
         migration1782772646: makeMigrationFromSqlFile(
           './sql/0046_melted_captain_flint.sql',
         ),
+        migration1788034821: makeMigrationFromSqlFile(
+          './sql/0047_abnormal_naoko.sql',
+        ),
       } satisfies Record<string, TunarrDatabaseMigration>,
       wrapWithTransaction,
     );

--- a/server/src/migration/db/sql/0046_add-program-extras-table.sql
+++ b/server/src/migration/db/sql/0046_add-program-extras-table.sql
@@ -1,0 +1,30 @@
+CREATE TABLE `program_extra` (
+	`uuid` text PRIMARY KEY NOT NULL,
+	`parent_program_uuid` text,
+	`parent_grouping_uuid` text,
+	`extra_type` text NOT NULL,
+	`title` text NOT NULL,
+	`summary` text,
+	`duration` integer NOT NULL,
+	`external_key` text NOT NULL,
+	`source_type` text NOT NULL,
+	`media_source_id` text NOT NULL,
+	`library_id` text,
+	`file_path` text,
+	`canonical_id` text,
+	`state` text DEFAULT 'ok' NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`parent_program_uuid`) REFERENCES `program`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`parent_grouping_uuid`) REFERENCES `program_grouping`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`media_source_id`) REFERENCES `media_source`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`library_id`) REFERENCES `media_source_library`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "one_parent_required" CHECK(("program_extra"."parent_program_uuid" IS NOT NULL AND "program_extra"."parent_grouping_uuid" IS NULL)
+          OR ("program_extra"."parent_program_uuid" IS NULL AND "program_extra"."parent_grouping_uuid" IS NOT NULL))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_program_extra` ON `program_extra` (`source_type`,`media_source_id`,`external_key`);--> statement-breakpoint
+CREATE INDEX `program_extra_program_idx` ON `program_extra` (`parent_program_uuid`,`extra_type`);--> statement-breakpoint
+CREATE INDEX `program_extra_grouping_idx` ON `program_extra` (`parent_grouping_uuid`,`extra_type`);--> statement-breakpoint
+ALTER TABLE `artwork` ADD `program_extra_id` text REFERENCES program_extra(uuid);--> statement-breakpoint
+CREATE INDEX `artwork_program_extra_idx` ON `artwork` (`program_extra_id`);

--- a/server/src/migration/db/sql/0047_abnormal_naoko.sql
+++ b/server/src/migration/db/sql/0047_abnormal_naoko.sql
@@ -1,0 +1,30 @@
+CREATE TABLE `program_extra` (
+	`uuid` text PRIMARY KEY NOT NULL,
+	`parent_program_uuid` text,
+	`parent_grouping_uuid` text,
+	`extra_type` text NOT NULL,
+	`title` text NOT NULL,
+	`summary` text,
+	`duration` integer NOT NULL,
+	`external_key` text NOT NULL,
+	`source_type` text NOT NULL,
+	`media_source_id` text NOT NULL,
+	`library_id` text,
+	`file_path` text,
+	`canonical_id` text,
+	`state` text DEFAULT 'ok' NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	FOREIGN KEY (`parent_program_uuid`) REFERENCES `program`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`parent_grouping_uuid`) REFERENCES `program_grouping`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`media_source_id`) REFERENCES `media_source`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`library_id`) REFERENCES `media_source_library`(`uuid`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "one_parent_required" CHECK(("program_extra"."parent_program_uuid" IS NOT NULL AND "program_extra"."parent_grouping_uuid" IS NULL)
+          OR ("program_extra"."parent_program_uuid" IS NULL AND "program_extra"."parent_grouping_uuid" IS NOT NULL))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_program_extra` ON `program_extra` (`source_type`,`media_source_id`,`external_key`);--> statement-breakpoint
+CREATE INDEX `program_extra_program_idx` ON `program_extra` (`parent_program_uuid`,`extra_type`);--> statement-breakpoint
+CREATE INDEX `program_extra_grouping_idx` ON `program_extra` (`parent_grouping_uuid`,`extra_type`);--> statement-breakpoint
+ALTER TABLE `artwork` ADD `program_extra_id` text REFERENCES program_extra(uuid);--> statement-breakpoint
+CREATE INDEX `artwork_program_extra_idx` ON `artwork` (`program_extra_id`);

--- a/server/src/migration/db/sql/meta/0046_snapshot.json
+++ b/server/src/migration/db/sql/meta/0046_snapshot.json
@@ -1,0 +1,4409 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "19a28d17-ae39-4b3b-af96-ee502e10185a",
+  "prevId": "882cf990-bbce-46d7-91ba-c2227a3f2098",
+  "tables": {
+    "artwork": {
+      "name": "artwork",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_path": {
+          "name": "cache_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork_type": {
+          "name": "artwork_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blur_hash43": {
+          "name": "blur_hash43",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blur_hash64": {
+          "name": "blur_hash64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credit_id": {
+          "name": "credit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_extra_id": {
+          "name": "program_extra_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artwork_program_idx": {
+          "name": "artwork_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_grouping_idx": {
+          "name": "artwork_grouping_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_credit_idx": {
+          "name": "artwork_credit_idx",
+          "columns": [
+            "credit_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_program_extra_idx": {
+          "name": "artwork_program_extra_idx",
+          "columns": [
+            "program_extra_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artwork_program_id_program_uuid_fk": {
+          "name": "artwork_program_id_program_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_grouping_id_program_grouping_uuid_fk": {
+          "name": "artwork_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_credit_id_credit_uuid_fk": {
+          "name": "artwork_credit_id_credit_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "credit",
+          "columnsFrom": [
+            "credit_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_program_extra_id_program_extra_uuid_fk": {
+          "name": "artwork_program_extra_id_program_extra_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program_extra",
+          "columnsFrom": [
+            "program_extra_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_image": {
+      "name": "cached_image",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel": {
+      "name": "channel",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_filler_overlay": {
+          "name": "disable_filler_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_repeat_cooldown": {
+          "name": "filler_repeat_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_title": {
+          "name": "group_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_flex_title": {
+          "name": "guide_flex_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_minimum_duration": {
+          "name": "guide_minimum_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offline": {
+          "name": "offline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "stream_mode": {
+          "name": "stream_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hls'"
+        },
+        "transcoding": {
+          "name": "transcoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_config_id": {
+          "name": "transcode_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitles_enabled": {
+          "name": "subtitles_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_number_unique": {
+          "name": "channel_number_unique",
+          "columns": [
+            "number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "channel_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "channel",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "channel_stream_mode_check": {
+          "name": "channel_stream_mode_check",
+          "value": "\"channel\".\"stream_mode\" in ('hls', 'hls_slower', 'mpegts', 'hls_direct', 'hls_direct_v2')"
+        }
+      }
+    },
+    "channel_fallback": {
+      "name": "channel_fallback",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_fallback_channel_uuid_channel_uuid_fk": {
+          "name": "channel_fallback_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_fallback",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_fallback_program_uuid_program_uuid_fk": {
+          "name": "channel_fallback_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_fallback",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_fallback_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_fallback_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_filler_show": {
+      "name": "channel_filler_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_filler_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_filler_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_filler_show_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "channel_filler_show_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_filler_show_channel_uuid_filler_show_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "filler_show_uuid"
+          ],
+          "name": "channel_filler_show_channel_uuid_filler_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_programs": {
+      "name": "channel_programs",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_programs_channel_uuid_channel_uuid_fk": {
+          "name": "channel_programs_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_programs_program_uuid_program_uuid_fk": {
+          "name": "channel_programs_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_programs_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_programs_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credit": {
+      "name": "credit",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "credit_program_id_idx": {
+          "name": "credit_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "credit_grouping_id_idx": {
+          "name": "credit_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "credit_program_id_program_uuid_fk": {
+          "name": "credit_program_id_program_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_grouping_id_program_grouping_uuid_fk": {
+          "name": "credit_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show": {
+      "name": "custom_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_media_source_id": {
+          "name": "sync_media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_media_source_type": {
+          "name": "sync_media_source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_external_playlist_id": {
+          "name": "sync_external_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_sync_media_source_id_media_source_uuid_fk": {
+          "name": "custom_show_sync_media_source_id_media_source_uuid_fk",
+          "tableFrom": "custom_show",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "sync_media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_content": {
+      "name": "custom_show_content",
+      "columns": {
+        "content_uuid": {
+          "name": "content_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_show_uuid": {
+          "name": "custom_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_content_content_uuid_program_uuid_fk": {
+          "name": "custom_show_content_content_uuid_program_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "content_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_custom_show_uuid_custom_show_uuid_fk": {
+          "name": "custom_show_content_custom_show_uuid_custom_show_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_content_uuid_foreign": {
+          "name": "custom_show_content_content_uuid_foreign",
+          "tableFrom": "custom_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "content_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_custom_show_uuid_foreign": {
+          "name": "custom_show_content_custom_show_uuid_foreign",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_show_content_content_uuid_custom_show_uuid_index_pk": {
+          "columns": [
+            "content_uuid",
+            "custom_show_uuid",
+            "index"
+          ],
+          "name": "custom_show_content_content_uuid_custom_show_uuid_index_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collections": {
+      "name": "external_collections",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_media_source_id_external_key_idx": {
+          "name": "external_collection_media_source_id_external_key_idx",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collection_library_id_external_key_idx": {
+          "name": "external_collection_library_id_external_key_idx",
+          "columns": [
+            "library_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collections_mediaSourceId_externalKey_unique": {
+          "name": "external_collections_mediaSourceId_externalKey_unique",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "external_collections_media_source_id_media_source_uuid_fk": {
+          "name": "external_collections_media_source_id_media_source_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collections_library_id_media_source_library_uuid_fk": {
+          "name": "external_collections_library_id_media_source_library_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collection_programs": {
+      "name": "external_collection_programs",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_program_idx": {
+          "name": "external_collection_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "external_collection_programs_collection_id_external_collections_uuid_fk": {
+          "name": "external_collection_programs_collection_id_external_collections_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "external_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_program_id_program_uuid_fk": {
+          "name": "external_collection_programs_program_id_program_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_grouping_id_program_grouping_uuid_fk": {
+          "name": "external_collection_programs_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_collection_programs_collection_id_program_id_pk": {
+          "columns": [
+            "collection_id",
+            "program_id"
+          ],
+          "name": "external_collection_programs_collection_id_program_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show": {
+      "name": "filler_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "filler_show_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "filler_show",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show_content": {
+      "name": "filler_show_content",
+      "columns": {
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_content_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "filler_show_content_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filler_show_content_program_uuid_program_uuid_fk": {
+          "name": "filler_show_content_program_uuid_program_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filler_show_content_filler_show_uuid_program_uuid_pk": {
+          "columns": [
+            "filler_show_uuid",
+            "program_uuid"
+          ],
+          "name": "filler_show_content_filler_show_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre_entity": {
+      "name": "genre_entity",
+      "columns": {
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_entity_id_index": {
+          "name": "genre_entity_id_index",
+          "columns": [
+            "genre_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_program_id_index": {
+          "name": "genre_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_group_id_index": {
+          "name": "genre_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "genre_program_unique_idx": {
+          "name": "genre_program_unique_idx",
+          "columns": [
+            "genre_id",
+            "program_id"
+          ],
+          "isUnique": true
+        },
+        "genre_grouping_unique_idx": {
+          "name": "genre_grouping_unique_idx",
+          "columns": [
+            "genre_id",
+            "group_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "genre_entity_genre_id_genre_uuid_fk": {
+          "name": "genre_entity_genre_id_genre_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "genre",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_program_id_program_uuid_fk": {
+          "name": "genre_entity_program_id_program_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_group_id_program_grouping_uuid_fk": {
+          "name": "genre_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre": {
+      "name": "genre",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_name_idx": {
+          "name": "genre_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_folder": {
+      "name": "local_media_folder",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "local_media_folder_library_id_path_idx": {
+          "name": "local_media_folder_library_id_path_idx",
+          "columns": [
+            "library_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_path_idx": {
+          "name": "local_media_folder_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_canonical_id_id": {
+          "name": "local_media_folder_canonical_id_id",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "local_media_folder_library_id_media_source_library_uuid_fk": {
+          "name": "local_media_folder_library_id_media_source_library_uuid_fk",
+          "tableFrom": "local_media_folder",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_source_path": {
+      "name": "local_media_source_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_media_source_path_media_source_id_media_source_uuid_fk": {
+          "name": "local_media_source_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "local_media_source_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_source": {
+      "name": "media_source",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_identifier": {
+          "name": "client_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "send_channel_updates": {
+          "name": "send_channel_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_guide_updates": {
+          "name": "send_guide_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_play_status_updates": {
+          "name": "send_play_status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_source_type_check": {
+          "name": "media_source_type_check",
+          "value": "\"media_source\".\"type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "media_source_library": {
+      "name": "media_source_library",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_type_check": {
+          "name": "media_type_check",
+          "value": "\"media_source_library\".\"media_type\" in ('movies', 'shows', 'music_videos', 'other_videos', 'tracks')"
+        }
+      }
+    },
+    "media_source_library_replace_path": {
+      "name": "media_source_library_replace_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_path": {
+          "name": "server_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_replace_path_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_replace_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library_replace_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program": {
+      "name": "program",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_uuid": {
+          "name": "album_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode": {
+          "name": "episode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_icon": {
+          "name": "episode_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_source_path_id": {
+          "name": "local_media_source_path_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_external_key": {
+          "name": "grandparent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_air_date": {
+          "name": "original_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_external_key": {
+          "name": "parent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_file_path": {
+          "name": "plex_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_icon": {
+          "name": "season_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_uuid": {
+          "name": "season_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_title": {
+          "name": "show_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tv_show_uuid": {
+          "name": "tv_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_season_uuid_index": {
+          "name": "program_season_uuid_index",
+          "columns": [
+            "season_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_tv_show_uuid_index": {
+          "name": "program_tv_show_uuid_index",
+          "columns": [
+            "tv_show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_album_uuid_index": {
+          "name": "program_album_uuid_index",
+          "columns": [
+            "album_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_artist_uuid_index": {
+          "name": "program_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_media_source_id_index": {
+          "name": "program_media_source_id_index",
+          "columns": [
+            "media_source_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_library_id_index": {
+          "name": "program_media_library_id_index",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        },
+        "program_source_type_external_source_id_external_key_unique": {
+          "name": "program_source_type_external_source_id_external_key_unique",
+          "columns": [
+            "source_type",
+            "external_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_source_type_media_source_external_key_unique": {
+          "name": "program_source_type_media_source_external_key_unique",
+          "columns": [
+            "source_type",
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_canonical_id_index": {
+          "name": "program_canonical_id_index",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        },
+        "program_state_index": {
+          "name": "program_state_index",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_album_uuid_program_grouping_uuid_fk": {
+          "name": "program_album_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "album_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_media_source_id_media_source_uuid_fk": {
+          "name": "program_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_library_id_media_source_library_uuid_fk": {
+          "name": "program_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_local_media_source_path_id_local_media_source_path_uuid_fk": {
+          "name": "program_local_media_source_path_id_local_media_source_path_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_source_path",
+          "columnsFrom": [
+            "local_media_source_path_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_season_uuid_program_grouping_uuid_fk": {
+          "name": "program_season_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "season_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_tv_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_tv_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "tv_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "program_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "program_type_check": {
+          "name": "program_type_check",
+          "value": "\"program\".\"type\" in ('movie', 'episode', 'track', 'music_video', 'other_video')"
+        },
+        "program_source_type_check": {
+          "name": "program_source_type_check",
+          "value": "\"program\".\"source_type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "program_chapter": {
+      "name": "program_chapter",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chapter_type": {
+          "name": "chapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chapter'"
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_chapter_program_version_id_program_version_uuid_fk": {
+          "name": "program_chapter_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_chapter",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_external_id": {
+      "name": "program_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direct_file_path": {
+          "name": "direct_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_external_id_program_uuid_index": {
+          "name": "program_external_id_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_multiple_external_id": {
+          "name": "unique_program_multiple_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is not null"
+        },
+        "unique_program_single_external_id": {
+          "name": "unique_program_single_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is null"
+        },
+        "unique_program_multiple_external_id_media_source": {
+          "name": "unique_program_multiple_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is not null"
+        },
+        "unique_program_single_external_id_media_source": {
+          "name": "unique_program_single_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is null"
+        }
+      },
+      "foreignKeys": {
+        "program_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_external_id_program_uuid_program_uuid_fk": {
+          "name": "program_external_id_program_uuid_program_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type": {
+          "name": "source_type",
+          "value": "\"program_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_extra": {
+      "name": "program_extra",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_program_uuid": {
+          "name": "parent_program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_grouping_uuid": {
+          "name": "parent_grouping_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_type": {
+          "name": "extra_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_program_extra": {
+          "name": "unique_program_extra",
+          "columns": [
+            "source_type",
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_extra_program_idx": {
+          "name": "program_extra_program_idx",
+          "columns": [
+            "parent_program_uuid",
+            "extra_type"
+          ],
+          "isUnique": false
+        },
+        "program_extra_grouping_idx": {
+          "name": "program_extra_grouping_idx",
+          "columns": [
+            "parent_grouping_uuid",
+            "extra_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_extra_parent_program_uuid_program_uuid_fk": {
+          "name": "program_extra_parent_program_uuid_program_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "program",
+          "columnsFrom": [
+            "parent_program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_parent_grouping_uuid_program_grouping_uuid_fk": {
+          "name": "program_extra_parent_grouping_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "parent_grouping_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_media_source_id_media_source_uuid_fk": {
+          "name": "program_extra_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_library_id_media_source_library_uuid_fk": {
+          "name": "program_extra_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "one_parent_required": {
+          "name": "one_parent_required",
+          "value": "(\"program_extra\".\"parent_program_uuid\" IS NOT NULL AND \"program_extra\".\"parent_grouping_uuid\" IS NULL)\n          OR (\"program_extra\".\"parent_program_uuid\" IS NULL AND \"program_extra\".\"parent_grouping_uuid\" IS NOT NULL)"
+        }
+      }
+    },
+    "program_grouping": {
+      "name": "program_grouping",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_uuid": {
+          "name": "show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {
+        "program_grouping_show_uuid_index": {
+          "name": "program_grouping_show_uuid_index",
+          "columns": [
+            "show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_grouping_artist_uuid_index": {
+          "name": "program_grouping_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type_check": {
+          "name": "type_check",
+          "value": "\"program_grouping\".\"type\" in ('show', 'season', 'artist', 'album')"
+        }
+      }
+    },
+    "program_grouping_external_id": {
+      "name": "program_grouping_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_uuid": {
+          "name": "group_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_grouping_group_uuid_index": {
+          "name": "program_grouping_group_uuid_index",
+          "columns": [
+            "group_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_grouping_multiple_external_id_media_source": {
+          "name": "unique_program_grouping_multiple_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is not null`"
+        },
+        "unique_program_grouping_single_external_id_media_source": {
+          "name": "unique_program_grouping_single_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is null`"
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_external_id_group_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_external_id_group_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "program_grouping_external_id_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_external_id_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type_check": {
+          "name": "source_type_check",
+          "value": "\"program_grouping_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_media_file": {
+      "name": "program_media_file",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_media_file_program_version_idx": {
+          "name": "program_media_file_program_version_idx",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_file_folder_idx": {
+          "name": "program_media_file_folder_idx",
+          "columns": [
+            "local_media_folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_file_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_file_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_media_file_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_media_file_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_media_stream": {
+      "name": "program_media_stream",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_kind": {
+          "name": "stream_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pixel_format": {
+          "name": "pixel_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_range": {
+          "name": "color_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_transfer": {
+          "name": "color_transfer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_primaries": {
+          "name": "color_primaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bits_per_sample": {
+          "name": "bits_per_sample",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_id": {
+          "name": "index_program_version_id",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_stream_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_stream_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_stream",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_play_history": {
+      "name": "program_play_history",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_duration": {
+          "name": "played_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_list_id": {
+          "name": "filler_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_play_history_program_uuid_index": {
+          "name": "program_play_history_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_uuid_index": {
+          "name": "program_play_history_channel_uuid_index",
+          "columns": [
+            "channel_uuid",
+            "program_uuid",
+            "filler_list_id"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_played_at_index": {
+          "name": "program_play_history_played_at_index",
+          "columns": [
+            "played_at"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_played_at_index": {
+          "name": "program_play_history_channel_played_at_index",
+          "columns": [
+            "channel_uuid",
+            "played_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_play_history_program_uuid_program_uuid_fk": {
+          "name": "program_play_history_program_uuid_program_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_channel_uuid_channel_uuid_fk": {
+          "name": "program_play_history_channel_uuid_channel_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_filler_list_id_filler_show_uuid_fk": {
+          "name": "program_play_history_filler_list_id_filler_show_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_list_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_subtitles": {
+      "name": "program_subtitles",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle_type": {
+          "name": "subtitle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_index": {
+          "name": "stream_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sdh": {
+          "name": "sdh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_extracted": {
+          "name": "is_extracted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_subtitles_program_id_program_uuid_fk": {
+          "name": "program_subtitles_program_id_program_uuid_fk",
+          "tableFrom": "program_subtitles",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_version": {
+      "name": "program_version",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_aspect_ratio": {
+          "name": "sample_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_aspect_ratio": {
+          "name": "display_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_kind": {
+          "name": "scan_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_program_id": {
+          "name": "index_program_version_program_id",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_version_program_id_program_uuid_fk": {
+          "name": "program_version_program_id_program_uuid_fk",
+          "tableFrom": "program_version",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "smart_collection": {
+      "name": "smart_collection",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stream_selection_profiles": {
+      "name": "stream_selection_profiles",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio": {
+      "name": "studio",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio_entity": {
+      "name": "studio_entity",
+      "columns": {
+        "studio_id": {
+          "name": "studio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "studio_entity_id_index": {
+          "name": "studio_entity_id_index",
+          "columns": [
+            "studio_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_program_id_index": {
+          "name": "studio_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_group_id_index": {
+          "name": "studio_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "studio_entity_studio_id_studio_uuid_fk": {
+          "name": "studio_entity_studio_id_studio_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "studio",
+          "columnsFrom": [
+            "studio_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_program_id_program_uuid_fk": {
+          "name": "studio_entity_program_id_program_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_group_id_program_grouping_uuid_fk": {
+          "name": "studio_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_subtitle_preferences": {
+      "name": "channel_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_priority_index": {
+          "name": "channel_priority_index",
+          "columns": [
+            "channel_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_subtitle_preferences_channel_id_channel_uuid_fk": {
+          "name": "channel_subtitle_preferences_channel_id_channel_uuid_fk",
+          "tableFrom": "channel_subtitle_preferences",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_subtitle_preferences": {
+      "name": "custom_show_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "custom_show_id": {
+          "name": "custom_show_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_show_priority_index": {
+          "name": "custom_show_priority_index",
+          "columns": [
+            "custom_show_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk": {
+          "name": "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk",
+          "tableFrom": "custom_show_subtitle_preferences",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_unique_tag_idx": {
+          "name": "tags_unique_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_relations": {
+      "name": "tag_relations",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'media'"
+        }
+      },
+      "indexes": {
+        "tag_relations_program_id_idx": {
+          "name": "tag_relations_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "tag_relations_grouping_id_idx": {
+          "name": "tag_relations_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "tag_program_id_unique_idx": {
+          "name": "tag_program_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "program_id",
+            "source"
+          ],
+          "isUnique": true
+        },
+        "tag_grouping_id_unique_idx": {
+          "name": "tag_grouping_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "grouping_id",
+            "source"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tag_relations_tag_id_tags_uuid_fk": {
+          "name": "tag_relations_tag_id_tags_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_program_id_program_uuid_fk": {
+          "name": "tag_relations_program_id_program_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_grouping_id_program_grouping_uuid_fk": {
+          "name": "tag_relations_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcode_config": {
+      "name": "transcode_config",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_count": {
+          "name": "thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hardware_acceleration_mode": {
+          "name": "hardware_acceleration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vaapi_driver": {
+          "name": "vaapi_driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "vaapi_device": {
+          "name": "vaapi_device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_format": {
+          "name": "video_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_profile": {
+          "name": "video_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_preset": {
+          "name": "video_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_bit_depth": {
+          "name": "video_bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 8
+        },
+        "video_bit_rate": {
+          "name": "video_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_buffer_size": {
+          "name": "video_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_bit_rate": {
+          "name": "audio_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_buffer_size": {
+          "name": "audio_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_sample_rate": {
+          "name": "audio_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_volume_percent": {
+          "name": "audio_volume_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "audio_loudnorm_config": {
+          "name": "audio_loudnorm_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalize_frame_rate": {
+          "name": "normalize_frame_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deinterlace_video": {
+          "name": "deinterlace_video",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "disable_channel_overlay": {
+          "name": "disable_channel_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_screen": {
+          "name": "error_screen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pic'"
+        },
+        "error_screen_audio": {
+          "name": "error_screen_audio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'silent'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_decoder": {
+          "name": "disable_hardware_decoder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_encoding": {
+          "name": "disable_hardware_encoding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_filters": {
+          "name": "disable_hardware_filters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcode_config_hardware_accel_check": {
+          "name": "transcode_config_hardware_accel_check",
+          "value": "\"transcode_config\".\"hardware_acceleration_mode\" in ('none', 'cuda', 'vaapi', 'qsv', 'videotoolbox')"
+        },
+        "transcode_config_vaapi_driver_check": {
+          "name": "transcode_config_vaapi_driver_check",
+          "value": "\"transcode_config\".\"vaapi_driver\" in ('system', 'ihd', 'i965', 'radeonsi', 'nouveau')"
+        },
+        "transcode_config_video_format_check": {
+          "name": "transcode_config_video_format_check",
+          "value": "\"transcode_config\".\"video_format\" in ('h264', 'hevc', 'mpeg2video')"
+        },
+        "transcode_config_audio_format_check": {
+          "name": "transcode_config_audio_format_check",
+          "value": "\"transcode_config\".\"audio_format\" in ('aac', 'ac3', 'copy', 'mp3')"
+        },
+        "transcode_config_error_screen_check": {
+          "name": "transcode_config_error_screen_check",
+          "value": "\"transcode_config\".\"error_screen\" in ('static', 'pic', 'blank', 'testsrc', 'text', 'kill')"
+        },
+        "transcode_config_error_screen_audio_check": {
+          "name": "transcode_config_error_screen_audio_check",
+          "value": "\"transcode_config\".\"error_screen_audio\" in ('silent', 'sine', 'whitenoise')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/migration/db/sql/meta/0047_snapshot.json
+++ b/server/src/migration/db/sql/meta/0047_snapshot.json
@@ -1,0 +1,4409 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0106ec9d-27bd-40bc-995d-153aca79d9cb",
+  "prevId": "19a20928-115f-40b1-8eb6-ea572d5edba6",
+  "tables": {
+    "artwork": {
+      "name": "artwork",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cache_path": {
+          "name": "cache_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork_type": {
+          "name": "artwork_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blur_hash43": {
+          "name": "blur_hash43",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blur_hash64": {
+          "name": "blur_hash64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credit_id": {
+          "name": "credit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_extra_id": {
+          "name": "program_extra_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artwork_program_idx": {
+          "name": "artwork_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_grouping_idx": {
+          "name": "artwork_grouping_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_credit_idx": {
+          "name": "artwork_credit_idx",
+          "columns": [
+            "credit_id"
+          ],
+          "isUnique": false
+        },
+        "artwork_program_extra_idx": {
+          "name": "artwork_program_extra_idx",
+          "columns": [
+            "program_extra_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "artwork_program_id_program_uuid_fk": {
+          "name": "artwork_program_id_program_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_grouping_id_program_grouping_uuid_fk": {
+          "name": "artwork_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_credit_id_credit_uuid_fk": {
+          "name": "artwork_credit_id_credit_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "credit",
+          "columnsFrom": [
+            "credit_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artwork_program_extra_id_program_extra_uuid_fk": {
+          "name": "artwork_program_extra_id_program_extra_uuid_fk",
+          "tableFrom": "artwork",
+          "tableTo": "program_extra",
+          "columnsFrom": [
+            "program_extra_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_image": {
+      "name": "cached_image",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel": {
+      "name": "channel",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_filler_overlay": {
+          "name": "disable_filler_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_repeat_cooldown": {
+          "name": "filler_repeat_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_title": {
+          "name": "group_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_flex_title": {
+          "name": "guide_flex_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guide_minimum_duration": {
+          "name": "guide_minimum_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offline": {
+          "name": "offline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stealth": {
+          "name": "stealth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "stream_mode": {
+          "name": "stream_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hls'"
+        },
+        "transcoding": {
+          "name": "transcoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_config_id": {
+          "name": "transcode_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watermark": {
+          "name": "watermark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitles_enabled": {
+          "name": "subtitles_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_number_unique": {
+          "name": "channel_number_unique",
+          "columns": [
+            "number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "channel_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "channel",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "channel_stream_mode_check": {
+          "name": "channel_stream_mode_check",
+          "value": "\"channel\".\"stream_mode\" in ('hls', 'hls_slower', 'mpegts', 'hls_direct', 'hls_direct_v2')"
+        }
+      }
+    },
+    "channel_fallback": {
+      "name": "channel_fallback",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_fallback_channel_uuid_channel_uuid_fk": {
+          "name": "channel_fallback_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_fallback",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_fallback_program_uuid_program_uuid_fk": {
+          "name": "channel_fallback_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_fallback",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_fallback_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_fallback_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_filler_show": {
+      "name": "channel_filler_show",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_filler_show_channel_uuid_channel_uuid_fk": {
+          "name": "channel_filler_show_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_filler_show_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "channel_filler_show_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "channel_filler_show",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_filler_show_channel_uuid_filler_show_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "filler_show_uuid"
+          ],
+          "name": "channel_filler_show_channel_uuid_filler_show_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_programs": {
+      "name": "channel_programs",
+      "columns": {
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_programs_channel_uuid_channel_uuid_fk": {
+          "name": "channel_programs_channel_uuid_channel_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_programs_program_uuid_program_uuid_fk": {
+          "name": "channel_programs_program_uuid_program_uuid_fk",
+          "tableFrom": "channel_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_programs_channel_uuid_program_uuid_pk": {
+          "columns": [
+            "channel_uuid",
+            "program_uuid"
+          ],
+          "name": "channel_programs_channel_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credit": {
+      "name": "credit",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "credit_program_id_idx": {
+          "name": "credit_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "credit_grouping_id_idx": {
+          "name": "credit_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "credit_program_id_program_uuid_fk": {
+          "name": "credit_program_id_program_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_grouping_id_program_grouping_uuid_fk": {
+          "name": "credit_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "credit",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show": {
+      "name": "custom_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_media_source_id": {
+          "name": "sync_media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_media_source_type": {
+          "name": "sync_media_source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_external_playlist_id": {
+          "name": "sync_external_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_sync_media_source_id_media_source_uuid_fk": {
+          "name": "custom_show_sync_media_source_id_media_source_uuid_fk",
+          "tableFrom": "custom_show",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "sync_media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_content": {
+      "name": "custom_show_content",
+      "columns": {
+        "content_uuid": {
+          "name": "content_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_show_uuid": {
+          "name": "custom_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_show_content_content_uuid_program_uuid_fk": {
+          "name": "custom_show_content_content_uuid_program_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "content_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_custom_show_uuid_custom_show_uuid_fk": {
+          "name": "custom_show_content_custom_show_uuid_custom_show_uuid_fk",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_content_uuid_foreign": {
+          "name": "custom_show_content_content_uuid_foreign",
+          "tableFrom": "custom_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "content_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_show_content_custom_show_uuid_foreign": {
+          "name": "custom_show_content_custom_show_uuid_foreign",
+          "tableFrom": "custom_show_content",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_show_content_content_uuid_custom_show_uuid_index_pk": {
+          "columns": [
+            "content_uuid",
+            "custom_show_uuid",
+            "index"
+          ],
+          "name": "custom_show_content_content_uuid_custom_show_uuid_index_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collections": {
+      "name": "external_collections",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_media_source_id_external_key_idx": {
+          "name": "external_collection_media_source_id_external_key_idx",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collection_library_id_external_key_idx": {
+          "name": "external_collection_library_id_external_key_idx",
+          "columns": [
+            "library_id",
+            "external_key"
+          ],
+          "isUnique": false
+        },
+        "external_collections_mediaSourceId_externalKey_unique": {
+          "name": "external_collections_mediaSourceId_externalKey_unique",
+          "columns": [
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "external_collections_media_source_id_media_source_uuid_fk": {
+          "name": "external_collections_media_source_id_media_source_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collections_library_id_media_source_library_uuid_fk": {
+          "name": "external_collections_library_id_media_source_library_uuid_fk",
+          "tableFrom": "external_collections",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "external_collection_programs": {
+      "name": "external_collection_programs",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "external_collection_program_idx": {
+          "name": "external_collection_program_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "external_collection_programs_collection_id_external_collections_uuid_fk": {
+          "name": "external_collection_programs_collection_id_external_collections_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "external_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_program_id_program_uuid_fk": {
+          "name": "external_collection_programs_program_id_program_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_collection_programs_grouping_id_program_grouping_uuid_fk": {
+          "name": "external_collection_programs_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "external_collection_programs",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_collection_programs_collection_id_program_id_pk": {
+          "columns": [
+            "collection_id",
+            "program_id"
+          ],
+          "name": "external_collection_programs_collection_id_program_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show": {
+      "name": "filler_show",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "filler_show_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "filler_show",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "filler_show_content": {
+      "name": "filler_show_content",
+      "columns": {
+        "filler_show_uuid": {
+          "name": "filler_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "filler_show_content_filler_show_uuid_filler_show_uuid_fk": {
+          "name": "filler_show_content_filler_show_uuid_filler_show_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "filler_show_content_program_uuid_program_uuid_fk": {
+          "name": "filler_show_content_program_uuid_program_uuid_fk",
+          "tableFrom": "filler_show_content",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filler_show_content_filler_show_uuid_program_uuid_pk": {
+          "columns": [
+            "filler_show_uuid",
+            "program_uuid"
+          ],
+          "name": "filler_show_content_filler_show_uuid_program_uuid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre_entity": {
+      "name": "genre_entity",
+      "columns": {
+        "genre_id": {
+          "name": "genre_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_entity_id_index": {
+          "name": "genre_entity_id_index",
+          "columns": [
+            "genre_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_program_id_index": {
+          "name": "genre_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "genre_entity_group_id_index": {
+          "name": "genre_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "genre_program_unique_idx": {
+          "name": "genre_program_unique_idx",
+          "columns": [
+            "genre_id",
+            "program_id"
+          ],
+          "isUnique": true
+        },
+        "genre_grouping_unique_idx": {
+          "name": "genre_grouping_unique_idx",
+          "columns": [
+            "genre_id",
+            "group_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "genre_entity_genre_id_genre_uuid_fk": {
+          "name": "genre_entity_genre_id_genre_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "genre",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_program_id_program_uuid_fk": {
+          "name": "genre_entity_program_id_program_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_entity_group_id_program_grouping_uuid_fk": {
+          "name": "genre_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "genre_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genre": {
+      "name": "genre",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genre_name_idx": {
+          "name": "genre_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_folder": {
+      "name": "local_media_folder",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "local_media_folder_library_id_path_idx": {
+          "name": "local_media_folder_library_id_path_idx",
+          "columns": [
+            "library_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_path_idx": {
+          "name": "local_media_folder_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "local_media_folder_canonical_id_id": {
+          "name": "local_media_folder_canonical_id_id",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "local_media_folder_library_id_media_source_library_uuid_fk": {
+          "name": "local_media_folder_library_id_media_source_library_uuid_fk",
+          "tableFrom": "local_media_folder",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_media_source_path": {
+      "name": "local_media_source_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_media_source_path_media_source_id_media_source_uuid_fk": {
+          "name": "local_media_source_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "local_media_source_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_source": {
+      "name": "media_source",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_identifier": {
+          "name": "client_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "send_channel_updates": {
+          "name": "send_channel_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_guide_updates": {
+          "name": "send_guide_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_play_status_updates": {
+          "name": "send_play_status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_source_type_check": {
+          "name": "media_source_type_check",
+          "value": "\"media_source\".\"type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "media_source_library": {
+      "name": "media_source_library",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "media_type_check": {
+          "name": "media_type_check",
+          "value": "\"media_source_library\".\"media_type\" in ('movies', 'shows', 'music_videos', 'other_videos', 'tracks')"
+        }
+      }
+    },
+    "media_source_library_replace_path": {
+      "name": "media_source_library_replace_path",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_path": {
+          "name": "server_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_source_library_replace_path_media_source_id_media_source_uuid_fk": {
+          "name": "media_source_library_replace_path_media_source_id_media_source_uuid_fk",
+          "tableFrom": "media_source_library_replace_path",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program": {
+      "name": "program",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_uuid": {
+          "name": "album_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode": {
+          "name": "episode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_icon": {
+          "name": "episode_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_media_source_path_id": {
+          "name": "local_media_source_path_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_external_key": {
+          "name": "grandparent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_air_date": {
+          "name": "original_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_external_key": {
+          "name": "parent_external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_file_path": {
+          "name": "plex_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_icon": {
+          "name": "season_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_uuid": {
+          "name": "season_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_icon": {
+          "name": "show_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_title": {
+          "name": "show_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tv_show_uuid": {
+          "name": "tv_show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "stream_selection_profile_id": {
+          "name": "stream_selection_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_season_uuid_index": {
+          "name": "program_season_uuid_index",
+          "columns": [
+            "season_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_tv_show_uuid_index": {
+          "name": "program_tv_show_uuid_index",
+          "columns": [
+            "tv_show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_album_uuid_index": {
+          "name": "program_album_uuid_index",
+          "columns": [
+            "album_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_artist_uuid_index": {
+          "name": "program_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_media_source_id_index": {
+          "name": "program_media_source_id_index",
+          "columns": [
+            "media_source_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_library_id_index": {
+          "name": "program_media_library_id_index",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        },
+        "program_source_type_external_source_id_external_key_unique": {
+          "name": "program_source_type_external_source_id_external_key_unique",
+          "columns": [
+            "source_type",
+            "external_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_source_type_media_source_external_key_unique": {
+          "name": "program_source_type_media_source_external_key_unique",
+          "columns": [
+            "source_type",
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_canonical_id_index": {
+          "name": "program_canonical_id_index",
+          "columns": [
+            "canonical_id"
+          ],
+          "isUnique": false
+        },
+        "program_state_index": {
+          "name": "program_state_index",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_album_uuid_program_grouping_uuid_fk": {
+          "name": "program_album_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "album_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_media_source_id_media_source_uuid_fk": {
+          "name": "program_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_library_id_media_source_library_uuid_fk": {
+          "name": "program_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_local_media_source_path_id_local_media_source_path_uuid_fk": {
+          "name": "program_local_media_source_path_id_local_media_source_path_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "local_media_source_path",
+          "columnsFrom": [
+            "local_media_source_path_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_season_uuid_program_grouping_uuid_fk": {
+          "name": "program_season_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "season_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_tv_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_tv_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "tv_show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_stream_selection_profile_id_stream_selection_profiles_uuid_fk": {
+          "name": "program_stream_selection_profile_id_stream_selection_profiles_uuid_fk",
+          "tableFrom": "program",
+          "tableTo": "stream_selection_profiles",
+          "columnsFrom": [
+            "stream_selection_profile_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "program_type_check": {
+          "name": "program_type_check",
+          "value": "\"program\".\"type\" in ('movie', 'episode', 'track', 'music_video', 'other_video')"
+        },
+        "program_source_type_check": {
+          "name": "program_source_type_check",
+          "value": "\"program\".\"source_type\" in ('plex', 'jellyfin', 'emby', 'local')"
+        }
+      }
+    },
+    "program_chapter": {
+      "name": "program_chapter",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chapter_type": {
+          "name": "chapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chapter'"
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_chapter_program_version_id_program_version_uuid_fk": {
+          "name": "program_chapter_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_chapter",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_external_id": {
+      "name": "program_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direct_file_path": {
+          "name": "direct_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_external_id_program_uuid_index": {
+          "name": "program_external_id_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_multiple_external_id": {
+          "name": "unique_program_multiple_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "external_source_id"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is not null"
+        },
+        "unique_program_single_external_id": {
+          "name": "unique_program_single_external_id",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`external_source_id` is null"
+        },
+        "unique_program_multiple_external_id_media_source": {
+          "name": "unique_program_multiple_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is not null"
+        },
+        "unique_program_single_external_id_media_source": {
+          "name": "unique_program_single_external_id_media_source",
+          "columns": [
+            "program_uuid",
+            "source_type"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id` is null"
+        }
+      },
+      "foreignKeys": {
+        "program_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_external_id_program_uuid_program_uuid_fk": {
+          "name": "program_external_id_program_uuid_program_uuid_fk",
+          "tableFrom": "program_external_id",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type": {
+          "name": "source_type",
+          "value": "\"program_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_extra": {
+      "name": "program_extra",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_program_uuid": {
+          "name": "parent_program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_grouping_uuid": {
+          "name": "parent_grouping_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_type": {
+          "name": "extra_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_program_extra": {
+          "name": "unique_program_extra",
+          "columns": [
+            "source_type",
+            "media_source_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "program_extra_program_idx": {
+          "name": "program_extra_program_idx",
+          "columns": [
+            "parent_program_uuid",
+            "extra_type"
+          ],
+          "isUnique": false
+        },
+        "program_extra_grouping_idx": {
+          "name": "program_extra_grouping_idx",
+          "columns": [
+            "parent_grouping_uuid",
+            "extra_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_extra_parent_program_uuid_program_uuid_fk": {
+          "name": "program_extra_parent_program_uuid_program_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "program",
+          "columnsFrom": [
+            "parent_program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_parent_grouping_uuid_program_grouping_uuid_fk": {
+          "name": "program_extra_parent_grouping_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "parent_grouping_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_media_source_id_media_source_uuid_fk": {
+          "name": "program_extra_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_extra_library_id_media_source_library_uuid_fk": {
+          "name": "program_extra_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_extra",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "one_parent_required": {
+          "name": "one_parent_required",
+          "value": "(\"program_extra\".\"parent_program_uuid\" IS NOT NULL AND \"program_extra\".\"parent_grouping_uuid\" IS NULL)\n          OR (\"program_extra\".\"parent_program_uuid\" IS NULL AND \"program_extra\".\"parent_grouping_uuid\" IS NOT NULL)"
+        }
+      }
+    },
+    "program_grouping": {
+      "name": "program_grouping",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_id": {
+          "name": "canonical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plot": {
+          "name": "plot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist_uuid": {
+          "name": "artist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_uuid": {
+          "name": "show_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        }
+      },
+      "indexes": {
+        "program_grouping_show_uuid_index": {
+          "name": "program_grouping_show_uuid_index",
+          "columns": [
+            "show_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_grouping_artist_uuid_index": {
+          "name": "program_grouping_artist_uuid_index",
+          "columns": [
+            "artist_uuid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_artist_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_artist_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "artist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_show_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_show_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "show_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type_check": {
+          "name": "type_check",
+          "value": "\"program_grouping\".\"type\" in ('show', 'season', 'artist', 'album')"
+        }
+      }
+    },
+    "program_grouping_external_id": {
+      "name": "program_grouping_external_id",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_file_path": {
+          "name": "external_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source_id": {
+          "name": "external_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_uuid": {
+          "name": "group_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_grouping_group_uuid_index": {
+          "name": "program_grouping_group_uuid_index",
+          "columns": [
+            "group_uuid"
+          ],
+          "isUnique": false
+        },
+        "unique_program_grouping_multiple_external_id_media_source": {
+          "name": "unique_program_grouping_multiple_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is not null`"
+        },
+        "unique_program_grouping_single_external_id_media_source": {
+          "name": "unique_program_grouping_single_external_id_media_source",
+          "columns": [
+            "group_uuid",
+            "source_type",
+            "media_source_id"
+          ],
+          "isUnique": true,
+          "where": "`media_source_id is null`"
+        }
+      },
+      "foreignKeys": {
+        "program_grouping_external_id_media_source_id_media_source_uuid_fk": {
+          "name": "program_grouping_external_id_media_source_id_media_source_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source",
+          "columnsFrom": [
+            "media_source_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_grouping_external_id_group_uuid_program_grouping_uuid_fk": {
+          "name": "program_grouping_external_id_group_uuid_program_grouping_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "program_grouping_external_id_library_id_media_source_library_uuid_fk": {
+          "name": "program_grouping_external_id_library_id_media_source_library_uuid_fk",
+          "tableFrom": "program_grouping_external_id",
+          "tableTo": "media_source_library",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_type_check": {
+          "name": "source_type_check",
+          "value": "\"program_grouping_external_id\".\"source_type\" in ('plex', 'plex-guid', 'tmdb', 'imdb', 'tvdb', 'jellyfin', 'emby')"
+        }
+      }
+    },
+    "program_media_file": {
+      "name": "program_media_file",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_media_folder_id": {
+          "name": "local_media_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_media_file_program_version_idx": {
+          "name": "program_media_file_program_version_idx",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        },
+        "program_media_file_folder_idx": {
+          "name": "program_media_file_folder_idx",
+          "columns": [
+            "local_media_folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_file_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_file_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_media_file_local_media_folder_id_local_media_folder_uuid_fk": {
+          "name": "program_media_file_local_media_folder_id_local_media_folder_uuid_fk",
+          "tableFrom": "program_media_file",
+          "tableTo": "local_media_folder",
+          "columnsFrom": [
+            "local_media_folder_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_media_stream": {
+      "name": "program_media_stream",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_kind": {
+          "name": "stream_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pixel_format": {
+          "name": "pixel_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_range": {
+          "name": "color_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_space": {
+          "name": "color_space",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_transfer": {
+          "name": "color_transfer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_primaries": {
+          "name": "color_primaries",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bits_per_sample": {
+          "name": "bits_per_sample",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_version_id": {
+          "name": "program_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_id": {
+          "name": "index_program_version_id",
+          "columns": [
+            "program_version_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_media_stream_program_version_id_program_version_uuid_fk": {
+          "name": "program_media_stream_program_version_id_program_version_uuid_fk",
+          "tableFrom": "program_media_stream",
+          "tableTo": "program_version",
+          "columnsFrom": [
+            "program_version_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_play_history": {
+      "name": "program_play_history",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_uuid": {
+          "name": "program_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_uuid": {
+          "name": "channel_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_duration": {
+          "name": "played_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filler_list_id": {
+          "name": "filler_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "program_play_history_program_uuid_index": {
+          "name": "program_play_history_program_uuid_index",
+          "columns": [
+            "program_uuid"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_uuid_index": {
+          "name": "program_play_history_channel_uuid_index",
+          "columns": [
+            "channel_uuid",
+            "program_uuid",
+            "filler_list_id"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_played_at_index": {
+          "name": "program_play_history_played_at_index",
+          "columns": [
+            "played_at"
+          ],
+          "isUnique": false
+        },
+        "program_play_history_channel_played_at_index": {
+          "name": "program_play_history_channel_played_at_index",
+          "columns": [
+            "channel_uuid",
+            "played_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_play_history_program_uuid_program_uuid_fk": {
+          "name": "program_play_history_program_uuid_program_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_channel_uuid_channel_uuid_fk": {
+          "name": "program_play_history_channel_uuid_channel_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "program_play_history_filler_list_id_filler_show_uuid_fk": {
+          "name": "program_play_history_filler_list_id_filler_show_uuid_fk",
+          "tableFrom": "program_play_history",
+          "tableTo": "filler_show",
+          "columnsFrom": [
+            "filler_list_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_subtitles": {
+      "name": "program_subtitles",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle_type": {
+          "name": "subtitle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_index": {
+          "name": "stream_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codec": {
+          "name": "codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default": {
+          "name": "default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sdh": {
+          "name": "sdh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_extracted": {
+          "name": "is_extracted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "program_subtitles_program_id_program_uuid_fk": {
+          "name": "program_subtitles_program_id_program_uuid_fk",
+          "tableFrom": "program_subtitles",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "program_version": {
+      "name": "program_version",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_aspect_ratio": {
+          "name": "sample_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_aspect_ratio": {
+          "name": "display_aspect_ratio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_kind": {
+          "name": "scan_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "index_program_version_program_id": {
+          "name": "index_program_version_program_id",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "program_version_program_id_program_uuid_fk": {
+          "name": "program_version_program_id_program_uuid_fk",
+          "tableFrom": "program_version",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "smart_collection": {
+      "name": "smart_collection",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stream_selection_profiles": {
+      "name": "stream_selection_profiles",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio": {
+      "name": "studio",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio_entity": {
+      "name": "studio_entity",
+      "columns": {
+        "studio_id": {
+          "name": "studio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "studio_entity_id_index": {
+          "name": "studio_entity_id_index",
+          "columns": [
+            "studio_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_program_id_index": {
+          "name": "studio_entity_program_id_index",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "studio_entity_group_id_index": {
+          "name": "studio_entity_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "studio_entity_studio_id_studio_uuid_fk": {
+          "name": "studio_entity_studio_id_studio_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "studio",
+          "columnsFrom": [
+            "studio_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_program_id_program_uuid_fk": {
+          "name": "studio_entity_program_id_program_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "studio_entity_group_id_program_grouping_uuid_fk": {
+          "name": "studio_entity_group_id_program_grouping_uuid_fk",
+          "tableFrom": "studio_entity",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_subtitle_preferences": {
+      "name": "channel_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_priority_index": {
+          "name": "channel_priority_index",
+          "columns": [
+            "channel_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_subtitle_preferences_channel_id_channel_uuid_fk": {
+          "name": "channel_subtitle_preferences_channel_id_channel_uuid_fk",
+          "tableFrom": "channel_subtitle_preferences",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_show_subtitle_preferences": {
+      "name": "custom_show_subtitle_preferences",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "allow_image_based": {
+          "name": "allow_image_based",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external": {
+          "name": "allow_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'any'"
+        },
+        "custom_show_id": {
+          "name": "custom_show_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_show_priority_index": {
+          "name": "custom_show_priority_index",
+          "columns": [
+            "custom_show_id",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk": {
+          "name": "custom_show_subtitle_preferences_custom_show_id_custom_show_uuid_fk",
+          "tableFrom": "custom_show_subtitle_preferences",
+          "tableTo": "custom_show",
+          "columnsFrom": [
+            "custom_show_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_unique_tag_idx": {
+          "name": "tags_unique_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_relations": {
+      "name": "tag_relations",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grouping_id": {
+          "name": "grouping_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'media'"
+        }
+      },
+      "indexes": {
+        "tag_relations_program_id_idx": {
+          "name": "tag_relations_program_id_idx",
+          "columns": [
+            "program_id"
+          ],
+          "isUnique": false
+        },
+        "tag_relations_grouping_id_idx": {
+          "name": "tag_relations_grouping_id_idx",
+          "columns": [
+            "grouping_id"
+          ],
+          "isUnique": false
+        },
+        "tag_program_id_unique_idx": {
+          "name": "tag_program_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "program_id",
+            "source"
+          ],
+          "isUnique": true
+        },
+        "tag_grouping_id_unique_idx": {
+          "name": "tag_grouping_id_unique_idx",
+          "columns": [
+            "tag_id",
+            "grouping_id",
+            "source"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tag_relations_tag_id_tags_uuid_fk": {
+          "name": "tag_relations_tag_id_tags_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_program_id_program_uuid_fk": {
+          "name": "tag_relations_program_id_program_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_relations_grouping_id_program_grouping_uuid_fk": {
+          "name": "tag_relations_grouping_id_program_grouping_uuid_fk",
+          "tableFrom": "tag_relations",
+          "tableTo": "program_grouping",
+          "columnsFrom": [
+            "grouping_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcode_config": {
+      "name": "transcode_config",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_count": {
+          "name": "thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hardware_acceleration_mode": {
+          "name": "hardware_acceleration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vaapi_driver": {
+          "name": "vaapi_driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "vaapi_device": {
+          "name": "vaapi_device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_format": {
+          "name": "video_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_profile": {
+          "name": "video_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_preset": {
+          "name": "video_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_bit_depth": {
+          "name": "video_bit_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 8
+        },
+        "video_bit_rate": {
+          "name": "video_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_buffer_size": {
+          "name": "video_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_bit_rate": {
+          "name": "audio_bit_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_buffer_size": {
+          "name": "audio_buffer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_sample_rate": {
+          "name": "audio_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_volume_percent": {
+          "name": "audio_volume_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "audio_loudnorm_config": {
+          "name": "audio_loudnorm_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalize_frame_rate": {
+          "name": "normalize_frame_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deinterlace_video": {
+          "name": "deinterlace_video",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "disable_channel_overlay": {
+          "name": "disable_channel_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_screen": {
+          "name": "error_screen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pic'"
+        },
+        "error_screen_audio": {
+          "name": "error_screen_audio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'silent'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_decoder": {
+          "name": "disable_hardware_decoder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_encoding": {
+          "name": "disable_hardware_encoding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "disable_hardware_filters": {
+          "name": "disable_hardware_filters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcode_config_hardware_accel_check": {
+          "name": "transcode_config_hardware_accel_check",
+          "value": "\"transcode_config\".\"hardware_acceleration_mode\" in ('none', 'cuda', 'vaapi', 'qsv', 'videotoolbox')"
+        },
+        "transcode_config_vaapi_driver_check": {
+          "name": "transcode_config_vaapi_driver_check",
+          "value": "\"transcode_config\".\"vaapi_driver\" in ('system', 'ihd', 'i965', 'radeonsi', 'nouveau')"
+        },
+        "transcode_config_video_format_check": {
+          "name": "transcode_config_video_format_check",
+          "value": "\"transcode_config\".\"video_format\" in ('h264', 'hevc', 'mpeg2video')"
+        },
+        "transcode_config_audio_format_check": {
+          "name": "transcode_config_audio_format_check",
+          "value": "\"transcode_config\".\"audio_format\" in ('aac', 'ac3', 'copy', 'mp3', 'libopus', 'eac3')"
+        },
+        "transcode_config_error_screen_check": {
+          "name": "transcode_config_error_screen_check",
+          "value": "\"transcode_config\".\"error_screen\" in ('static', 'pic', 'blank', 'testsrc', 'text', 'kill')"
+        },
+        "transcode_config_error_screen_audio_check": {
+          "name": "transcode_config_error_screen_audio_check",
+          "value": "\"transcode_config\".\"error_screen_audio\" in ('silent', 'sine', 'whitenoise')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/migration/db/sql/meta/_journal.json
+++ b/server/src/migration/db/sql/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1779654984240,
       "tag": "0045_lean_violations",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1780154215017,
+      "tag": "0046_add-program-extras-table",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/migration/db/sql/meta/_journal.json
+++ b/server/src/migration/db/sql/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1782780220054,
       "tag": "0046_melted_captain_flint",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1788034821145,
+      "tag": "0047_abnormal_naoko",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/services/XmlTvWriter.test.ts
+++ b/server/src/services/XmlTvWriter.test.ts
@@ -30,6 +30,7 @@ function makeArtwork(
     programId: null,
     groupingId: null,
     creditId: null,
+    programExtraId: null,
     createdAt: null,
     updatedAt: null,
     ...overrides,

--- a/server/src/services/XmlTvWriter.test.ts
+++ b/server/src/services/XmlTvWriter.test.ts
@@ -31,6 +31,7 @@ function makeArtwork(
     programId: null,
     groupingId: null,
     creditId: null,
+    programExtraId: null,
     createdAt: null,
     updatedAt: null,
     ...overrides,

--- a/server/src/services/scanner/MediaSourceMovieLibraryScanner.ts
+++ b/server/src/services/scanner/MediaSourceMovieLibraryScanner.ts
@@ -215,6 +215,7 @@ export abstract class MediaSourceMovieLibraryScanner<
         fullMovie.externalId,
         existingMovie.uuid,
       );
+      await this.scanExtrasForMovie(context, fullMovie, existingMovie.uuid);
       return;
     }
 
@@ -262,10 +263,18 @@ export abstract class MediaSourceMovieLibraryScanner<
           libraryId: library.uuid,
         },
       ]);
+
+      await this.scanExtrasForMovie(context, fullMovie, dbMovie.uuid);
     } else {
       this.logger.warn('No upserted movie');
     }
   }
+
+  protected async scanExtrasForMovie(
+    _context: ScanContext<ApiClientTypeT>,
+    _movie: MovieT & HasMediaSourceInfo,
+    _dbMovieUuid: string,
+  ): Promise<void> {}
 
   protected abstract scanMovie(
     context: ScanContext<ApiClientTypeT>,

--- a/server/src/services/scanner/MediaSourceMovieLibraryScanner.ts
+++ b/server/src/services/scanner/MediaSourceMovieLibraryScanner.ts
@@ -217,6 +217,7 @@ export abstract class MediaSourceMovieLibraryScanner<
         fullMovie.externalId,
         existingMovie.uuid,
       );
+      await this.scanExtrasForMovie(context, fullMovie, existingMovie.uuid);
       return;
     }
 
@@ -264,10 +265,18 @@ export abstract class MediaSourceMovieLibraryScanner<
           libraryId: library.uuid,
         },
       ]);
+
+      await this.scanExtrasForMovie(context, fullMovie, dbMovie.uuid);
     } else {
       this.logger.warn('No upserted movie');
     }
   }
+
+  protected async scanExtrasForMovie(
+    _context: ScanContext<ApiClientTypeT>,
+    _movie: MovieT & HasMediaSourceInfo,
+    _dbMovieUuid: string,
+  ): Promise<void> {}
 
   protected abstract scanMovie(
     context: ScanContext<ApiClientTypeT>,

--- a/server/src/services/scanner/MediaSourceTvShowLibraryScanner.ts
+++ b/server/src/services/scanner/MediaSourceTvShowLibraryScanner.ts
@@ -185,8 +185,10 @@ export abstract class MediaSourceTvShowLibraryScanner<
 
       const scannedShow = showResult.get()!;
 
+      await this.scanExtrasForShow(context, scannedShow, scannedShow.uuid);
+
       const scanSeasonsResult = await this.scanSeasons(
-        showResult.get()!,
+        scannedShow,
         context,
       );
 
@@ -383,9 +385,17 @@ export abstract class MediaSourceTvShowLibraryScanner<
           continue;
         }
 
+        const persistedSeasonT = persistedSeason.get()!
+
+        await this.scanExtrasForSeason(
+          scanContext,
+          persistedSeasonT,
+          persistedSeasonT.uuid,
+        );
+
         const scanEpisodesResult = await this.scanEpisodes(
           show,
-          persistedSeason.get()!,
+          persistedSeasonT,
           scanContext,
         );
 
@@ -564,6 +574,10 @@ export abstract class MediaSourceTvShowLibraryScanner<
             "Skipping episode key = %s because it hasn't changed",
             externalKey,
           );
+          const existingUuid = existing[externalKey]?.uuid;
+          if (existingUuid !== undefined) {
+            await this.scanExtrasForEpisode(scanContext, fullEpisode, existingUuid);
+          }
           continue;
         }
 
@@ -605,6 +619,14 @@ export abstract class MediaSourceTvShowLibraryScanner<
               createdAt: upsertResult!.createdAt,
             },
           ]);
+
+          if (upsertResult !== undefined) {
+            await this.scanExtrasForEpisode(
+              scanContext,
+              fullEpisode,
+              upsertResult.uuid,
+            );
+          }
         } catch (e) {
           this.logger.warn(
             e,
@@ -634,6 +656,27 @@ export abstract class MediaSourceTvShowLibraryScanner<
       }
     });
   }
+
+   
+  protected async scanExtrasForShow(
+    _context: ScanContext<ApiClientTypeT>,
+    _show: ShowT,
+    _dbShowUuid: string,
+  ): Promise<void> {}
+
+   
+  protected async scanExtrasForSeason(
+    _context: ScanContext<ApiClientTypeT>,
+    _season: SeasonWithShow<SeasonT, ShowT> & HasMediaSourceAndLibraryId,
+    _dbSeasonUuid: string,
+  ): Promise<void> {}
+
+   
+  protected async scanExtrasForEpisode(
+    _context: ScanContext<ApiClientTypeT>,
+    _episode: EpisodeT,
+    _dbEpisodeUuid: string,
+  ): Promise<void> {}
 
   protected abstract getTvShowLibraryContents(
     libraryId: string, // TODO: Full library type?

--- a/server/src/types/Media.ts
+++ b/server/src/types/Media.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { MediaSourceType } from '@/db/schema/base.js';
-import type { Folder } from '@tunarr/types';
+import type { ExtraType } from '@/db/schema/ProgramExtra.js';
+import type { MediaSourceType, RemoteSourceType } from '@/db/schema/base.js';
+import type { Folder, MediaArtwork } from '@tunarr/types';
 import type {
   Episode,
   ExternalIdType,
@@ -172,6 +173,19 @@ export type MediaSourceMusicTrack<
 
 export type MediaSourceOtherVideo = OtherVideo & HasMediaSourceInfo;
 export type MediaSourceMusicVideo = MusicVideo & HasMediaSourceInfo;
+
+export type MediaSourceExtra = HasMediaSourceAndLibraryId & {
+  sourceType: RemoteSourceType;
+  externalId: string;
+  title: string;
+  summary?: string | null;
+  duration: number;
+  extraType: ExtraType;
+  parentExternalId: string;
+  artwork: MediaArtwork[];
+  filePath?: string | null;
+  canonicalId?: string | null;
+};
 
 type PlexMixin = HasMediaSourceInfo & {
   sourceType: typeof MediaSourceType.Plex;

--- a/server/src/types/inject.ts
+++ b/server/src/types/inject.ts
@@ -97,6 +97,7 @@ const KEYS = {
   ),
   ProgramSearchRepository: Symbol.for('ProgramSearchRepository'),
   ProgramStateRepository: Symbol.for('ProgramStateRepository'),
+  ProgramExtraRepository: Symbol.for('ProgramExtraRepository'),
 
   // Stream Selection
   CelEvaluationService: Symbol.for('CelEvaluationService'),


### PR DESCRIPTION
Introduce the vendor-agnostic foundation for persisting program extras from remote media sources.

- Add `program_extra` table with dual nullable parent FKs covering all four content levels (movie, episode, show, season)
- Add `ProgramExtraMinter` injectable class for minting extra + artwork DAOs from `MediaSourceExtra` input
- Add `ProgramExtraRepository` and `upsertProgramExtras()` on `IProgramDB` / `ProgramDB`
- Add `MediaSourceExtra` type to `Media.ts` using `RemoteSourceType`
- Add no-op `scanExtrasForMovie()` hook to `MediaSourceMovieLibraryScanner`, called for both unchanged and newly-upserted movies
- Add no-op `scanExtrasForShow/Season/Episode()` hooks to `MediaSourceTvShowLibraryScanner` with equivalent call-site coverage