### PR TITLE
fix(ffmpeg): loop offline-screen image so the encoder produces the full declared duration

### DIFF
--- a/server/src/ffmpeg/FfmpegStreamFactory.ts
+++ b/server/src/ffmpeg/FfmpegStreamFactory.ts
@@ -958,6 +958,7 @@ export class FfmpegStreamFactory {
         videoPreset: playbackParams.videoPreset ?? null,
         videoProfile: null, // TODO:
         deinterlace: false,
+        infiniteLoop: true,
       }),
       DefaultPipelineOptions,
     );


### PR DESCRIPTION
**Problem**:
When a flex slot falls through to the offline screen, the rendered HLS
segments are malformed: the offline ffmpeg invocation exits in ~250 ms
regardless of the requested `-t` duration, leaving each segment with one
video frame but a multi-second `EXTINF`. On strict players (Kodi via
`inputstream.adaptive` in particular) this manifests as the offline
image strobing rapidly against the last buffered frame of the previous
program.

**Cause**:
`FfmpegStreamFactory.createOfflineSession` constructs a `FrameState`
without `infiniteLoop: true`. `BasePipelineBuilder.execute` only adds
`-loop 1` to the input options when `desiredState.infiniteLoop` is
truthy (see `BasePipelineBuilder.ts:632`). Without that flag, the still
image demuxer emits one frame and ffmpeg terminates.

**Repro**:
```
ffmpeg -readrate 1 -i http://localhost:8000/images/generic-offline-screen.png \
  -f lavfi -i anullsrc -filter_complex '[1:0]aresample=async=1,apad[a]' \
  -map 0:0 -map '[a]' -t 15000ms -r 24 -fps_mode cfr \
  -c:v h264_videotoolbox -c:a aac -f hls -hls_time 4 \
  -hls_segment_filename '/tmp/buggy-%06d.ts' /tmp/buggy.m3u8
# ffmpeg exits in ~250ms.
ffprobe -count_frames -show_entries stream=nb_read_frames /tmp/buggy-000000.ts
# nb_read_frames=1 for video; mismatch with EXTINF.
```

**Fix**:
Add `infiniteLoop: true` to the `FrameState` in `createOfflineSession`.
This is consistent with how other still-image inputs (e.g. watermark)
are handled. The lineup-item path already sets it from
`lineupItem.infiniteLoop`.

**Testing**:
* Live HLS playback in Kodi 21 (Omega) on an Nvidia Shield: offline
  image now holds steady through a 19-second flex slot. Server log
  shows ffmpeg running for the full duration with `-loop 1` in the
  args.
* ffprobe on a regenerated `.ts` segment shows 96 video frames per
  4-second segment as expected (24 fps x 4s).