### PR TITLE
fix(scheduler): restore SLACK tolerance in FillerPickerV2 for short flex gaps

### DIFF
--- a/server/src/services/scheduling/FillerPickerV2.ts
+++ b/server/src/services/scheduling/FillerPickerV2.ts
@@ -23,6 +23,13 @@ import {
   type FillerPickOptions,
 } from '../interfaces/IFillerPicker.ts';
 
+// Match the legacy (pre-V2) picker's tolerance: clips up to this many
+// milliseconds longer than the remaining gap are still eligible. The
+// caller (StreamProgramCalculator) clips streamDuration to the gap so
+// the overrun is truncated at playback time, which prevents short
+// leftover gaps from falling through to the "channel offline" pad.
+const FillerDurationSlackMs = 9999;
+
 // A (near) re-implementation of the original DTV filler picker.
 @injectable()
 @loggingDef({
@@ -106,7 +113,7 @@ export class FillerPickerV2 implements IFillerPicker {
         // we'd risk picking a list and then failing to find a program.
         let hasEligibleProgram = false;
         for (const program of filler.fillerContent) {
-          if (program.duration > maxDuration) continue;
+          if (program.duration > maxDuration + FillerDurationSlackMs) continue;
           const programLastPlayed = fillerHistory?.find(
             (h) => h.programUuid === program.uuid,
           );
@@ -118,7 +125,10 @@ export class FillerPickerV2 implements IFillerPicker {
           } else {
             const timeUntilProgramCanPlay =
               fillerRepeatCooldownMs - timeSincePlayed;
-            if (program.duration + timeUntilProgramCanPlay <= maxDuration) {
+            if (
+              program.duration + timeUntilProgramCanPlay <=
+              maxDuration + FillerDurationSlackMs
+            ) {
               minimumWait = Math.min(minimumWait, timeUntilProgramCanPlay);
               this.logger.trace('New minimumWait: %d', minimumWait);
             }
@@ -154,7 +164,10 @@ export class FillerPickerV2 implements IFillerPicker {
           (min, p) => Math.min(min, p.duration),
           Number.MAX_SAFE_INTEGER,
         );
-        if (shortestProgram + timeUntilListIsCandidate <= maxDuration) {
+        if (
+          shortestProgram + timeUntilListIsCandidate <=
+          maxDuration + FillerDurationSlackMs
+        ) {
           minimumWait = Math.min(
             minimumWait,
             shortestProgram + timeUntilListIsCandidate,
@@ -181,7 +194,7 @@ export class FillerPickerV2 implements IFillerPicker {
     let pickedProgram: Nullable<ProgramOrmWithExternalIds> = null;
 
     for (const program of shuffledPrograms) {
-      if (program.duration > maxDuration) {
+      if (program.duration > maxDuration + FillerDurationSlackMs) {
         this.logger.trace(
           'Skipping program %s (%s) from filler list %s because it is too long (%d > %d)',
           program.uuid,
@@ -212,7 +225,10 @@ export class FillerPickerV2 implements IFillerPicker {
         );
         const timeUntilProgramCanPlay =
           fillerRepeatCooldownMs - timeSincePlayed;
-        if (program.duration + timeUntilProgramCanPlay <= maxDuration) {
+        if (
+          program.duration + timeUntilProgramCanPlay <=
+          maxDuration + FillerDurationSlackMs
+        ) {
           minimumWait = Math.min(minimumWait, timeUntilProgramCanPlay);
           this.logger.trace('New minimumWait: %d', minimumWait);
         }

--- a/server/src/services/scheduling/FillerPickerV2.ts
+++ b/server/src/services/scheduling/FillerPickerV2.ts
@@ -1,3 +1,4 @@
+import constants from '@tunarr/shared/constants';
 import dayjs from 'dayjs';
 import { inject, injectable } from 'inversify';
 import { groupBy, isEmpty, maxBy, sumBy } from 'lodash-es';
@@ -22,13 +23,6 @@ import {
   IFillerPicker,
   type FillerPickOptions,
 } from '../interfaces/IFillerPicker.ts';
-
-// Match the legacy (pre-V2) picker's tolerance: clips up to this many
-// milliseconds longer than the remaining gap are still eligible. The
-// caller (StreamProgramCalculator) clips streamDuration to the gap so
-// the overrun is truncated at playback time, which prevents short
-// leftover gaps from falling through to the "channel offline" pad.
-const FillerDurationSlackMs = 9999;
 
 // A (near) re-implementation of the original DTV filler picker.
 @injectable()
@@ -113,7 +107,7 @@ export class FillerPickerV2 implements IFillerPicker {
         // we'd risk picking a list and then failing to find a program.
         let hasEligibleProgram = false;
         for (const program of filler.fillerContent) {
-          if (program.duration > maxDuration + FillerDurationSlackMs) continue;
+          if (program.duration > maxDuration + constants.SLACK) continue;
           const programLastPlayed = fillerHistory?.find(
             (h) => h.programUuid === program.uuid,
           );
@@ -127,7 +121,7 @@ export class FillerPickerV2 implements IFillerPicker {
               fillerRepeatCooldownMs - timeSincePlayed;
             if (
               program.duration + timeUntilProgramCanPlay <=
-              maxDuration + FillerDurationSlackMs
+              maxDuration + constants.SLACK
             ) {
               minimumWait = Math.min(minimumWait, timeUntilProgramCanPlay);
               this.logger.trace('New minimumWait: %d', minimumWait);
@@ -166,7 +160,7 @@ export class FillerPickerV2 implements IFillerPicker {
         );
         if (
           shortestProgram + timeUntilListIsCandidate <=
-          maxDuration + FillerDurationSlackMs
+          maxDuration + constants.SLACK
         ) {
           minimumWait = Math.min(
             minimumWait,
@@ -194,7 +188,7 @@ export class FillerPickerV2 implements IFillerPicker {
     let pickedProgram: Nullable<ProgramOrmWithExternalIds> = null;
 
     for (const program of shuffledPrograms) {
-      if (program.duration > maxDuration + FillerDurationSlackMs) {
+      if (program.duration > maxDuration + constants.SLACK) {
         this.logger.trace(
           'Skipping program %s (%s) from filler list %s because it is too long (%d > %d)',
           program.uuid,
@@ -227,7 +221,7 @@ export class FillerPickerV2 implements IFillerPicker {
           fillerRepeatCooldownMs - timeSincePlayed;
         if (
           program.duration + timeUntilProgramCanPlay <=
-          maxDuration + FillerDurationSlackMs
+          maxDuration + constants.SLACK
         ) {
           minimumWait = Math.min(minimumWait, timeUntilProgramCanPlay);
           this.logger.trace('New minimumWait: %d', minimumWait);


### PR DESCRIPTION
**Background**:
While diffing `FillerPickerV2` (1.3.x) against the legacy `FillerPicker`
(1.1.x) to investigate offline-pad events on my channels, I noticed
that the V2 rewrite dropped a `SLACK` tolerance the original picker
had. My specific cases turned out to be a different root cause (list
cooldown blocking the only list with short clips), but the missing
SLACK is a real v1.1.x to v2 regression worth restoring.

**Cause**:
`FillerPickerV2` rejects any clip whose duration exceeds `maxDuration`
exactly:

```ts
if (program.duration > maxDuration) continue;
```

The original picker allowed clips up to `maxDuration + SLACK` (with
`SLACK = 9999` ms, ~10s) and the stream calculator already truncates
playback to the actual gap. That meant a 10s clip could fit a 5s gap;
under V2, it cannot, and if 10s is also the shortest clip in the
channel's library the picker has nothing to pick.

**Symptom this addresses**:
This is plausibly the cause behind the "channel offline appears
between programs" symptom that's been described on Discord by a couple
of users whose filler library might not have a selection of very short
clips. This is *not* the same as the cooldown-driven offline event some
users see when a short-clip list is on list-cooldown; that one needs a
separate look.

**Fix**:
Re-introduce the slack as a named constant `FillerDurationSlackMs` and
apply it at all the comparison sites:

* the two `program.duration > maxDuration` rejection points
* the three `minimumWait` cooldown comparisons, for consistency: a
  cooldown is only worth waiting on if the program *will* fit when it
  becomes eligible, slack inclusive

**Testing**:
* Confirmed via diff against `v1.1.18`'s `FillerPicker.ts` that this
  matches the legacy tolerance.
* My own channels (with idents down to 5s) don't actually exercise this
  path; verified that streaming still works normally with the fix in
  place. Users whose libraries lack short clips would be the ones
  helped by this change.
* `FillerPickerV2.test.ts` still passes; the change only loosens
  acceptance, no test relies on a rejection at exactly `maxDuration + 1ms`.