### PR TITLE
fix(stream): skip extracted subtitles whose sidecar file is missing on disk

### DIFF
--- a/server/src/db/ProgramDB.ts
+++ b/server/src/db/ProgramDB.ts
@@ -96,6 +96,10 @@ export class ProgramDB implements IProgramDB {
     return this.basicProg.updateProgramDuration(programId, duration);
   }
 
+  clearExtractedSubtitle(uuid: string): Promise<void> {
+    return this.metadataRepo.clearExtractedSubtitle(uuid);
+  }
+
   getProgramsByIds(
     ids: string[] | readonly string[],
     batchSize?: number,

--- a/server/src/db/interfaces/IProgramDB.ts
+++ b/server/src/db/interfaces/IProgramDB.ts
@@ -54,6 +54,8 @@ export interface IProgramDB {
 
   updateProgramDuration(programId: string, duration: number): Promise<void>;
 
+  clearExtractedSubtitle(uuid: string): Promise<void>;
+
   getProgramsByIds(
     ids: string[] | readonly string[],
     batchSize?: number,

--- a/server/src/db/program/ProgramMetadataRepository.ts
+++ b/server/src/db/program/ProgramMetadataRepository.ts
@@ -410,6 +410,13 @@ export class ProgramMetadataRepository {
     }
   }
 
+  async clearExtractedSubtitle(uuid: string): Promise<void> {
+    await this.drizzleDB
+      .update(ProgramSubtitles)
+      .set({ isExtracted: false, path: null, updatedAt: new Date() })
+      .where(eq(ProgramSubtitles.uuid, uuid));
+  }
+
   upsertCredits(credits: NewCredit[]) {
     if (credits.length === 0) {
       return;

--- a/server/src/stream/ProgramStreamDetailsFetcher.ts
+++ b/server/src/stream/ProgramStreamDetailsFetcher.ts
@@ -131,7 +131,9 @@ export class ProgramStreamDetailsFetcher {
     // Only surface extracted/sidecar subtitles that still exist on disk.
     // The DB flag can outlive the file (cache pruned, db restored on a host
     // with no cache folder, etc.). Surfacing a stale path makes ffmpeg's
-    // libass filter init fail and the whole stream stalls.
+    // libass filter init fail and the whole stream stalls. When we see the
+    // mismatch, also clear the DB flag so the next SubtitleExtractorTask
+    // run rebuilds the sidecar instead of trusting stale state forever.
     const extractedSubtitles = program.subtitles?.filter(
       (subtitle) => subtitle.isExtracted,
     );
@@ -142,10 +144,12 @@ export class ProgramStreamDetailsFetcher {
           !(await fileExists(subtitle.path))
         ) {
           this.logger.debug(
-            'Skipping extracted subtitle for program %s: file missing on disk (%s)',
+            'Clearing isExtracted flag for program %s subtitle %s: file missing on disk (%s)',
             program.uuid,
+            subtitle.uuid,
             subtitle.path ?? '<no path>',
           );
+          await this.programDB.clearExtractedSubtitle(subtitle.uuid);
           continue;
         }
         subtitleStreamDetails.push({

--- a/server/src/stream/ProgramStreamDetailsFetcher.ts
+++ b/server/src/stream/ProgramStreamDetailsFetcher.ts
@@ -128,22 +128,36 @@ export class ProgramStreamDetailsFetcher {
           }) satisfies SubtitleStreamDetails,
       ) ?? [];
 
-    subtitleStreamDetails.push(
-      ...(program.subtitles
-        ?.filter((subtitle) => subtitle.isExtracted)
-        .map(
-          (subtitle) =>
-            ({
-              ...subtitle,
-              index: nullToUndefined(subtitle.streamIndex),
-              type:
-                subtitle.subtitleType === 'embedded' ? 'embedded' : 'external',
-              languageCodeISO6392: subtitle.language,
-              sdh: subtitle.sdh,
-              path: nullToUndefined(subtitle.path),
-            }) satisfies SubtitleStreamDetails,
-        ) ?? []),
+    // Only surface extracted/sidecar subtitles that still exist on disk.
+    // The DB flag can outlive the file (cache pruned, db restored on a host
+    // with no cache folder, etc.). Surfacing a stale path makes ffmpeg's
+    // libass filter init fail and the whole stream stalls.
+    const extractedSubtitles = program.subtitles?.filter(
+      (subtitle) => subtitle.isExtracted,
     );
+    if (extractedSubtitles && extractedSubtitles.length > 0) {
+      for (const subtitle of extractedSubtitles) {
+        if (
+          !isNonEmptyString(subtitle.path) ||
+          !(await fileExists(subtitle.path))
+        ) {
+          this.logger.debug(
+            'Skipping extracted subtitle for program %s: file missing on disk (%s)',
+            program.uuid,
+            subtitle.path ?? '<no path>',
+          );
+          continue;
+        }
+        subtitleStreamDetails.push({
+          ...subtitle,
+          index: nullToUndefined(subtitle.streamIndex),
+          type: subtitle.subtitleType === 'embedded' ? 'embedded' : 'external',
+          languageCodeISO6392: subtitle.language,
+          sdh: subtitle.sdh,
+          path: subtitle.path,
+        } satisfies SubtitleStreamDetails);
+      }
+    }
 
     const streamDetails: StreamDetails = {
       audioDetails: isNonEmptyArray(audioStreamDetails)


### PR DESCRIPTION
**Problem**:
Subtitles silently break on channels that had previously-working
extracted/sidecar subs after a cache prune, db restore, or upgrade. The
stream either freezes at session start or falls back to no subtitles
with a libass init error in the logs.

**Cause**:
`ProgramStreamDetailsFetcher.getStream` pushes every program subtitle
row marked `isExtracted = true` into the stream details, trusting
`subtitle.path` without checking the file actually exists:

```ts
subtitleStreamDetails.push(
  ...(program.subtitles
    ?.filter((subtitle) => subtitle.isExtracted)
    .map((subtitle) => ({ ..., path: nullToUndefined(subtitle.path) })) ?? []),
);
```

The DB row can outlive the file: cache pruned by hand, db restored on a
different host, cache folder reset on upgrade, manual delete. When the
stale path then reaches the `subtitles=` filter, ffmpeg fails libass
init and the HLS session stalls.

**Repro**:
1. Let `SubtitleExtractorTask` populate the sidebar cache for a program.
2. Delete the file under
   `<dataDir>/cache/subtitles/...` (or `rm -rf` the whole subtitles
   cache).
3. Stream a channel containing that program with `subtitlesEnabled = 1`
   and a default subtitle pick that lands on the missing sidecar.
4. Observe: HLS hangs / ffmpeg logs `Unable to open ...`.

**Fix**:
Gate each extracted-subtitle entry on `isNonEmptyString(path)` and
`fileExists(path)` before pushing into `subtitleStreamDetails`. Skipped
entries get a `debug` log line so users debugging missing burn-ins can
see the path that wasn't found. No behavioral change for healthy caches.

**Testing**:
* With a healthy sidecar cache: subs render unchanged, no new log spam
  at default log level.
* After `rm -rf` of the subtitles cache for a known-extracted program:
  stream now starts cleanly, the channel falls back to whatever
  non-extracted subs the source provides (or none), and a debug line
  reports the missing path. Re-running `SubtitleExtractorTask` repopulates
  the cache and subs come back without code changes.