### PR TITLE
fix(stream): consolidate image-based subtitle codec list and fold case

### DIFF
--- a/server/src/ffmpeg/StreamSelectionEvaluator.ts
+++ b/server/src/ffmpeg/StreamSelectionEvaluator.ts
@@ -13,6 +13,7 @@ import type {
   AudioStreamDetails,
   SubtitleStreamDetails,
 } from '../stream/types.ts';
+import { isImageBasedSubtitle } from '../stream/util.ts';
 import { isDefined } from '../util/index.ts';
 import { LoggerFactory } from '../util/logging/LoggerFactory.ts';
 import { SubtitleStreamPicker } from './SubtitleStreamPicker.ts';
@@ -275,13 +276,3 @@ async function resolveSubtitleAction(
   }
 }
 
-function isImageBasedSubtitle(codec: string): boolean {
-  const imageCodecs = [
-    'hdmv_pgs_subtitle',
-    'pgssub',
-    'dvd_subtitle',
-    'dvdsub',
-    'dvbsub',
-  ];
-  return imageCodecs.includes(codec.toLowerCase());
-}

--- a/server/src/stream/util.ts
+++ b/server/src/stream/util.ts
@@ -6,7 +6,8 @@ export function isImageBasedSubtitle(codec: string) {
     'vobsub',
     'pgssub',
     'pgs',
-  ].includes(codec);
+    'dvbsub',
+  ].includes(codec.toLowerCase());
 }
 
 export function extractIsAnamorphic(


### PR DESCRIPTION
**Problem**:
DVB image-based subtitle tracks (codec `dvbsub`) sometimes slip into
text-subtitle code paths and trigger libass init failures or "image
sub treated as text" misbehaviour. Similarly, codec strings reported
in mixed case (e.g. `PGSSub`) are recognised by some call sites and
not others.

**Cause**:
There are two `isImageBasedSubtitle` functions covering the same
question and they disagree:

| Codec               | shared (`stream/util.ts`) | local (`StreamSelectionEvaluator.ts`) | post-PR (`stream/util.ts`) |
|---------------------|:-------------------------:|:-------------------------------------:|:--------------------------:|
| `hdmv_pgs_subtitle` | yes                       | yes                                   | yes                        |
| `pgssub`            | yes                       | yes                                   | yes                        |
| `dvd_subtitle`      | yes                       | yes                                   | yes                        |
| `dvdsub`            | yes                       | yes                                   | yes                        |
| `vobsub`            | yes                       | **no**                                | yes                        |
| `pgs`               | yes                       | **no**                                | yes                        |
| `dvbsub`            | **no**                    | yes                                   | yes                        |
| case-folded input   | no                        | yes (`.toLowerCase()`)                | yes (`.toLowerCase()`)     |

So depending on which path fired first for a given stream, a `dvbsub`
or upper-case codec could be treated either way.

**Fix**:
* Extend the shared `isImageBasedSubtitle` in `stream/util.ts` to
  include `dvbsub` and apply `.toLowerCase()` to the input. The new
  list is a **strict superset** of both prior lists.
* Delete the local shadow in `StreamSelectionEvaluator.ts` and import
  the shared one, matching every other call site
  (`FfmpegStreamFactory`, `SubtitleStreamPicker`,
  `SubtitleExtractorTask`).

Note on the diff appearance: the `-10` in `StreamSelectionEvaluator.ts`
is the deleted local function (the codec list lines plus the function
wrapper). None of those codecs are dropped from the project. They are
re-homed in `stream/util.ts` (see the `+2` there), where every call
site already imports them.

**Testing**:
* Confirmed all callers (`FfmpegStreamFactory` x 2,
  `SubtitleStreamPicker` x 4, `StreamSelectionEvaluator` x 3,
  `SubtitleExtractorTask` x 1) now resolve to the same function.
* TypeScript build passes.
* No behaviour change for sources whose codec strings were already
  lower-case and in the previously-shared list.