### PR TITLE
fix(subtitles): strip NUL bytes when writing extracted subtitle files

### DIFF
--- a/server/src/tasks/SubtitleExtractorTask.ts
+++ b/server/src/tasks/SubtitleExtractorTask.ts
@@ -320,7 +320,13 @@ export class SubtitleExtractorTask extends Task2<
 
     const copyResults = await Promise.allSettled(
       subtitlesToSave.map(async ({ outPath, tmpPath }) => {
-        return fs.cp(tmpPath, outPath);
+        // Strip stray NUL bytes that some sources (notably mov_text -> ass
+        // and certain Plex muxers) embed inside the extracted text. libass
+        // refuses to parse a file that contains a NUL, which manifests as
+        // missing burn-in subtitles with no obvious ffmpeg-level error.
+        const data = await fs.readFile(tmpPath, 'utf-8');
+        const cleaned = data.includes('\0') ? data.replace(/\0/g, '') : data;
+        await fs.writeFile(outPath, cleaned, 'utf-8');
       }),
     );
 

--- a/server/src/tasks/SubtitleExtractorTask.ts
+++ b/server/src/tasks/SubtitleExtractorTask.ts
@@ -3,8 +3,11 @@ import { ContentGuideProgram, tag } from '@tunarr/types';
 import dayjs from 'dayjs';
 import { inject, injectable } from 'inversify';
 import { isUndefined } from 'lodash-es';
+import { createReadStream, createWriteStream } from 'node:fs';
 import fs from 'node:fs/promises';
 import path, { dirname, extname } from 'node:path';
+import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { tmpName } from 'tmp-promise';
 import z from 'zod';
 import { IChannelDB } from '../db/interfaces/IChannelDB.ts';
@@ -320,13 +323,20 @@ export class SubtitleExtractorTask extends Task2<
 
     const copyResults = await Promise.allSettled(
       subtitlesToSave.map(async ({ outPath, tmpPath }) => {
-        // Strip stray NUL bytes that some sources (notably mov_text -> ass
-        // and certain Plex muxers) embed inside the extracted text. libass
-        // refuses to parse a file that contains a NUL, which manifests as
-        // missing burn-in subtitles with no obvious ffmpeg-level error.
-        const data = await fs.readFile(tmpPath, 'utf-8');
-        const cleaned = data.includes('\0') ? data.replace(/\0/g, '') : data;
-        await fs.writeFile(outPath, cleaned, 'utf-8');
+        // Stream through a Transform that drops stray NUL bytes that some
+        // sources (notably mov_text -> ass and certain Plex muxers) embed
+        // inside the extracted text. libass refuses to parse a file that
+        // contains a NUL, which manifests as missing burn-in subtitles
+        // with no obvious ffmpeg-level error.
+        await pipeline(
+          createReadStream(tmpPath),
+          new Transform({
+            transform(chunk: Buffer, _encoding, cb) {
+              cb(null, chunk.filter((byte) => byte !== 0x00));
+            },
+          }),
+          createWriteStream(outPath),
+        );
       }),
     );
 


### PR DESCRIPTION
**Problem**:
On some channels with text-based embedded subtitles, the SubtitleExtractorTask
runs and writes a sidecar file to the cache, but the resulting burn-in
shows nothing. ffmpeg doesn't fail loudly; libass just drops the
track. Re-extracting doesn't help because the broken bytes come back
the same way.

**Cause**:
ffmpeg's `mov_text -> ass` conversion (and at least one Plex muxer
path I tested with) emits stray `\0` NUL bytes inside the extracted
subtitle text. libass treats a NUL as end-of-file mid-parse and
silently discards the rest of the track. The current writer is
`fs.cp(tmpPath, outPath)` which copies the bytes verbatim, so the
broken sidecar lands in the cache and every subsequent playback hits
the same silent drop.

**Repro**:
1. Find an mp4 with embedded `mov_text` subs (common from iTunes /
   Plex-managed transcodes).
2. Add it to a Tunarr channel with `subtitlesEnabled = 1`.
3. Let `SubtitleExtractorTask` extract the sub.
4. `xxd <cache>/subtitles/.../*.ass | grep -m1 '00'` shows NUL bytes.
5. Burn-in is empty on playback.

**Fix**:
Replace the `fs.cp` step with read-as-utf8, strip any `\0` bytes,
write cleaned content to outPath. Short-circuit on the common healthy
case (`includes('\0')`) so we don't pay the regex cost on files that
don't need it.

**Testing**:
* Manually pre-built a tmp ASS with a NUL inserted, ran the writer,
  confirmed cleaned output renders correctly in libass / mpv.
* Healthy files round-trip unchanged byte-for-byte except for the
  utf-8 read/write hop (no BOM added, line endings preserved by Node's
  text mode on every platform I have to test on: macOS + Linux).
* After clearing the subtitles cache and re-running the task on the
  affected files in my library, burn-in renders on the next stream.