### PR TITLE
fix(stream): restore sidecar subtitle visibility after #1908 unified the filter

### DIFF
--- a/server/src/stream/ProgramStreamDetailsFetcher.ts
+++ b/server/src/stream/ProgramStreamDetailsFetcher.ts
@@ -1,4 +1,4 @@
-import { nullToUndefined } from '@tunarr/shared/util';
+import { nullToUndefined, seq } from '@tunarr/shared/util';
 import dayjs from 'dayjs';
 import { inject, injectable } from 'inversify';
 import {
@@ -128,21 +128,18 @@ export class ProgramStreamDetailsFetcher {
           }) satisfies SubtitleStreamDetails,
       ) ?? [];
 
-    // Only surface extracted/sidecar subtitles that still exist on disk.
-    // The DB flag can outlive the file (cache pruned, db restored on a host
-    // with no cache folder, etc.). Surfacing a stale path makes ffmpeg's
-    // libass filter init fail and the whole stream stalls. When we see the
-    // mismatch, also clear the DB flag so the next SubtitleExtractorTask
-    // run rebuilds the sidecar instead of trusting stale state forever.
-    const extractedSubtitles = program.subtitles?.filter(
-      (subtitle) => subtitle.isExtracted,
-    );
-    if (extractedSubtitles && extractedSubtitles.length > 0) {
-      for (const subtitle of extractedSubtitles) {
-        if (
-          !isNonEmptyString(subtitle.path) ||
-          !(await fileExists(subtitle.path))
-        ) {
+    const usableSubtitles = await Promise.all(
+      (program.subtitles ?? []).map(async (subtitle) => {
+        const pathOnDisk =
+          isNonEmptyString(subtitle.path) &&
+          (await fileExists(subtitle.path));
+        if (subtitle.subtitleType === 'sidecar') {
+          return pathOnDisk ? subtitle : null;
+        }
+        if (!subtitle.isExtracted) {
+          return null;
+        }
+        if (!pathOnDisk) {
           this.logger.debug(
             'Clearing isExtracted flag for program %s subtitle %s: file missing on disk (%s)',
             program.uuid,
@@ -150,18 +147,26 @@ export class ProgramStreamDetailsFetcher {
             subtitle.path ?? '<no path>',
           );
           await this.programDB.clearExtractedSubtitle(subtitle.uuid);
-          continue;
+          return null;
         }
-        subtitleStreamDetails.push({
+        return subtitle;
+      }),
+    );
+
+    subtitleStreamDetails.push(
+      ...seq.collect(usableSubtitles, (subtitle) => {
+        if (!subtitle) return null;
+        return {
           ...subtitle,
           index: nullToUndefined(subtitle.streamIndex),
-          type: subtitle.subtitleType === 'embedded' ? 'embedded' : 'external',
+          type:
+            subtitle.subtitleType === 'embedded' ? 'embedded' : 'external',
           languageCodeISO6392: subtitle.language,
           sdh: subtitle.sdh,
-          path: subtitle.path,
-        } satisfies SubtitleStreamDetails);
-      }
-    }
+          path: nullToUndefined(subtitle.path),
+        } satisfies SubtitleStreamDetails;
+      }),
+    );
 
     const streamDetails: StreamDetails = {
       audioDetails: isNonEmptyArray(audioStreamDetails)


### PR DESCRIPTION
**Problem**:
#1908 introduced a regression in `ProgramStreamDetailsFetcher.getStream`: sidecar subtitles no longer make it into the stream selection candidate list. The filter now gates `program.subtitles` rows on `subtitle.isExtracted`, and nothing in the codebase ever sets `isExtracted = true` on a sidecar row. The cached SRT exists, the row points at it, the file is on disk and ready for ffmpeg, but it's filtered out before the picker ever sees it.

**Cause**:
#1908 unified the two row types (embedded extracted and sidecar) behind a single `.filter(s => s.isExtracted)` gate plus a file-existence guard. Before that, sidecar rows were handled separately, gated on `path` being non-empty and the file existing on disk. The unification was a mistake on my part. `ExternalSubtitleDownloader` writes sidecar files to the cache and updates `stream.path` but doesn't touch `isExtracted`, and `SubtitleExtractorTask` only handles embedded extractions, so the flag never becomes `true` for sidecars and they get filtered out unconditionally.

**Repro**:
On current `main`:
1. Add a Plex source with at least one item that has a sidecar SRT and no embedded subtitle track (or where the embedded track shouldn't win for the language preference).
2. Create a channel with `subtitlesEnabled = 1` and a `by_language` subtitle preference matching the sidecar's language.
3. Confirm the sidecar SRT is present in the local cache at the path stored in `program_subtitles.path` (set by `ExternalSubtitleDownloader`).
4. Stream the channel. ffmpeg invocation has no `subtitles=` filter; the pipeline log shows `subtitleDetails: undefined`. No burn-in.

**Fix**:
Restore the pre-#1908 handling of sidecar rows alongside #1908's file-existence guard for embedded extractions. Gate the two row types separately rather than through a single `isExtracted` filter:

* `sidecar` rows: surface them when `path` is non-empty and the file exists on disk. They don't go through extraction; the file *is* the source-of-truth artifact, so `isExtracted` isn't the right flag for them. This is the path check sidecars had before #1908 collapsed them into the unified filter.
* `embedded` rows that were extracted to cache (`isExtracted = true`): keep #1908's behavior verbatim, including the `clearExtractedSubtitle` call so the extractor task rebuilds the cache on its next pass if the file has been pruned.

Embedded rows where `isExtracted = false` continue to be ignored. Unchanged behavior; the picker resolves those via `getSubtitleDetailsWithExtractedPath` directly from `version.mediaStreams`.

**Testing**:
Verified end-to-end against my actual Plex library on a patched dev server, four scenarios:

* **Sidecar-only program** (no embedded subtitle track in the mkv): sidecar SRT surfaces as `type: 'external'` with path pointing at the cached file; `by_language` rule matches it; ffmpeg burns it in. Before this change: no subs at all.
* **Mixed embedded + sidecar with healthy embedded extraction**: embedded extracted ASS still wins via `getSubtitleDetailsWithExtractedPath`. Unchanged.
* **Mixed embedded + sidecar with the embedded extraction file removed from cache**: picker iterates past the missing embedded entry and falls through to the sidecar. Validates the fallback semantics on `by_language`.
* **Channel with no explicit subtitle preferences**: behavior unchanged. The `default` rule in `resolveSubtitleAction` still returns null when no stream is flagged `default = true`. This PR doesn't change anything about that path; channels without explicit preferences continue to honor the user's lack of expressed preference.

No new schema, no migration, no new DB writes, no flag overloading. Just a localized fix to the row-surfacing logic to match the pre-#1908 semantic for sidecars.