### PR TITLE
fix(server): properly exclude season 0 of a show when that season is on the exclude list

### DIFF
--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -24,6 +24,7 @@ import type { Duration } from 'dayjs/plugin/duration.js';
 import {
   forEach,
   isEmpty,
+  isNil,
   isNull,
   last,
   map,
@@ -570,7 +571,7 @@ function getContentProgramIterator(
     if (slot.seasonExcludeFilter?.length > 0) {
       programs = programs.filter((program) => {
         const season = program.season?.index ?? program.seasonNumber;
-        return season == null || !slot.seasonExcludeFilter.includes(season);
+        return isNil(season) || !slot.seasonExcludeFilter.includes(season);
       });
     }
   }

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -570,7 +570,7 @@ function getContentProgramIterator(
     if (slot.seasonExcludeFilter?.length > 0) {
       programs = programs.filter((program) => {
         const season = program.season?.index ?? program.seasonNumber;
-        return !season || !slot.seasonExcludeFilter.includes(season);
+        return season == null || !slot.seasonExcludeFilter.includes(season);
       });
     }
   }


### PR DESCRIPTION
the problem here was that `!season` evaluates to `true` when `season` is `0` so programs from season 0 could never  be excluded.