### PR TITLE
perf(server): speed up tests with pre-migrated template DB

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig(
       'server/esbuild/*',
       'server/src/web/*',
       'server/src/testing/*',
+      'server/tests/*',
       'server/cjs-shim.ts',
       // 'release.config.mjs',
     ],

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -12,3 +12,4 @@ bin/
 src/generated/**
 !src/generated/env.ts
 emby.ts
+.test-cache/

--- a/server/src/db/ChannelDB.test.ts
+++ b/server/src/db/ChannelDB.test.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { SaveableChannel } from '@tunarr/types';
 import tmp from 'tmp-promise';
+import { copyPreMigratedDb } from '../testing/testDbFactory.ts';
 import { mock } from 'ts-mockito';
 import { v4 } from 'uuid';
 import { test as baseTest, describe, expect } from 'vitest';
@@ -34,6 +35,7 @@ type Fixture = {
 const test = baseTest.extend<Fixture>({
   db: async ({}, use) => {
     const dbResult = await tmp.dir({ unsafeCleanup: true });
+    await copyPreMigratedDb(dbResult.path);
     const opts = setGlobalOptionsUnchecked({
       database: dbResult.path,
       log_level: 'debug',

--- a/server/src/db/CustomShowDB.test.ts
+++ b/server/src/db/CustomShowDB.test.ts
@@ -3,6 +3,7 @@ import type { ContentProgram } from '@tunarr/types';
 import { tag } from '@tunarr/types';
 import dayjs from 'dayjs';
 import tmp from 'tmp-promise';
+import { copyPreMigratedDb } from '../testing/testDbFactory.ts';
 import { v4 } from 'uuid';
 import { test as baseTest, describe, expect, vi } from 'vitest';
 import { bootstrapTunarr } from '../bootstrap.ts';
@@ -47,19 +48,20 @@ type Fixture = {
 const test = baseTest.extend<Fixture>({
   db: async ({}, use) => {
     const dbResult = await tmp.dir({ unsafeCleanup: true });
+    await copyPreMigratedDb(dbResult.path);
     const opts = setGlobalOptionsUnchecked({
       database: dbResult.path,
       log_level: 'debug',
       verbose: 0,
     });
-    await bootstrapTunarr(opts, ':memory:');
+    await bootstrapTunarr(opts);
     await use(dbResult.path);
-    // const dbPath = `${dbResult.path}/db.db`;
-    // await DBAccess.instance.closeConnection(dbPath);
+    const dbPath = `${dbResult.path}/db.db`;
+    await DBAccess.instance.closeConnection(dbPath);
     await dbResult.cleanup();
   },
   mediaSourceId: async ({ db: _ }, use) => {
-    const drizzle = DBAccess.instance.getConnection(':memory:')!.drizzle!;
+    const drizzle = DBAccess.instance.drizzle!;
     const uuid = v4() as MediaSourceId;
     const now = +dayjs();
     await drizzle.insert(MediaSource).values({
@@ -77,8 +79,8 @@ const test = baseTest.extend<Fixture>({
   customShowDb: async ({ db: _ }, use) => {
     const dbAccess = DBAccess.instance;
 
-    const kyselyDb = dbAccess.getKyselyDatabase(':memory:')!;
-    const drizzleDb = dbAccess.getConnection(':memory:')!.drizzle!;
+    const kyselyDb = dbAccess.db!;
+    const drizzleDb = dbAccess.drizzle!;
     const basicProgramRepo = new BasicProgramRepository(kyselyDb, drizzleDb);
     const customShowDb = new CustomShowDB(
       kyselyDb,
@@ -89,7 +91,7 @@ const test = baseTest.extend<Fixture>({
     await use(customShowDb);
   },
   drizzle: async ({ db: _ }, use) => {
-    await use(DBAccess.instance.getConnection(':memory:')!.drizzle!);
+    await use(DBAccess.instance.drizzle!);
   },
 });
 

--- a/server/src/db/ProgramDB.test.ts
+++ b/server/src/db/ProgramDB.test.ts
@@ -5,6 +5,7 @@ import { sql, SQL } from 'drizzle-orm';
 import { SelectResultFields } from 'drizzle-orm/query-builders/select.types';
 import { SelectedFields } from 'drizzle-orm/sqlite-core';
 import tmp from 'tmp-promise';
+import { copyPreMigratedDb } from '../testing/testDbFactory.ts';
 import { StrictOmit } from 'ts-essentials';
 import { v4 } from 'uuid';
 import { test as baseTest } from 'vitest';
@@ -92,6 +93,7 @@ type Fixture = {
 const test = baseTest.extend<Fixture>({
   db: async ({}, use) => {
     const dbResult = await tmp.dir({ unsafeCleanup: true });
+    await copyPreMigratedDb(dbResult.path);
     setGlobalOptions({
       database: dbResult.path,
       log_level: 'debug',

--- a/server/src/db/TagRepo.test.ts
+++ b/server/src/db/TagRepo.test.ts
@@ -1,7 +1,8 @@
 import tmp from 'tmp-promise';
 import { test as baseTest } from 'vitest';
 import { bootstrapTunarr } from '../bootstrap.ts';
-import { globalOptions, setGlobalOptions } from '../globals.ts';
+import { setGlobalOptions } from '../globals.ts';
+import { copyPreMigratedDb } from '../testing/testDbFactory.ts';
 import { DBAccess } from './DBAccess.ts';
 import { DrizzleDBAccess } from './schema/index.ts';
 import { TagRepo } from './TagRepo.ts';
@@ -15,18 +16,20 @@ type Fixture = {
 const test = baseTest.extend<Fixture>({
   db: async ({}, use) => {
     const dbResult = await tmp.dir({ unsafeCleanup: true });
+    await copyPreMigratedDb(dbResult.path);
     setGlobalOptions({
       database: dbResult.path,
       log_level: 'info',
       verbose: 0,
     });
-    await bootstrapTunarr(globalOptions(), ':memory:');
+    await bootstrapTunarr();
     await use(dbResult.path);
+    const dbPath = `${dbResult.path}/db.db`;
+    await DBAccess.instance.closeConnection(dbPath);
     await dbResult.cleanup();
   },
   drizzle: async ({ db: _ }, use) => {
-    const conn = DBAccess.instance.getConnection(':memory:');
-    await use(conn!.drizzle);
+    await use(DBAccess.instance.drizzle!);
   },
   tagRepo: async ({ drizzle }, use) => {
     await use(new TagRepo(drizzle));

--- a/server/src/testing/globalTestSetup.ts
+++ b/server/src/testing/globalTestSetup.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const CACHE_DIR = path.resolve(process.cwd(), '.test-cache');
+
+export const templateDbPath = path.join(CACHE_DIR, 'template.db');
+
+export async function setup() {
+  const { default: tmp } = await import('tmp-promise');
+  const { setGlobalOptionsUnchecked } = await import('../globals.ts');
+  const { bootstrapTunarr } = await import('../bootstrap.ts');
+  const { DBAccess } = await import('../db/DBAccess.ts');
+  const { getDefaultDatabaseName } = await import('../util/defaults.ts');
+
+  const tmpDir = await tmp.dir({ unsafeCleanup: true });
+
+  setGlobalOptionsUnchecked({
+    database: tmpDir.path,
+    log_level: 'error',
+    verbose: 0,
+  });
+
+  await bootstrapTunarr();
+
+  const dbPath = getDefaultDatabaseName();
+  const conn = DBAccess.instance.getConnection(dbPath);
+  // Flush WAL so the main file is self-contained for copying
+  conn?.sqlite.pragma('wal_checkpoint(TRUNCATE)');
+  await DBAccess.instance.closeConnection(dbPath);
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  await fs.copyFile(dbPath, templateDbPath);
+
+  await tmpDir.cleanup();
+}
+
+export async function teardown() {
+  await fs.rm(CACHE_DIR, { recursive: true, force: true }).catch(() => {});
+}

--- a/server/src/testing/testDbFactory.ts
+++ b/server/src/testing/testDbFactory.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { templateDbPath } from './globalTestSetup.ts';
+
+/**
+ * Copy the pre-migrated template database into the given directory.
+ * Call this before {@link bootstrapTunarr} so the bootstrap detects
+ * all migrations as already applied and skips them.
+ */
+export async function copyPreMigratedDb(targetDir: string): Promise<void> {
+  await fs.copyFile(templateDbPath, path.join(targetDir, 'db.db'));
+}

--- a/server/tests/testServer.ts
+++ b/server/tests/testServer.ts
@@ -1,4 +1,5 @@
 import tmp from 'tmp-promise';
+import { copyPreMigratedDb } from '../src/testing/testDbFactory.ts';
 import { bootstrapTunarr } from '../src/bootstrap.ts';
 import { container } from '../src/container.ts';
 import { setServerOptions } from '../src/globals.js';
@@ -9,6 +10,7 @@ export let dbResult: tmp.DirectoryResult;
 
 export async function initTestApp(port: number) {
   dbResult = await tmp.dir({ unsafeCleanup: true });
+  await copyPreMigratedDb(dbResult.path);
   setServerOptions({
     database: dbResult.path,
     force_migration: false,

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     },
   },
   test: {
+    globalSetup: ['src/testing/globalTestSetup.ts'],
     globals: true,
     watch: false,
     includeSource: ['src/**/*.test.ts'],


### PR DESCRIPTION
Instead of running all ~67 migrations from scratch for every test file
that needs a database, run them once in a vitest globalSetup to produce
a template DB, then copy it for each test.

- Add globalTestSetup.ts that creates a fully-migrated template at
  .test-cache/template.db before any tests run
- Add copyPreMigratedDb() helper used by test fixtures
- Convert CustomShowDB and TagRepo tests from :memory: to file-based
  so they also benefit from the template
- bootstrapTunarr() naturally detects no pending migrations on the
  copied DB and skips them
- Add server/tests/ to ESLint ignores (pre-existing config gap)

Results:
  Wall-clock duration: 31s -> 17s (47% faster)
  Test execution time:  50s ->  9s (82% faster)
