### PR TITLE
fix(server): repair channels with dangling transcode config ids

### DIFF
--- a/server/src/stream/SessionManager.ts
+++ b/server/src/stream/SessionManager.ts
@@ -16,6 +16,7 @@ import {
 import {
   ChannelNotFoundError,
   GenericError,
+  TranscodeConfigNotFoundError,
   TypedError,
 } from '../types/errors.js';
 import type { ConcatSession } from './ConcatSession.js';
@@ -278,8 +279,21 @@ export class SessionManager {
         if (isNil(session)) {
           const channel = await this.channelDB.getChannelOrm(channelId);
 
-          if (!channel?.transcodeConfig) {
+          if (isNil(channel)) {
             throw new ChannelNotFoundError(channelId);
+          }
+
+          if (isNil(channel.transcodeConfig)) {
+            // The channel exists but points at a transcode config that
+            // doesn't. Surface an accurate error instead of a misleading
+            // "channel not found" (see issue #1772).
+            this.logger.error(
+              'Channel %s (%s) references transcode config %s, which does not exist. The channel cannot be streamed until it is assigned a valid transcode config; restarting the server will reassign it to the default config.',
+              channel.name,
+              channel.uuid,
+              channel.transcodeConfigId,
+            );
+            throw new TranscodeConfigNotFoundError(channel.transcodeConfigId);
           }
 
           session = sessionFactory(channel);

--- a/server/src/tasks/fixers/EnsureTranscodeConfigIds.test.ts
+++ b/server/src/tasks/fixers/EnsureTranscodeConfigIds.test.ts
@@ -1,0 +1,137 @@
+import tmp from 'tmp-promise';
+import { v4 } from 'uuid';
+import { test as baseTest, describe, expect } from 'vitest';
+import { bootstrapTunarr } from '../../bootstrap.ts';
+import { DBAccess } from '../../db/DBAccess.ts';
+import { Channel } from '../../db/schema/Channel.ts';
+import {
+  defaultTranscodeConfig,
+  TranscodeConfig,
+} from '../../db/schema/TranscodeConfig.ts';
+import { setGlobalOptionsUnchecked } from '../../globals.ts';
+import { copyPreMigratedDb } from '../../testing/testDbFactory.ts';
+import { EnsureTranscodeConfigIds } from './EnsureTranscodeConfigIds.ts';
+
+type Fixture = {
+  db: string;
+  defaultTranscodeConfigId: string;
+};
+
+const test = baseTest.extend<Fixture>({
+  db: async ({}, use) => {
+    const dbResult = await tmp.dir({ unsafeCleanup: true });
+    await copyPreMigratedDb(dbResult.path);
+    const opts = setGlobalOptionsUnchecked({
+      database: dbResult.path,
+      log_level: 'debug',
+      verbose: 0,
+    });
+    await bootstrapTunarr(opts);
+    await use(dbResult.path);
+    const dbPath = `${dbResult.path}/db.db`;
+    await DBAccess.instance.closeConnection(dbPath);
+    await dbResult.cleanup();
+  },
+  defaultTranscodeConfigId: async ({ db: _ }, use) => {
+    const config = await DBAccess.instance
+      .db!.selectFrom('transcodeConfig')
+      .select('uuid')
+      .where('isDefault', '=', 1)
+      .executeTakeFirstOrThrow();
+    await use(config.uuid);
+  },
+});
+
+function channelRow(
+  overrides: Partial<typeof Channel.$inferInsert> = {},
+): typeof Channel.$inferInsert {
+  return {
+    uuid: v4(),
+    duration: 0,
+    guideMinimumDuration: 30_000,
+    icon: { path: '', width: 100, duration: 0, position: 'bottom-right' },
+    name: 'Test Channel',
+    number: 1,
+    offline: { mode: 'pic' },
+    startTime: 0,
+    streamMode: 'hls',
+    transcodeConfigId: 'placeholder',
+    ...overrides,
+  };
+}
+
+describe('EnsureTranscodeConfigIds', () => {
+  test('reassigns channels with dangling transcode config ids to the default config', async ({
+    db: _,
+    defaultTranscodeConfigId,
+  }) => {
+    const drizzle = DBAccess.instance.drizzle!;
+    const kysely = DBAccess.instance.db!;
+
+    // Mirrors issue #1772: a channel saved (pre-validation) with the literal
+    // string "default" as its transcode config ID, which references nothing.
+    const danglingChannel = channelRow({
+      number: 1,
+      transcodeConfigId: 'default',
+    });
+    // A channel pointing at a config UUID that once existed but no longer does.
+    const orphanedChannel = channelRow({
+      number: 2,
+      transcodeConfigId: v4(),
+    });
+    // A healthy channel that must not be touched.
+    const validChannel = channelRow({
+      number: 3,
+      transcodeConfigId: defaultTranscodeConfigId,
+    });
+
+    await drizzle
+      .insert(Channel)
+      .values([danglingChannel, orphanedChannel, validChannel]);
+
+    await new EnsureTranscodeConfigIds(kysely).run();
+
+    const rows = await kysely
+      .selectFrom('channel')
+      .select(['uuid', 'transcodeConfigId'])
+      .execute();
+    const byUuid = Object.fromEntries(
+      rows.map((r) => [r.uuid, r.transcodeConfigId]),
+    );
+
+    expect(byUuid[danglingChannel.uuid]).toBe(defaultTranscodeConfigId);
+    expect(byUuid[orphanedChannel.uuid]).toBe(defaultTranscodeConfigId);
+    expect(byUuid[validChannel.uuid]).toBe(defaultTranscodeConfigId);
+  });
+
+  test('leaves channels with valid non-default transcode configs untouched', async ({
+    db: _,
+  }) => {
+    const drizzle = DBAccess.instance.drizzle!;
+    const kysely = DBAccess.instance.db!;
+
+    // Create a second, non-default transcode config.
+    const secondConfig = {
+      ...defaultTranscodeConfig(false),
+      name: 'Secondary',
+    };
+    const secondConfigId = secondConfig.uuid;
+    await drizzle.insert(TranscodeConfig).values(secondConfig);
+
+    const channelOnSecondConfig = channelRow({
+      number: 10,
+      transcodeConfigId: secondConfigId,
+    });
+    await drizzle.insert(Channel).values([channelOnSecondConfig]);
+
+    await new EnsureTranscodeConfigIds(kysely).run();
+
+    const row = await kysely
+      .selectFrom('channel')
+      .select('transcodeConfigId')
+      .where('uuid', '=', channelOnSecondConfig.uuid)
+      .executeTakeFirstOrThrow();
+
+    expect(row.transcodeConfigId).toBe(secondConfigId);
+  });
+});

--- a/server/src/tasks/fixers/EnsureTranscodeConfigIds.ts
+++ b/server/src/tasks/fixers/EnsureTranscodeConfigIds.ts
@@ -50,15 +50,35 @@ export class EnsureTranscodeConfigIds extends Fixer {
         .execute();
     }
 
+    // Channels with a NULL transcode config ID, or with an ID that does not
+    // reference an existing transcode config (e.g. channels saved via the API
+    // before referential validation existed -- see issue #1772). Note that the
+    // explicit NULL check is required because `NOT IN` never matches NULL.
     const channelsMissingTranscodeId = await this.db
       .selectFrom('channel')
-      .where('channel.transcodeConfigId', 'is', null)
+      .where((eb) =>
+        eb.or([
+          eb('channel.transcodeConfigId', 'is', null),
+          eb(
+            'channel.transcodeConfigId',
+            'not in',
+            eb.selectFrom('transcodeConfig').select('transcodeConfig.uuid'),
+          ),
+        ]),
+      )
       .selectAll()
       .execute();
 
     if (channelsMissingTranscodeId.length === 0) {
       return;
     }
+
+    this.logger.warn(
+      'Found %d channel(s) with a missing or dangling transcode config ID. Reassigning them to the default transcode config (%s): %O',
+      channelsMissingTranscodeId.length,
+      defaultConfig!.uuid,
+      map(channelsMissingTranscodeId, 'uuid'),
+    );
 
     await this.db
       .updateTable('channel')


### PR DESCRIPTION
# PR Title

fix(server): repair channels with dangling transcode config ids

# PR Description

Fixes #1772

## Problem

Channels whose `transcodeConfigId` doesn't reference an existing transcode config (e.g. channels created via the API before save-time validation existed, with values like the literal string `"default"`) fail to stream with a misleading `ChannelNotFoundError`, even though the channel exists, appears in `GET /api/channels`, and has its guide built successfully.

## Root cause

Three factors combine:

1. `Channel.transcodeConfigId` is a plain `text().notNull()` column with no foreign key, so any string is accepted at the DB level.
2. `SessionManager.getOrCreateSession` conflates two distinct failures — `if (!channel?.transcodeConfig)` throws `ChannelNotFoundError` both when the channel is missing *and* when the channel exists but its transcode config relation resolves to null. Guide building and the channels API never touch that relation, which is why everything looks healthy until stream time.
3. The `EnsureTranscodeConfigIds` startup fixer only repaired channels where `transcodeConfigId IS NULL`, so dangling non-null references were never healed.

Save-time validation on `POST /channels` and `PUT /channels/:id` (already on main) blocks new corruption, but databases corrupted on ≤1.2.8 stay broken on every stream attempt.

## Changes

- **`EnsureTranscodeConfigIds`**: also repairs dangling references (`transcodeConfigId NOT IN (SELECT uuid FROM transcodeConfig)`), reassigning affected channels to the default config with a warning log. Existing broken databases self-heal on next restart. The explicit `IS NULL` branch is kept since `NOT IN` never matches NULL.
- **`SessionManager`**: splits the conflated check. Missing channel → `ChannelNotFoundError` (unchanged behavior). Channel present but config missing → `TranscodeConfigNotFoundError` plus an actionable error log telling the operator that a restart will reassign the channel to the default config.
- **New regression test** (`EnsureTranscodeConfigIds.test.ts`): inserts a channel with the literal `"default"` ID from the issue repro, a channel with an orphaned UUID, and healthy channels; verifies the fixer repairs the broken ones and leaves valid non-default assignments untouched.

## Testing

- 2 new fixer tests pass
- All 9 existing `SessionManager` tests pass
- `tsgo -p tsconfig.build.json --noEmit` clean
- `pnpm lint-changed` clean

## Possible follow-up (out of scope)

A schema-level FK on `Channel.transcodeConfigId` (mirroring `streamSelectionProfileId`) would prevent this class of bug entirely, but requires a table-rebuild migration in SQLite, so I've left that to your migration workflow if you want it.
