### PR TITLE
fix: ensure that slot filler iterators loop infinitely

### DIFF
--- a/server/src/services/scheduling/ProgramIterator.ts
+++ b/server/src/services/scheduling/ProgramIterator.ts
@@ -11,6 +11,11 @@ import type {
 export type IterationState = {
   slotDuration: number; // ms
   timeCursor: number; // ms since epoch
+  /** Optional dedup cooldown override. When set, the weighted filler
+   *  iterator uses this instead of slotDuration for its "last seen"
+   *  cooldown check. Pass 0 to disable hard dedup and rely solely on
+   *  weight decay for variety. Defaults to slotDuration when omitted. */
+  cooldownMs?: number;
 };
 
 export interface ProgramIterator<

--- a/server/src/services/scheduling/RandomSlotsService.ts
+++ b/server/src/services/scheduling/RandomSlotsService.ts
@@ -260,14 +260,20 @@ export class RandomSlotScheduler {
         paddedPrograms = maybePrograms;
       }
 
-      const finalPrograms: PaddedProgram[] = paddedPrograms.flatMap((pp) =>
-        applyMidRollBreaks(
-          pp,
-          currSlot,
-          currSlot.midRollConfig,
-          context.random,
-        ),
-      );
+      let midRollOffset = 0;
+      const finalPrograms: PaddedProgram[] = [];
+      for (const pp of paddedPrograms) {
+        finalPrograms.push(
+          ...applyMidRollBreaks(
+            pp,
+            currSlot,
+            currSlot.midRollConfig,
+            context.random,
+            +context.timeCursor + midRollOffset,
+          ),
+        );
+        midRollOffset += pp.totalDuration;
+      }
 
       const totalDuration = sum(map(finalPrograms, (p) => p.totalDuration));
       let remainingTimeInSlot = 0;
@@ -426,6 +432,7 @@ export class RandomSlotScheduler {
       currSlot,
       paddedProgram,
       slotDuration - paddedProgram.totalDuration,
+      +context.timeCursor,
     );
 
     let totalDuration = paddedProgram.totalDuration;
@@ -445,6 +452,7 @@ export class RandomSlotScheduler {
         currSlot,
         nextPadded,
         slotDuration - nextPadded.totalDuration,
+        +context.timeCursor + totalDuration,
       );
       totalDuration += nextPadded.totalDuration;
     }
@@ -461,7 +469,12 @@ export class RandomSlotScheduler {
     // Fallback filler gets added outside of this method after we've packed the
     // slot as much as possible.
     const remainingTime = currSlot.durationMs! - totalDuration;
-    addHeadAndTailFillerToSlot(remainingTime, currSlot, paddedPrograms);
+    addHeadAndTailFillerToSlot(
+      remainingTime,
+      currSlot,
+      paddedPrograms,
+      +context.timeCursor,
+    );
     return paddedPrograms;
   }
 

--- a/server/src/services/scheduling/TimeSlotService.test.ts
+++ b/server/src/services/scheduling/TimeSlotService.test.ts
@@ -2406,6 +2406,92 @@ describe('TimeSlotService', () => {
         }
       });
 
+      test('weighted pre-roll filler does not deplete across programs in a slot', async () => {
+        const fillerListId = randomUUID();
+
+        // 6 short episodes that each fit within a 1-hour pad,
+        // so multiple programs fill the slot and each gets pre-roll filler.
+        const episodes: SlotSchedulerProgram[] = Array.from(
+          { length: 6 },
+          (_, i) => ({
+            ...createFakeProgramOrm({
+              uuid: `ep-${i}`,
+              title: `Episode ${i}`,
+              type: 'episode',
+              duration: 30 * 60 * 1000, // 30 min each
+              episode: i + 1,
+              tvShowUuid: 'show1',
+              show: { uuid: 'show1' },
+            }),
+            parentFillerLists: [],
+            parentCustomShows: [],
+            parentSmartCollections: [],
+          }),
+        );
+
+        // Only 2 filler programs — previously these would deplete after
+        // 2 programs, leaving the remaining 4 without pre-roll.
+        const fillerPrograms: SlotSchedulerProgram[] = Array.from(
+          { length: 2 },
+          (_, i) => ({
+            ...createFakeProgramOrm({
+              uuid: `filler-${i}`,
+              title: `Filler ${i}`,
+              type: 'movie',
+              duration: 15 * 1000, // 15 seconds each
+            }),
+            parentFillerLists: [fillerListId],
+            parentCustomShows: [],
+            parentSmartCollections: [],
+          }),
+        );
+
+        const schedule: TimeSlotSchedule = {
+          type: 'time',
+          period: 'day',
+          maxDays: 1,
+          flexPreference: 'end',
+          padMs: oneHour,
+          latenessMs: 0,
+          timeZoneOffset: 0,
+          slots: [
+            {
+              id: randomUUID(),
+              startTime: 0,
+              type: 'show',
+              showId: 'show1',
+              order: 'next',
+              direction: 'asc',
+              seasonFilter: [],
+              filler: [
+                {
+                  types: ['pre'],
+                  fillerListId,
+                  fillerOrder: 'shuffle_prefer_short',
+                },
+              ],
+            },
+          ],
+        };
+
+        const result = await scheduleTimeSlots(
+          schedule,
+          [...episodes, ...fillerPrograms],
+          [42, 99],
+          undefined,
+          midnight,
+        );
+
+        const fillerItems = result.lineup.filter((p) => p.type === 'filler');
+        const contentItems = result.lineup.filter((p) => p.type === 'content');
+
+        // We should have at least as many pre-roll filler items as
+        // content programs — the 2-item filler list should cycle, not
+        // deplete after 2 uses.
+        expect(contentItems.length).toBeGreaterThanOrEqual(6);
+        expect(fillerItems.length).toBeGreaterThanOrEqual(contentItems.length);
+      });
+
       test('same group, different ordering → independent', async () => {
         const episodes = makeEpisodes('show1', 10);
         const slotIdA = randomUUID();

--- a/server/src/services/scheduling/TimeSlotService.ts
+++ b/server/src/services/scheduling/TimeSlotService.ts
@@ -279,6 +279,7 @@ export async function scheduleTimeSlots(
       currSlot,
       paddedProgram,
       slotDuration - paddedProgram.totalDuration,
+      +timeCursor,
     );
     let totalAddedDuration = paddedProgram.totalDuration;
 
@@ -301,6 +302,7 @@ export async function scheduleTimeSlots(
         currSlot,
         nextPadded,
         slotDuration - nextPadded.totalDuration,
+        +timeCursor + totalAddedDuration,
       );
       totalAddedDuration += nextPadded.totalDuration;
     }
@@ -311,12 +313,24 @@ export async function scheduleTimeSlots(
         remainingTimeInSlot,
         currSlot,
         paddedPrograms,
+        +timeCursor,
       );
     }
 
-    const finalPrograms: PaddedProgram[] = paddedPrograms.flatMap((pp) =>
-      applyMidRollBreaks(pp, currSlot, currSlot.midRollConfig, random),
-    );
+    let midRollOffset = 0;
+    const finalPrograms: PaddedProgram[] = [];
+    for (const pp of paddedPrograms) {
+      finalPrograms.push(
+        ...applyMidRollBreaks(
+          pp,
+          currSlot,
+          currSlot.midRollConfig,
+          random,
+          +timeCursor + midRollOffset,
+        ),
+      );
+      midRollOffset += pp.totalDuration;
+    }
 
     // We have two options here if there is remaining time in the slot
     // If we want to be "greedy", we can keep attempting to look for items
@@ -353,7 +367,7 @@ export async function scheduleTimeSlots(
       if (padMs > 0) {
         let filler = currSlot.getFillerOfType('fallback', {
           slotDuration: -Infinity, // Pick anything
-          timeCursor: -1,
+          timeCursor: +timeCursor,
         });
 
         if (filler) {

--- a/server/src/services/scheduling/WeightedFillerProgramIterator.test.ts
+++ b/server/src/services/scheduling/WeightedFillerProgramIterator.test.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from 'node:crypto';
+import type { FillerProgrammingSlot } from '@tunarr/types/api';
+import { MersenneTwister19937, Random } from 'random-js';
+import { describe, expect, test } from 'vitest';
+import { createFakeProgramOrm } from '../../testing/fakes/entityCreators.ts';
+import type { SlotSchedulerProgram } from './slotSchedulerUtil.ts';
+import { WeightedFillerProgramIterator } from './WeightedFillerProgramIterator.ts';
+
+function makeFillerPrograms(
+  count: number,
+  durationMs: number = 30_000,
+): SlotSchedulerProgram[] {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      ({
+        ...createFakeProgramOrm({
+          uuid: `filler-${i}`,
+          title: `Filler ${i}`,
+          type: 'movie',
+          duration: durationMs,
+        }),
+        parentFillerLists: [],
+        parentCustomShows: [],
+        parentSmartCollections: [],
+      }) satisfies SlotSchedulerProgram,
+  );
+}
+
+function makeSlotDef(
+  overrides?: Partial<FillerProgrammingSlot>,
+): FillerProgrammingSlot {
+  return {
+    id: randomUUID(),
+    type: 'filler',
+    fillerListId: randomUUID(),
+    order: 'shuffle_prefer_short',
+    durationWeighting: 'linear',
+    decayFactor: 0.5,
+    recoveryFactor: 0.05,
+    ...overrides,
+  };
+}
+
+function makeRandom(seed: number = 42): Random {
+  return new Random(MersenneTwister19937.seed(seed));
+}
+
+describe('WeightedFillerProgramIterator', () => {
+  describe('pre-roll filler depletion fix', () => {
+    test('returns filler beyond the size of the list with cooldownMs: 0', () => {
+      const programs = makeFillerPrograms(3, 15_000);
+      const slotDef = makeSlotDef();
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'pre',
+      );
+
+      // Pick more fillers than the list size. With cooldownMs: 0,
+      // the hard dedup is disabled and weight decay drives variety.
+      const picks: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        const result = iterator.current({
+          timeCursor: i * 1_000_000,
+          slotDuration: 60_000,
+          cooldownMs: 0,
+        });
+        expect(result).not.toBeNull();
+        picks.push(result!.id);
+        iterator.next();
+      }
+
+      // All 10 picks should have returned a filler program.
+      expect(picks).toHaveLength(10);
+      // We should see repeats — the list has only 3 items.
+      const unique = new Set(picks);
+      expect(unique.size).toBeLessThanOrEqual(3);
+    });
+
+    test('returns filler beyond the size of the list when timeCursor advances past cooldown', () => {
+      const programs = makeFillerPrograms(3, 15_000);
+      const slotDef = makeSlotDef();
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'pre',
+      );
+
+      // With an advancing timeCursor that exceeds the default cooldown
+      // (slotDuration), previously-seen programs become eligible again.
+      const picks: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        const result = iterator.current({
+          timeCursor: i * 1_000_000,
+          slotDuration: 60_000,
+        });
+        expect(result).not.toBeNull();
+        picks.push(result!.id);
+        iterator.next();
+      }
+
+      expect(picks).toHaveLength(10);
+      const unique = new Set(picks);
+      expect(unique.size).toBeLessThanOrEqual(3);
+    });
+
+    test('depletes when timeCursor is constant (same time window)', () => {
+      const programs = makeFillerPrograms(3, 15_000);
+      const slotDef = makeSlotDef();
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'mid',
+      );
+
+      // With constant timeCursor, the lastSeen dedup should filter
+      // out programs after they're picked, which is correct behavior
+      // for mid-roll breaks within a single time window.
+      const picks: string[] = [];
+      for (let i = 0; i < 6; i++) {
+        const result = iterator.current({
+          timeCursor: 1_000_000,
+          slotDuration: 60_000,
+        });
+        if (!result) break;
+        picks.push(result.id);
+        iterator.next();
+      }
+
+      // Should pick at most 3 (one per unique program) before depleting.
+      expect(picks.length).toBeLessThanOrEqual(3);
+      expect(new Set(picks).size).toBe(picks.length);
+    });
+  });
+
+  describe('negative slotDuration handling', () => {
+    test('returns filler when slotDuration is -1 (no duration constraint)', () => {
+      const programs = makeFillerPrograms(5, 30_000);
+      const slotDef = makeSlotDef();
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'pre',
+      );
+
+      // With slotDuration = -1, all programs should be considered
+      // regardless of their duration.
+      const result = iterator.current({
+        timeCursor: 1_000_000,
+        slotDuration: -1,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('filler');
+    });
+
+    test('includes all programs when slotDuration is negative', () => {
+      // Create programs with varying durations. Use shuffle_prefer_long
+      // so the long program has significant weight and gets picked.
+      const programs: SlotSchedulerProgram[] = [
+        {
+          ...createFakeProgramOrm({
+            uuid: 'short',
+            title: 'Short',
+            type: 'movie',
+            duration: 10_000,
+          }),
+          parentFillerLists: [],
+          parentCustomShows: [],
+          parentSmartCollections: [],
+        },
+        {
+          ...createFakeProgramOrm({
+            uuid: 'long',
+            title: 'Long',
+            type: 'movie',
+            duration: 300_000,
+          }),
+          parentFillerLists: [],
+          parentCustomShows: [],
+          parentSmartCollections: [],
+        },
+      ];
+
+      const slotDef = makeSlotDef({ order: 'shuffle_prefer_long' });
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'pre',
+      );
+
+      // With slotDuration = -1, even the "long" program should be eligible.
+      // Pick several times to verify both can appear.
+      const ids = new Set<string>();
+      for (let i = 0; i < 20; i++) {
+        const result = iterator.current({
+          timeCursor: i * 1_000_000,
+          slotDuration: -1,
+        });
+        if (result) {
+          ids.add(result.id);
+          iterator.next();
+        }
+      }
+
+      expect(ids.size).toBe(2);
+    });
+
+    test('previously only included programs shorter than slotDuration', () => {
+      // Verify the positive slotDuration gating still works correctly.
+      const programs: SlotSchedulerProgram[] = [
+        {
+          ...createFakeProgramOrm({
+            uuid: 'fits',
+            title: 'Fits',
+            type: 'movie',
+            duration: 10_000,
+          }),
+          parentFillerLists: [],
+          parentCustomShows: [],
+          parentSmartCollections: [],
+        },
+        {
+          ...createFakeProgramOrm({
+            uuid: 'too-long',
+            title: 'Too Long',
+            type: 'movie',
+            duration: 300_000,
+          }),
+          parentFillerLists: [],
+          parentCustomShows: [],
+          parentSmartCollections: [],
+        },
+      ];
+
+      const slotDef = makeSlotDef();
+      const random = makeRandom();
+      const iterator = new WeightedFillerProgramIterator(
+        programs as never,
+        slotDef,
+        random,
+        'pre',
+      );
+
+      // With slotDuration = 60_000, only the 10s program should be eligible.
+      const ids = new Set<string>();
+      for (let i = 0; i < 10; i++) {
+        const result = iterator.current({
+          timeCursor: i * 1_000_000,
+          slotDuration: 60_000,
+        });
+        if (result) {
+          ids.add(result.id);
+          iterator.next();
+        }
+      }
+
+      expect(ids).toContain('fits');
+      expect(ids).not.toContain('too-long');
+    });
+  });
+});

--- a/server/src/services/scheduling/WeightedFillerProgramIterator.ts
+++ b/server/src/services/scheduling/WeightedFillerProgramIterator.ts
@@ -114,7 +114,7 @@ export class WeightedFillerProgramIterator
 
   current(state: IterationState): Nullable<FillerProgram> {
     let idx = 0;
-    if (state.slotDuration > this.maxDuration) {
+    if (state.slotDuration < 0 || state.slotDuration > this.maxDuration) {
       idx = this.weightedPrograms.length;
     } else {
       while (idx < this.weightedPrograms.length) {
@@ -125,14 +125,12 @@ export class WeightedFillerProgramIterator
       }
     }
 
+    const cooldown = state.cooldownMs ?? state.slotDuration;
     const programsToConsider = this.weightedPrograms
       .slice(0, idx)
       .filter(({ program }) => {
         const lastSeen = this.lastSeenTimestampById.get(program.uuid);
-        if (
-          !isNil(lastSeen) &&
-          state.timeCursor - lastSeen < state.slotDuration
-        ) {
+        if (!isNil(lastSeen) && state.timeCursor - lastSeen < cooldown) {
           return false;
         }
         return true;

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -738,6 +738,7 @@ export function addHeadAndTailFillerToSlot(
   remainingTime: number,
   slot: SlotImpl<BaseSlot>,
   contentPrograms: NonEmptyArray<PaddedProgram>,
+  timeCursor: number,
 ): number {
   if (remainingTime <= 0) {
     return remainingTime;
@@ -748,7 +749,8 @@ export function addHeadAndTailFillerToSlot(
       () =>
         slot.getFillerOfType(FillerTypes.head, {
           slotDuration: remainingTime,
-          timeCursor: -1,
+          timeCursor,
+          cooldownMs: 0,
         }),
       3,
     );
@@ -771,7 +773,8 @@ export function addHeadAndTailFillerToSlot(
       () =>
         slot.getFillerOfType(FillerTypes.tail, {
           slotDuration: remainingTime + lastItemPad,
-          timeCursor: -1,
+          timeCursor,
+          cooldownMs: 0,
         }),
       3,
     );
@@ -794,14 +797,22 @@ export function maybeAddPrePostFiller(
   slot: SlotImpl<BaseSlot>,
   program: PaddedProgram,
   remainingTime: number,
+  timeCursor: number,
 ): number {
   remainingTime = maybeAddFillerOfType(
     FillerTypes.pre,
     remainingTime,
     slot,
     program,
+    timeCursor,
   );
-  return maybeAddFillerOfType(FillerTypes.post, remainingTime, slot, program);
+  return maybeAddFillerOfType(
+    FillerTypes.post,
+    remainingTime,
+    slot,
+    program,
+    timeCursor,
+  );
 }
 
 function maybeAddFillerOfType(
@@ -809,6 +820,7 @@ function maybeAddFillerOfType(
   remainingTime: number,
   slot: SlotImpl<BaseSlot>,
   program: PaddedProgram,
+  timeCursor: number,
 ): number {
   if (!slot.hasFillerOfType(fillerType)) {
     // return { nextPrograms: contentPrograms, nextRemainingTime: remainingTime };
@@ -825,7 +837,8 @@ function maybeAddFillerOfType(
       () =>
         slot.getFillerOfType(fillerType, {
           slotDuration: totalTime,
-          timeCursor: -1,
+          timeCursor,
+          cooldownMs: 0,
         }),
       3,
     );
@@ -886,6 +899,7 @@ export function applyMidRollBreaks(
   slot: SlotImpl<BaseSlot>,
   midRollConfig: MidRollConfig | undefined,
   random: Random,
+  timeCursor: number,
 ): PaddedProgram[] {
   if (!midRollConfig || slot.getMidFillerListIds().length === 0) {
     return [paddedProgram];
@@ -925,6 +939,7 @@ export function applyMidRollBreaks(
     midRollConfig,
     slot,
     random,
+    timeCursor,
   );
 }
 
@@ -934,6 +949,7 @@ function buildEagerBreaks(
   config: MidRollConfig,
   slot: SlotImpl<BaseSlot>,
   random: Random,
+  timeCursor: number,
 ): PaddedProgram[] {
   const program = paddedProgram.program as CondensedContentProgram;
   const baseOffset = program.startOffsetMs ?? 0;
@@ -955,7 +971,7 @@ function buildEagerBreaks(
     );
 
     const breakDuration = resolveBreakDuration(config, random);
-    const fillers = fillDurationWithFiller(slot, breakDuration);
+    const fillers = fillDurationWithFiller(slot, breakDuration, timeCursor);
 
     for (const filler of fillers.fillers) {
       result.push(new PaddedProgram(filler, 0, {}));
@@ -1048,6 +1064,7 @@ function buildLazyBreaks(
 function fillDurationWithFiller(
   slot: SlotImpl<BaseSlot>,
   targetDurationMs: number,
+  timeCursor: number,
   maxAttempts: number = 10,
 ): { fillers: FillerProgram[]; totalDuration: number } {
   const fillers: FillerProgram[] = [];
@@ -1058,7 +1075,7 @@ function fillDurationWithFiller(
     const remaining = targetDurationMs - totalDuration;
     const filler = slot.getFillerOfType('mid', {
       slotDuration: remaining,
-      timeCursor: -1,
+      timeCursor,
     });
 
     if (!filler) break;


### PR DESCRIPTION
Scheduler was passing bogus "-1" time cursor values into the filler
iterator. After the first iteration, this stopped returning any
programs. The fix here is to send accurate time cursors in to 1.
properly use weighted cooldown and 2. actually loop filler infinitely
