### PR TITLE
docs: establish ChannelForge foundation and attribution

### DIFF
--- a/LICENSES/tunarr-zlib.txt
+++ b/LICENSES/tunarr-zlib.txt
@@ -1,0 +1,19 @@
+zlib License
+
+Copyright (c) 2020 Dan Ferguson, Victor Hugo Soliz Kuncar
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,21 @@
+# ChannelForge Notices
+
+ChannelForge is an independent open-source virtual television project derived
+in part from the Tunarr codebase.
+
+The original Tunarr source code is distributed under the zlib License. A copy
+of that license is retained at:
+
+`LICENSES/tunarr-zlib.txt`
+
+ChannelForge preserves the inherited repository history so that the origin of
+the underlying work remains traceable. Changes made for ChannelForge are
+identified through Git history, release records, and project documentation.
+
+ChannelForge introduces its own product direction, including a network-first
+programming model, deterministic programming rules, network templates,
+programming packs, network health analysis, branding, interface, terminology,
+and roadmap.
+
+ChannelForge is an independent project and is not represented as the original
+Tunarr software or as work authored entirely by the ChannelForge maintainers.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,71 @@
+# ChannelForge Architecture
+
+## Mission
+
+**Build television networks, not playlists.**
+
+ChannelForge allows users to define the identity and programming strategy of a
+television network. The application then builds and maintains the network's
+schedule using deterministic, explainable rules.
+
+## Current Phase
+
+ChannelForge is currently in its architecture and foundation phase.
+
+No broad package renaming, branding replacement, database migration, or
+functional redesign should begin until the core domain boundaries and migration
+strategy are documented.
+
+## Technical Foundation
+
+ChannelForge uses portions of Tunarr's existing open-source runtime foundation
+to avoid rebuilding mature virtual television infrastructure unnecessarily.
+
+Inherited or adapted areas may include:
+
+- Plex, Jellyfin, and Emby integrations
+- Media-library synchronization
+- FFmpeg orchestration
+- Stream-session management
+- IPTV playlist output
+- XMLTV guide generation
+- HDHomeRun-compatible output
+- Existing scheduling primitives
+- Docker deployment infrastructure
+
+## ChannelForge Product Layer
+
+ChannelForge will introduce or substantially redesign:
+
+- Networks and network identities
+- Editorial and audience profiles
+- Dayparts and programming blocks
+- Deterministic schedule planning
+- Hard constraints and weighted preferences
+- Network templates
+- Programming packs
+- Programming Director recommendations
+- Network health metrics
+- Multi-user authorization
+- Plugin contracts
+- ChannelForge branding and interface
+
+## Architectural Rules
+
+1. Scheduling and playout remain separate subsystems.
+2. The media catalog remains independent of any single media server.
+3. Scheduling must be deterministic when given the same inputs and seed.
+4. Hard constraints cannot be overridden by weighted preferences.
+5. Integrations communicate through explicit adapter contracts.
+6. Plugins do not receive unrestricted database or process access.
+7. Docker Compose remains the canonical deployment model.
+8. Unraid support is implemented as a deployment wrapper around the canonical
+   container configuration.
+9. Inherited Tunarr code remains attributable and traceable.
+10. Architecture decisions are recorded before major implementation work.
+
+## Architecture Decision Records
+
+Architecture Decision Records are stored in:
+
+`docs/architecture/adr/`

--- a/docs/architecture/adr/0001-tunarr-runtime-foundation.md
+++ b/docs/architecture/adr/0001-tunarr-runtime-foundation.md
@@ -1,0 +1,66 @@
+# ADR-0001: Use Tunarr as the Runtime Foundation
+
+- **Status:** Accepted
+- **Date:** 2026-07-26
+- **Decision owners:** ChannelForge maintainers
+
+## Context
+
+ChannelForge requires substantial virtual television infrastructure, including
+media-server integrations, media synchronization, FFmpeg process management,
+stream sessions, IPTV output, XMLTV generation, HDHomeRun compatibility, and
+Docker deployment.
+
+Tunarr already provides mature implementations of many of these capabilities
+under the permissive zlib License.
+
+Rebuilding all of these systems before validating ChannelForge's network-first
+programming model would consume significant development effort without creating
+the project's primary differentiator.
+
+## Decision
+
+ChannelForge will preserve Tunarr's repository history and use portions of its
+runtime architecture and source code as a technical foundation.
+
+ChannelForge will build a distinct product and domain layer above that
+foundation. The defining ChannelForge model will organize programming around
+networks, editorial identities, dayparts, blocks, deterministic rules,
+templates, programming packs, and network-health analysis.
+
+Inherited code will remain attributable. Altered versions will be identifiable
+through Git history and project documentation.
+
+The initial implementation will remain a modular monolith. Existing runtime
+components will be isolated behind explicit interfaces before major internal
+replacement or extraction is attempted.
+
+## Consequences
+
+### Positive
+
+- Existing media-server integrations can be retained and adapted.
+- Proven FFmpeg and streaming behavior does not need to be rebuilt immediately.
+- IPTV, XMLTV, and HDHomeRun compatibility can remain available during the
+  ChannelForge transition.
+- Existing tests provide regression coverage.
+- Development can focus on ChannelForge's network-first programming model.
+
+### Negative
+
+- Some inherited modules are coupled to Tunarr terminology and assumptions.
+- The current SQLite persistence layer limits immediate PostgreSQL adoption.
+- The existing frontend does not match the planned ChannelForge interface.
+- Package names, configuration keys, paths, and documentation will require a
+  controlled migration.
+- Upstream fixes cannot always be merged automatically after substantial
+  divergence.
+
+## Constraints
+
+- Do not claim inherited Tunarr code as original ChannelForge work.
+- Do not remove or alter the inherited zlib license notice.
+- Do not perform a mass rename before identifying compatibility boundaries.
+- Do not couple the new programming engine directly to FFmpeg or stream-session
+  internals.
+- Preserve the tagged untouched baseline for comparison and recovery.


### PR DESCRIPTION
## Summary

Establishes the initial ChannelForge project foundation before functional development begins.

### Added

- Preserved Tunarr zlib license under `LICENSES/tunarr-zlib.txt`
- Added `NOTICE.md` documenting ChannelForge's relationship to Tunarr
- Added the initial ChannelForge architecture overview
- Added ADR-0001 defining Tunarr as the inherited runtime foundation
- Documented the separation between inherited runtime infrastructure and the new ChannelForge product layer

## Validation

- Dependency installation completed using:
  - Node.js 22.20.0
  - pnpm 10.28.0
- Baseline build passed:
  - 5 successful tasks
  - 0 failed build tasks
- Windows test run completed:
  - 1,069 tests passed
  - 43 tests failed due to Windows path handling and temporary SQLite file locking
- Working tree is clean

## Notes

This pull request makes no functional application changes and does not begin package renaming or branding replacement.