### PR TITLE
fix: don't let user's collection-grouping preference affect movie library scans

### DIFF
--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -156,6 +156,11 @@ export type JellyfinGetItemsQuery = {
   contributingArtistIds?: string[];
   excludeItemIds?: string[];
   albumArtistIds?: string[];
+  // Jellyfin defaults this to the connected user's own "Group movies into
+  // collections" display preference when omitted. Library scans need this to
+  // be explicitly false, or movies inside a BoxSet are silently collapsed
+  // into their parent collection and never returned as individual items.
+  collapseBoxSetItems?: boolean;
 };
 
 type JellyfinItemTypes = {
@@ -580,7 +585,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
       'Movie',
       (movie) => this.jellyfinApiMovieInjection(movie),
       [],
-      {},
+      { collapseBoxSetItems: false },
       pageSize,
     );
   }
@@ -901,6 +906,11 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
         limit: 0,
         recursive: true,
         includeItemTypes: itemType,
+        // See comment on JellyfinGetItemsQuery#collapseBoxSetItems — without
+        // this, counts (and therefore pagination) silently undercount any
+        // library containing BoxSet collections whenever the connected
+        // account has "Group movies into collections" enabled.
+        collapseBoxSetItems: false,
       },
     }).then((_) => _.map((response) => response.TotalRecordCount));
   }


### PR DESCRIPTION
# Fix: Movies inside a Jellyfin BoxSet collection are silently skipped during library scans

## The bug

`JellyfinApiClient.getMovieLibraryContents()` (and the pagination-count method
`getChildItemCount()`) call Jellyfin's `/Items` endpoint without ever setting
the `CollapseBoxSetItems` query parameter. When that parameter is omitted,
Jellyfin falls back to **the connected user account's own personal display
preference** ("Group movies into collections" under Settings → Display).

If that preference happens to be enabled for whichever account/API key Tunarr
authenticates as, Jellyfin collapses every movie that belongs to a BoxSet
collection down into just the collection's own summary entry — meaning none
of the individual movies inside any collection are returned by the scan at
all. `getChildItemCount()` has the same gap, so even the item *count* used to
drive pagination is wrong, undercounting by exactly the number of collected
movies.

## Repro

1. In Jellyfin, enable "Group movies into collections" (Settings → Display)
   on the account/API key Tunarr uses to connect
2. Have at least one Movie collection (BoxSet) in your library
3. Force-scan the Movies library in Tunarr
4. Search `type:movie` in Tunarr — movies belonging to any collection never
   appear, even though they exist and are taggable via other parts of the
   Jellyfin API (e.g. `/Items?ParentId={boxSetId}`)

This is easy to miss because it depends entirely on a per-user Jellyfin
setting that has nothing to do with Tunarr's own configuration, and the
symptom (some movies just... don't show up) doesn't produce an error anywhere.

## The fix

Explicitly pass `collapseBoxSetItems: false` on both the item-listing call
and the count call used during a movie library scan, so the scan's behavior
no longer depends on the connected account's personal Jellyfin UI
preference.

Three small changes in `server/src/external/jellyfin/JellyfinApiClient.ts`:

1. Added `collapseBoxSetItems?: boolean` to the `JellyfinGetItemsQuery` type
2. `getMovieLibraryContents()` now passes `{ collapseBoxSetItems: false }`
   instead of `{}`
3. `getChildItemCount()` now always sends `collapseBoxSetItems: false`