### PR TITLE
feat: add Block Shuffle ordering for Smart Collection slots

### DIFF
--- a/server/src/services/scheduling/ProgramChunkedShuffle.test.ts
+++ b/server/src/services/scheduling/ProgramChunkedShuffle.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'vitest';
+import { createFakeProgramOrm } from '../../testing/fakes/entityCreators.ts';
+import { ContentProgramBlockShuffle } from './ProgramChunkedShuffle.ts';
+import type { SlotSchedulerProgram } from './slotSchedulerUtil.ts';
+
+function makeEpisodes(
+  showUuid: string,
+  count: number,
+  durationMs: number = 60_000,
+): SlotSchedulerProgram[] {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      ({
+        ...createFakeProgramOrm({
+          uuid: `${showUuid}-ep-${i + 1}`,
+          title: `Episode ${i + 1}`,
+          type: 'episode',
+          duration: durationMs,
+          episode: i + 1,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          show: { uuid: showUuid, title: showUuid } as any,
+        }),
+        parentFillerLists: [],
+        parentCustomShows: [],
+        parentSmartCollections: [],
+      }) satisfies SlotSchedulerProgram,
+  );
+}
+
+function collect(
+  iterator: ContentProgramBlockShuffle,
+  count: number,
+): string[] {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const current = iterator.current();
+    ids.push(current!.id);
+    iterator.next();
+  }
+  return ids;
+}
+
+// Maps back from a minted content program id to the original fake episode's
+// title, to make assertions about "which show/episode played" readable.
+function toShowEpisode(id: string): [string, number] {
+  const match = /^(.+)-ep-(\d+)$/.exec(id);
+  if (!match) {
+    throw new Error(`Unexpected id shape: ${id}`);
+  }
+  return [match[1]!, Number(match[2])];
+}
+
+describe('ContentProgramBlockShuffle', () => {
+  test('plays blockSize episodes from one show before moving to the next', () => {
+    const showA = makeEpisodes('showA', 6);
+    const showB = makeEpisodes('showB', 6);
+    const iterator = new ContentProgramBlockShuffle(
+      [...showA, ...showB],
+      3,
+      true,
+    );
+
+    const ids = collect(iterator, 12);
+    const showsPlayed = ids.map((id) => toShowEpisode(id)[0]);
+
+    // Every group of 3 consecutive plays should be from the same show.
+    for (let i = 0; i < showsPlayed.length; i += 3) {
+      const block = showsPlayed.slice(i, i + 3);
+      expect(new Set(block).size).toBe(1);
+    }
+
+    // Both shows should have been played across the 12 slots (2 blocks each
+    // of 3, for 2 shows = 12 total).
+    expect(new Set(showsPlayed)).toEqual(new Set(['showA', 'showB']));
+  });
+
+  test('plays episodes within a show in order', () => {
+    const showA = makeEpisodes('showA', 6);
+    const iterator = new ContentProgramBlockShuffle(showA, 3, true);
+
+    const ids = collect(iterator, 6);
+    const episodeNumbers = ids.map((id) => toShowEpisode(id)[1]);
+
+    expect(episodeNumbers).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test('desc direction reverses in-show episode order', () => {
+    const showA = makeEpisodes('showA', 3);
+    const iterator = new ContentProgramBlockShuffle(showA, 3, true, false);
+
+    const ids = collect(iterator, 3);
+    const episodeNumbers = ids.map((id) => toShowEpisode(id)[1]);
+
+    expect(episodeNumbers).toEqual([3, 2, 1]);
+  });
+
+  test('loops a shorter show to match the longer show block-count when loopShortPrograms is true', () => {
+    const showA = makeEpisodes('showA', 6); // 2 blocks of 3
+    const showB = makeEpisodes('showB', 3); // 1 block of 3, needs to loop once more
+
+    const iterator = new ContentProgramBlockShuffle(
+      [...showA, ...showB],
+      3,
+      true,
+    );
+
+    const ids = collect(iterator, 12);
+    const showBPlays = ids
+      .map(toShowEpisode)
+      .filter(([show]) => show === 'showB');
+
+    // showB only has 3 episodes but should appear in both of the 2 blocks
+    // (6 total plays), looping back to episode 1 for the second block.
+    expect(showBPlays.length).toBe(6);
+    expect(showBPlays.map(([, ep]) => ep)).toEqual([1, 2, 3, 1, 2, 3]);
+  });
+
+  test('does not loop a shorter show when loopShortPrograms is false', () => {
+    const showA = makeEpisodes('showA', 6); // 2 blocks of 3
+    const showB = makeEpisodes('showB', 3); // 1 block of 3, no second block
+
+    const iterator = new ContentProgramBlockShuffle(
+      [...showA, ...showB],
+      3,
+      false,
+    );
+
+    const ids = collect(iterator, 9);
+    const showBPlays = ids
+      .map(toShowEpisode)
+      .filter(([show]) => show === 'showB');
+
+    // Without looping, showB only ever contributes its original 3 episodes
+    // once, even though the full rotation (driven by showA) is longer.
+    expect(showBPlays.length).toBe(3);
+  });
+
+  test('handles a single group the same as a simple ordered rotation', () => {
+    const showA = makeEpisodes('showA', 4);
+    const iterator = new ContentProgramBlockShuffle(showA, 2, true);
+
+    const ids = collect(iterator, 4);
+    const episodeNumbers = ids.map((id) => toShowEpisode(id)[1]);
+
+    expect(episodeNumbers).toEqual([1, 2, 3, 4]);
+  });
+
+  test('returns an empty iterator for an empty program list', () => {
+    const iterator = new ContentProgramBlockShuffle([], 3, true);
+    expect(iterator.current()).toBeNull();
+  });
+
+  test('the iterator wraps around and repeats from the start', () => {
+    const showA = makeEpisodes('showA', 2);
+    const iterator = new ContentProgramBlockShuffle(showA, 2, true);
+
+    const ids = collect(iterator, 4); // 2 episodes, ask for 4 -> should wrap
+    const episodeNumbers = ids.map((id) => toShowEpisode(id)[1]);
+
+    expect(episodeNumbers).toEqual([1, 2, 1, 2]);
+  });
+});

--- a/server/src/services/scheduling/ProgramChunkedShuffle.ts
+++ b/server/src/services/scheduling/ProgramChunkedShuffle.ts
@@ -1,10 +1,13 @@
 import { seq } from '@tunarr/shared/util';
+import { isNonEmptyString } from '@tunarr/shared/util';
 import type {
   CondensedChannelProgram,
   CondensedContentProgram,
 } from '@tunarr/types';
 import type { CondensedCustomProgram } from '@tunarr/types/schemas';
-import { orderBy } from 'lodash-es';
+import { chunk, orderBy } from 'lodash-es';
+import { P, match } from 'ts-pattern';
+import { getProgramOrderer } from './ProgramIterator.js';
 import { IndexBasedProgramIterator } from './ProgramIterator.js';
 import { random } from './RandomSlotsService.ts';
 import {
@@ -59,6 +62,158 @@ export class CustomProgramChunkedShuffle extends ProgramChunkedShuffle<Condensed
       id: program.uuid,
       index: this.indexById[program.uuid]!,
       type: 'custom',
+    };
+  }
+}
+
+/**
+ * Groups programs by their "show" (or equivalent grouping unit -- artist for
+ * tracks, a single shared bucket for movies/music videos/other videos, since
+ * those aren't naturally grouped into a series the way episodes are).
+ *
+ * Mirrors the grouping key used by createProgramMap in slotSchedulerUtil.ts,
+ * but operates over an already-resolved flat list rather than building the
+ * full ProgramMapping.
+ */
+function groupProgramsForBlockShuffle(
+  programs: SlotSchedulerProgram[],
+): Map<string, SlotSchedulerProgram[]> {
+  const groups = new Map<string, SlotSchedulerProgram[]>();
+  for (const program of programs) {
+    const key = match(program)
+      .returnType<string>()
+      .with(
+        { type: P.union('movie', 'music_video', 'other_video') },
+        () => 'movie',
+      )
+      .with(
+        { type: 'episode', show: { uuid: P.when(isNonEmptyString) } },
+        (ep) => `show.${ep.show.uuid}`,
+      )
+      .with(
+        { type: 'episode', tvShowUuid: P.when(isNonEmptyString) },
+        (ep) => `show.${ep.tvShowUuid}`,
+      )
+      .with(
+        { type: 'track', artist: { uuid: P.when(isNonEmptyString) } },
+        (track) => `artist.${track.artist.uuid}`,
+      )
+      .otherwise(() => 'ungrouped');
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(program);
+    } else {
+      groups.set(key, [program]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Implements "Block Shuffle" (N episodes per show, then move to the next
+ * show, looping back to the first once every show has had a turn) for a
+ * dynamically-resolved list of programs -- e.g. the contents of a Smart
+ * Collection at schedule-generation time.
+ *
+ * This mirrors the client-side-only algorithm in
+ * web/src/hooks/programming_controls/useBlockShuffle.ts (grouping, chunking,
+ * and optional short-program looping), adapted to run server-side against
+ * SlotSchedulerProgram so it can be used as a genuine slot ordering mode
+ * rather than a one-time reorder of an already-static program list.
+ */
+export class ContentProgramBlockShuffle extends IndexBasedProgramIterator<CondensedContentProgram> {
+  constructor(
+    programs: SlotSchedulerProgram[],
+    blockSize: number,
+    loopShortPrograms: boolean = true,
+    asc: boolean = true,
+  ) {
+    super(
+      ContentProgramBlockShuffle.buildBlockShuffledList(
+        programs,
+        Math.max(1, Math.floor(blockSize)),
+        loopShortPrograms,
+        asc,
+      ),
+    );
+  }
+
+  private static buildBlockShuffledList(
+    programs: SlotSchedulerProgram[],
+    blockSize: number,
+    loopShortPrograms: boolean,
+    asc: boolean,
+  ): SlotSchedulerProgram[] {
+    if (programs.length === 0) {
+      return [];
+    }
+
+    const orderer = getProgramOrderer('next');
+    const groups = groupProgramsForBlockShuffle(programs);
+
+    // Sort each group's programs by their natural episode/track order, then
+    // chunk into blocks of `blockSize`.
+    const chunkedGroups = new Map<string, SlotSchedulerProgram[][]>();
+    for (const [key, groupPrograms] of groups) {
+      const sorted = orderBy(groupPrograms, orderer, [asc ? 'asc' : 'desc']);
+      chunkedGroups.set(key, chunk(sorted, blockSize));
+    }
+
+    const maxChunkCount = Math.max(
+      ...Array.from(chunkedGroups.values(), (chunks) => chunks.length),
+    );
+
+    if (loopShortPrograms) {
+      for (const [key, groupPrograms] of groups) {
+        const chunks = chunkedGroups.get(key)!;
+        if (chunks.length < maxChunkCount && groupPrograms.length > 0) {
+          const sorted = orderBy(groupPrograms, orderer, [
+            asc ? 'asc' : 'desc',
+          ]);
+          const targetLength = maxChunkCount * blockSize;
+          const padded = [...sorted];
+          let i = 0;
+          while (padded.length < targetLength) {
+            padded.push(sorted[i % sorted.length]!);
+            i++;
+          }
+          chunkedGroups.set(key, chunk(padded, blockSize));
+        }
+      }
+    }
+
+    // Randomize the starting rotation offset (which group airs "first" in
+    // the loop) but keep a stable group order thereafter, mirroring
+    // ContentProgramChunkedShuffle's use of a random start point rather than
+    // a fully random shuffle each generation.
+    const groupKeys = seq.rotateArray(
+      Array.from(chunkedGroups.keys()),
+      random.integer(0, chunkedGroups.size),
+    );
+
+    const result: SlotSchedulerProgram[] = [];
+    for (let i = 0; i < maxChunkCount; i++) {
+      for (const key of groupKeys) {
+        const chunks = chunkedGroups.get(key)!;
+        // Do NOT modulo-wrap here: padding above already extends every
+        // group to maxChunkCount chunks when loopShortPrograms is true. If
+        // it's false, a group simply has fewer chunks and should drop out
+        // of later rounds entirely, rather than silently repeating.
+        const block = chunks[i];
+        if (block) {
+          result.push(...block);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  protected mint(program: SlotSchedulerProgram): CondensedContentProgram {
+    return {
+      type: 'content',
+      duration: program.duration,
+      id: program.uuid,
     };
   }
 }

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -53,6 +53,7 @@ import {
   resolveBreakPoints,
 } from './midRollBreakRules.ts';
 import {
+  ContentProgramBlockShuffle,
   ContentProgramChunkedShuffle,
   CustomProgramChunkedShuffle,
 } from './ProgramChunkedShuffle.ts';
@@ -382,6 +383,13 @@ export function createSlotProgramIterator(
             getProgramOrderer('next'),
             slot.direction === 'asc',
           );
+        case 'block':
+          return new ContentProgramBlockShuffle(
+            programs,
+            slot.blockSize ?? 3,
+            slot.loopShortPrograms ?? true,
+            slot.direction === 'asc',
+          );
       }
     })
     .exhaustive();
@@ -626,6 +634,16 @@ function getContentProgramIterator(
     case 'shuffle':
       return new ContentProgramShuffleIterator(programs, random);
     case 'ordered_shuffle':
+      return new ContentProgramChunkedShuffle(
+        programs,
+        getProgramOrderer('next'),
+        slot.direction === 'asc',
+      );
+    case 'block':
+      // Movie/show slots only ever contain a single group (all movies, or
+      // a single show's own episodes), so there's nothing meaningful to
+      // alternate between -- fall back to the same behavior as
+      // ordered_shuffle rather than leaving this order type unhandled.
       return new ContentProgramChunkedShuffle(
         programs,
         getProgramOrderer('next'),

--- a/types/src/api/CommonSlots.ts
+++ b/types/src/api/CommonSlots.ts
@@ -6,6 +6,7 @@ export const SlotProgrammingOrderSchema = z.enum([
   'ordered_shuffle',
   'alphanumeric',
   'chronological',
+  'block',
 ]);
 
 export const SlotProgrammingFillerOrder = z.enum([
@@ -206,6 +207,15 @@ export const SmartCollectionProgrammingSlot = z.object({
   smartCollectionId: z.uuid(),
   ...BaseSlotOrdering.shape,
   ...Slot.shape,
+  // Only meaningful when order === 'block'. Number of consecutive
+  // episodes/programs to play from one show/group before moving to the
+  // next.
+  blockSize: z.number().int().positive().default(3).optional(),
+  // Only meaningful when order === 'block'. When true, groups with fewer
+  // programs than the largest group are looped (repeated from the start)
+  // so every group completes the same number of blocks before the whole
+  // rotation repeats, rather than shorter shows dropping out early.
+  loopShortPrograms: z.boolean().default(true).optional(),
 });
 
 export const BaseSlotSchema = z.discriminatedUnion('type', [

--- a/web/src/components/slot_scheduler/SlotOrderFormControl.tsx
+++ b/web/src/components/slot_scheduler/SlotOrderFormControl.tsx
@@ -1,11 +1,14 @@
 import { Trans, useLingui } from '@lingui/react/macro';
 import {
+  Checkbox,
   FormControl,
+  FormControlLabel,
   FormHelperText,
   InputLabel,
   MenuItem,
   Select,
   Stack,
+  TextField,
   ToggleButton,
   ToggleButtonGroup,
 } from '@mui/material';
@@ -73,7 +76,8 @@ export const SlotOrderFormControl = () => {
       order === 'alphanumeric' ||
       order === 'next' ||
       order === 'ordered_shuffle' ||
-      order === 'chronological'
+      order === 'chronological' ||
+      order === 'block'
     ) {
       return (
         <Controller
@@ -104,31 +108,73 @@ export const SlotOrderFormControl = () => {
     return null;
   }
 
-  return (
-    <Stack direction="row" spacing={2}>
-      <Controller
-        control={control}
-        name="order"
-        render={({ field }) => {
-          const opts = slotOrderOptions(type);
-          const helperText = find(opts, { value: field.value })?.helperText;
-          return (
-            <FormControl fullWidth>
-              <InputLabel>{t`Order`}</InputLabel>
-              <Select label={t`Order`} disabled={false} {...field}>
-                {map(opts, ({ description, value }) => (
-                  <MenuItem key={value} value={value}>
-                    {description}
-                  </MenuItem>
-                ))}
-              </Select>
-              {helperText && <FormHelperText>{helperText}</FormHelperText>}
-            </FormControl>
-          );
-        }}
-      />
+  const blockShuffleControls =
+    type === 'smart-collection' && order === 'block' ? (
+      <Stack direction="row" spacing={2} alignItems="center">
+        <Controller
+          control={control}
+          name="blockSize"
+          render={({ field }) => (
+            <TextField
+              {...field}
+              type="number"
+              label={t`Block Size`}
+              helperText={t`Episodes per show before switching`}
+              slotProps={{ htmlInput: { min: 1 } }}
+              onChange={(e) =>
+                field.onChange(
+                  e.target.value === '' ? '' : Number(e.target.value),
+                )
+              }
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="loopShortPrograms"
+          render={({ field }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={field.value}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                />
+              }
+              label={t`Loop Short Programs`}
+            />
+          )}
+        />
+      </Stack>
+    ) : null;
 
-      {directionComponent}
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <Controller
+          control={control}
+          name="order"
+          render={({ field }) => {
+            const opts = slotOrderOptions(type);
+            const helperText = find(opts, { value: field.value })?.helperText;
+            return (
+              <FormControl fullWidth>
+                <InputLabel>{t`Order`}</InputLabel>
+                <Select label={t`Order`} disabled={false} {...field}>
+                  {map(opts, ({ description, value }) => (
+                    <MenuItem key={value} value={value}>
+                      {description}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {helperText && <FormHelperText>{helperText}</FormHelperText>}
+              </FormControl>
+            );
+          }}
+        />
+
+        {directionComponent}
+      </Stack>
+      {blockShuffleControls}
     </Stack>
   );
 };

--- a/web/src/components/slot_scheduler/SlotOrderFormControl.tsx
+++ b/web/src/components/slot_scheduler/SlotOrderFormControl.tsx
@@ -84,20 +84,23 @@ export const SlotOrderFormControl = () => {
           control={control}
           name="direction"
           render={({ field }) => (
-            <ToggleButtonGroup
-              exclusive
-              value={field.value}
-              onChange={(_, value) =>
-                handleDirectionChange(value as string | null, field.onChange)
-              }
-            >
-              <ToggleButton value="asc">
-                <Trans>Asc</Trans>
-              </ToggleButton>
-              <ToggleButton value="desc">
-                <Trans>Desc</Trans>
-              </ToggleButton>
-            </ToggleButtonGroup>
+            <Stack sx={{ minWidth: 240, maxWidth: 320, width: '100%' }}>
+              <ToggleButtonGroup
+                exclusive
+                value={field.value}
+                onChange={(_, value) =>
+                  handleDirectionChange(value as string | null, field.onChange)
+                }
+                sx={{ width: '100%' }}
+              >
+                <ToggleButton value="asc">
+                  <Trans>Asc</Trans>
+                </ToggleButton>
+                <ToggleButton value="desc">
+                  <Trans>Desc</Trans>
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Stack>
           )}
         />
       );
@@ -110,7 +113,7 @@ export const SlotOrderFormControl = () => {
 
   const blockShuffleControls =
     type === 'smart-collection' && order === 'block' ? (
-      <Stack direction="row" spacing={2} alignItems="center">
+      <Stack direction="row" flexWrap="wrap" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
         <Controller
           control={control}
           name="blockSize"
@@ -126,14 +129,17 @@ export const SlotOrderFormControl = () => {
                   e.target.value === '' ? '' : Number(e.target.value),
                 )
               }
+              sx={{ minWidth: 240, maxWidth: 320, flex: '1 1 320px' }}
             />
           )}
         />
+
         <Controller
           control={control}
           name="loopShortPrograms"
           render={({ field }) => (
             <FormControlLabel
+              sx={{ m: 0, alignSelf: 'flex-start' }}
               control={
                 <Checkbox
                   checked={field.value}
@@ -149,7 +155,7 @@ export const SlotOrderFormControl = () => {
 
   return (
     <Stack spacing={2}>
-      <Stack direction="row" spacing={2}>
+      <Stack direction="row" spacing={2} alignItems="flex-start">
         <Controller
           control={control}
           name="order"

--- a/web/src/helpers/slotSchedulerUtil.ts
+++ b/web/src/helpers/slotSchedulerUtil.ts
@@ -179,6 +179,12 @@ const OrderedShuffleSortOpt = {
   value: 'ordered_shuffle',
   description: 'Ordered Shuffle',
 } as const;
+const BlockShuffleSortOpt = {
+  value: 'block',
+  description: 'Block Shuffle',
+  helperText:
+    'Plays a fixed number of episodes from each show before moving to the next',
+} as const;
 const ShufflePreferLongSortOpt = {
   value: 'shuffle_prefer_long',
   description: 'Shuffle (prefer long)',
@@ -220,6 +226,7 @@ export function slotOrderOptions(
       ShuffleSortOpt,
       NextEpSortOpt,
       OrderedShuffleSortOpt,
+      BlockShuffleSortOpt,
     ])
     .exhaustive();
 }

--- a/web/src/model/CommonSlotModels.ts
+++ b/web/src/model/CommonSlotModels.ts
@@ -112,6 +112,9 @@ export const CommonSmartCollectionViewModel = z.object({
   smartCollectionId: z.uuid(),
   smartCollection: SmartCollection.nullable(),
   isMissing: z.boolean().optional().default(false),
+  // Only meaningful when order === 'block'.
+  blockSize: z.number().int().positive().default(3),
+  loopShortPrograms: z.boolean().default(true),
 });
 
 export type CommonSmartCollectionViewModel = z.infer<


### PR DESCRIPTION
# Feature: "Block Shuffle" ordering for Smart Collection slots

## The gap

Tunarr's standalone Block Shuffle tool (the modal with "# of Programs" /
Type / Loop Short Programs) only operates on a channel's already-populated,
static programming list — it's entirely a client-side reorder
(`web/src/hooks/programming_controls/useBlockShuffle.ts`) of programs added
via "Add Media." It has no way to work against a Smart Collection, since a
Smart Collection's contents are resolved dynamically by the server at
schedule-generation time, not materialized in the browser.

Meanwhile, the Smart Collection slot's `order` field only supports `next`,
`shuffle`, `ordered_shuffle`, `alphanumeric`, and `chronological` — none of
which alternate a fixed number of episodes per show before moving to the
next show. For a Smart Collection spanning many shows (e.g. all shows tagged
"sitcom"), there was no way to get block-style pacing without giving up the
Smart Collection's auto-updating nature and switching to a static,
manually-curated program list.

## The fix

Adds `'block'` as a genuine server-side ordering mode for Smart Collection
slots, implemented as a new `ProgramIterator`
(`ContentProgramBlockShuffle` in `ProgramChunkedShuffle.ts`) that:

1. Groups the Smart Collection's resolved programs by show (or a single
   shared group for movies/music videos/other videos, and by artist for
   tracks — mirroring the grouping used elsewhere in the scheduler, e.g.
   `createProgramMap`)
2. Sorts each group by its natural order (season/episode number for
   episodes, matching the existing `next` orderer) and chunks into blocks of
   `blockSize`
3. Interleaves blocks across groups, so N episodes of one show play, then N
   of the next, cycling through all groups before repeating
4. Optionally pads shorter groups (via `loopShortPrograms`) so every group
   completes the same number of blocks before the whole rotation loops,
   rather than shorter shows dropping out of rotation early

This is adapted from the existing client-side `useBlockShuffle.ts` algorithm
(grouping/chunking/loop-short-programs), but reimplemented server-side so it
can run against a Smart Collection's dynamically-resolved program list
instead of a static array.

## Scope

- Only wired up for **Smart Collection** slots, since that's the reported
  gap. `'block'` is added to the shared order enum (so movie/show/custom-show
  slots don't break with an unhandled case), but for those slot types it
  falls back to the same behavior as `ordered_shuffle` — there's only ever
  one group in a movie or single-show slot, so there's nothing meaningful to
  alternate between. A maintainer may want a cleaner way to express "not
  applicable" for those slot types than a silent fallback; open to feedback
  on that.
- New optional fields on the Smart Collection slot schema: `blockSize`
  (default 3) and `loopShortPrograms` (default true) — both no-ops unless
  `order === 'block'`.
- Frontend: `'block'` added to the Smart Collection order dropdown, with a
  block-size input and loop-short-programs checkbox shown when selected.
