### PR TITLE
fix: multiple fixes to filler in slot editors

### DIFF
--- a/docs/configure/scheduling/concepts.md
+++ b/docs/configure/scheduling/concepts.md
@@ -19,3 +19,5 @@
     * **Tail**: Filler that plays at the _end_ of each slot
     * **Mid**: Filler that plays during [mid-roll breaks](mid-roll-breaks.md) inserted _within_ a program
     * **Fallback**: Filler that is played during flex time in the slot
+
+    Filler is placed *inside* the slot rather than added on top of it: head, pre, post, and tail filler draw from the slot's unused time, including any *padding* applied to the programs around them. A slot only omits filler when it has genuinely no time left to give.

--- a/server/src/services/scheduling/RandomSlotsService.test.ts
+++ b/server/src/services/scheduling/RandomSlotsService.test.ts
@@ -181,3 +181,113 @@ describe('randomSlotsService', () => {
     expect(seqA).not.toEqual(seqB);
   });
 });
+
+describe('random slot filler budgeting', () => {
+  const oneMin = 60 * 1000;
+  const slotMs = 30 * oneMin;
+  const midnight = dayjs('2024-01-01T00:00:00.000Z');
+
+  const makeEpisodes = (
+    showId: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `${showId}-ep${i + 1}`,
+        title: `${showId} Episode ${i + 1}`,
+        type: 'episode',
+        duration: durationMs,
+        episode: i + 1,
+        tvShowUuid: showId,
+        show: { uuid: showId },
+      }),
+      parentFillerLists: [],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  const makeFillers = (
+    fillerListId: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `bumper-${i}`,
+        title: `Bumper ${i}`,
+        type: 'movie',
+        duration: durationMs,
+      }),
+      parentFillerLists: [fillerListId],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  test('post-roll filler on a later program cannot overflow a fixed duration slot', () => {
+    const fillerListId = randomUUID();
+
+    const scheduler = new RandomSlotScheduler({
+      type: 'random',
+      flexPreference: 'end',
+      maxDays: 1,
+      padMs: oneMin,
+      padStyle: 'episode',
+      randomDistribution: 'uniform',
+      lockWeights: false,
+      slots: [
+        {
+          weight: 100,
+          cooldownMs: 0,
+          durationSpec: { type: 'fixed', durationMs: slotMs },
+          type: 'show',
+          showId: 'show1',
+          order: 'next',
+          direction: 'asc',
+          seasonFilter: [],
+          filler: [
+            {
+              types: ['post'],
+              fillerListId,
+              fillerOrder: 'shuffle_prefer_short',
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = scheduler.generateSchedule(
+      [
+        ...makeEpisodes('show1', 12, 5 * oneMin),
+        // Only fits at the top of a slot; budgeting it against the whole slot
+        // instead of the remaining time overruns the slot's duration.
+        ...makeFillers(fillerListId, 3, 12 * oneMin),
+      ],
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    // A 30 minute slot holding 5 minute episodes can afford exactly one
+    // 12 minute post-roll: after the first episode and its bumper there are
+    // 13 minutes left, which is not enough for a second one. Budgeting the
+    // bumper against the whole slot rather than the time actually left over
+    // buys a second one and overruns the slot.
+    const shape = result.lineup
+      .slice(0, 6)
+      .map((item) =>
+        item.type === 'content' && 'id' in item
+          ? `content:${item.id}`
+          : `${item.type}:${item.duration / oneMin}min`,
+      );
+
+    expect(shape).toEqual([
+      'content:show1-ep1',
+      'filler:12min',
+      'content:show1-ep2',
+      'content:show1-ep3',
+      'content:show1-ep4',
+      'filler:12min',
+    ]);
+  });
+});

--- a/server/src/services/scheduling/RandomSlotsService.ts
+++ b/server/src/services/scheduling/RandomSlotsService.ts
@@ -451,7 +451,7 @@ export class RandomSlotScheduler {
       maybeAddPrePostFiller(
         currSlot,
         nextPadded,
-        slotDuration - nextPadded.totalDuration,
+        slotDuration - totalDuration - nextPadded.totalDuration,
         +context.timeCursor + totalDuration,
       );
       totalDuration += nextPadded.totalDuration;

--- a/server/src/services/scheduling/SlotImpl.ts
+++ b/server/src/services/scheduling/SlotImpl.ts
@@ -10,6 +10,21 @@ import type { Random } from 'random-js';
 import type { Nullable } from '../../types/util.ts';
 import type { IterationState, ProgramIterator } from './ProgramIterator.js';
 
+/**
+ * A negative or non-finite {@link IterationState#slotDuration} is the caller's
+ * way of saying "pick anything" (fallback filler), so only a finite,
+ * non-negative budget constrains the pick.
+ */
+function fillerFitsAvailableTime(
+  filler: FillerProgram,
+  state: IterationState,
+): boolean {
+  if (!Number.isFinite(state.slotDuration) || state.slotDuration < 0) {
+    return true;
+  }
+  return filler.duration <= state.slotDuration;
+}
+
 export abstract class SlotImpl<
   SlotType extends BaseSlot,
   ProgramT extends CondensedChannelProgram = CondensedChannelProgram,
@@ -73,10 +88,21 @@ export abstract class SlotImpl<
     // Random pick right now
     const it = this.random.pick(its);
     const filler = it.current(state);
-    if (filler) {
-      it.next();
+    if (!filler) {
+      return null;
     }
-    return filler;
+
+    it.next();
+
+    // Not every iterator constrains its picks by the available time (index
+    // based orderings such as "uniform" hand back whatever is next in the
+    // shuffle). Reject an item that doesn't fit so it can't overflow the slot
+    // -- the iterator has already advanced, so a retry gets a new candidate.
+    if (!fillerFitsAvailableTime(filler, state)) {
+      return null;
+    }
+
+    return { ...filler, fillerType: type };
   }
 
   hasFillerOfType(type: SlotFillerTypes) {

--- a/server/src/services/scheduling/TimeSlotService.test.ts
+++ b/server/src/services/scheduling/TimeSlotService.test.ts
@@ -2548,3 +2548,455 @@ describe('TimeSlotService', () => {
     });
   });
 });
+
+describe('slot filler placement', () => {
+  const oneMin = 60 * 1000;
+  const midnight = dayjs('2024-01-01T00:00:00.000Z').utc();
+
+  const makeShortEpisodes = (
+    showId: string,
+    count: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `${showId}-ep${i + 1}`,
+        title: `${showId} Episode ${i + 1}`,
+        type: 'episode',
+        // 7-11 minute episodes, several of which fit in a 30 minute slot
+        duration: (7 + (i % 5)) * oneMin,
+        episode: i + 1,
+        tvShowUuid: showId,
+        show: { uuid: showId },
+      }),
+      parentFillerLists: [],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  const makeFillers = (
+    fillerListId: string,
+    prefix: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `${prefix}-${i}`,
+        title: `${prefix} ${i}`,
+        type: 'movie',
+        duration: durationMs,
+      }),
+      parentFillerLists: [fillerListId],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  type LineupItem = {
+    type: string;
+    id?: string;
+    duration: number;
+    fillerType?: string;
+  };
+
+  test('head/tail filler is emitted even when every program is padded', async () => {
+    const headList = randomUUID();
+    const bumperList = randomUUID();
+    const tailList = randomUUID();
+    const shows = ['show1', 'show2', 'show3'];
+
+    const schedule: TimeSlotSchedule = {
+      type: 'time',
+      period: 'day',
+      maxDays: 1,
+      flexPreference: 'end',
+      // A pad this large pads every short episode out to the boundary, which
+      // used to make the slot look "full" and starve head/tail filler.
+      padMs: 15 * oneMin,
+      latenessMs: 0,
+      timeZoneOffset: 0,
+      slots: shows.map((showId, i) => ({
+        id: randomUUID(),
+        startTime: i * 30 * oneMin,
+        type: 'show',
+        showId,
+        order: 'next',
+        direction: 'asc',
+        seasonFilter: [],
+        filler: [
+          {
+            types: ['head'],
+            fillerListId: headList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+          {
+            types: ['pre', 'post'],
+            fillerListId: bumperList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+          {
+            types: ['tail'],
+            fillerListId: tailList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+        ],
+      })),
+    };
+
+    const result = await scheduleTimeSlots(
+      schedule,
+      [
+        ...shows.flatMap((s) => makeShortEpisodes(s, 12)),
+        ...makeFillers(headList, 'head', 4, 30 * 1000),
+        ...makeFillers(bumperList, 'bumper', 6, 15 * 1000),
+        ...makeFillers(tailList, 'tail', 4, 30 * 1000),
+      ],
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    const lineup = result.lineup as LineupItem[];
+    const byType = (t: string) =>
+      lineup.filter((p) => p.type === 'filler' && p.fillerType === t);
+
+    expect(byType('head').length).toBeGreaterThan(0);
+    expect(byType('tail').length).toBeGreaterThan(0);
+    // Every emitted head/tail should come from the list it was assigned to.
+    expect(byType('head').every((p) => p.id?.startsWith('head-'))).toBe(true);
+    expect(byType('tail').every((p) => p.id?.startsWith('tail-'))).toBe(true);
+  });
+
+  test('head filler opens a slot and tail filler closes it, across back-to-back slots', async () => {
+    const headList = randomUUID();
+    const tailList = randomUUID();
+    const shows = ['show1', 'show2', 'show3'];
+
+    const schedule: TimeSlotSchedule = {
+      type: 'time',
+      period: 'day',
+      maxDays: 1,
+      flexPreference: 'end',
+      padMs: 5 * oneMin,
+      latenessMs: 0,
+      timeZoneOffset: 0,
+      slots: shows.map((showId, i) => ({
+        id: randomUUID(),
+        startTime: i * 30 * oneMin,
+        type: 'show',
+        showId,
+        order: 'next',
+        direction: 'asc',
+        seasonFilter: [],
+        filler: [
+          {
+            types: ['head'],
+            fillerListId: headList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+          {
+            types: ['tail'],
+            fillerListId: tailList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+        ],
+      })),
+    };
+
+    const result = await scheduleTimeSlots(
+      schedule,
+      [
+        ...shows.flatMap((s) => makeShortEpisodes(s, 12)),
+        ...makeFillers(headList, 'head', 4, 30 * 1000),
+        ...makeFillers(tailList, 'tail', 4, 30 * 1000),
+      ],
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    const lineup = result.lineup as LineupItem[];
+
+    // Walk the lineup and record the offset of each head/tail item.
+    let offset = 0;
+    const headOffsets: number[] = [];
+    const tailOffsets: number[] = [];
+    for (const item of lineup) {
+      if (item.type === 'filler' && item.fillerType === 'head') {
+        headOffsets.push(offset);
+      } else if (item.type === 'filler' && item.fillerType === 'tail') {
+        tailOffsets.push(offset);
+      }
+      offset += item.duration;
+    }
+
+    expect(headOffsets.length).toBeGreaterThanOrEqual(3);
+    // Each head lands exactly on a slot boundary.
+    for (const o of headOffsets) {
+      expect(o % (30 * oneMin)).toBe(0);
+    }
+    // A tail always precedes the next slot's head rather than spilling into it.
+    for (const tail of tailOffsets) {
+      const nextBoundary = Math.ceil((tail + 1) / (30 * oneMin)) * 30 * oneMin;
+      expect(tail).toBeLessThan(nextBoundary);
+    }
+  });
+
+  test.each(['eager', 'lazy'] as const)(
+    'head filler plays before the program when %s mid-roll breaks split it',
+    async (strategy) => {
+      const headList = randomUUID();
+      const midList = randomUUID();
+
+      const episodes: SlotSchedulerProgram[] = [
+        {
+          ...createFakeProgramOrm({
+            uuid: 'show1-ep1',
+            title: 'Episode 1',
+            type: 'episode',
+            duration: 20 * oneMin,
+            episode: 1,
+            tvShowUuid: 'show1',
+            show: { uuid: 'show1' },
+          }),
+          parentFillerLists: [],
+          parentCustomShows: [],
+          parentSmartCollections: [],
+        },
+      ];
+
+      const schedule: TimeSlotSchedule = {
+        type: 'time',
+        period: 'day',
+        maxDays: 1,
+        flexPreference: 'end',
+        padMs: 30 * oneMin,
+        latenessMs: 0,
+        timeZoneOffset: 0,
+        slots: [
+          {
+            id: randomUUID(),
+            startTime: 0,
+            type: 'show',
+            showId: 'show1',
+            order: 'next',
+            direction: 'asc',
+            seasonFilter: [],
+            filler: [
+              {
+                types: ['head'],
+                fillerListId: headList,
+                fillerOrder: 'shuffle_prefer_short',
+              },
+              {
+                types: ['mid'],
+                fillerListId: midList,
+                fillerOrder: 'shuffle_prefer_short',
+              },
+            ],
+            midRoll: {
+              strategy,
+              breakRule: { type: 'fixed_interval', intervalMs: 8 * oneMin },
+              breakDurationMs: 30 * 1000,
+              maxBreaks: 2,
+              minProgramDurationMs: 0,
+              tailBufferMs: 0,
+            },
+          },
+        ],
+      };
+
+      const result = await scheduleTimeSlots(
+        schedule,
+        [
+          ...episodes,
+          ...makeFillers(headList, 'head', 3, 30 * 1000),
+          ...makeFillers(midList, 'mid', 3, 30 * 1000),
+        ],
+        [42, 99],
+        undefined,
+        midnight,
+      );
+
+      const lineup = result.lineup as LineupItem[];
+      const headIdx = lineup.findIndex(
+        (p) => p.type === 'filler' && p.fillerType === 'head',
+      );
+      const firstContentIdx = lineup.findIndex((p) => p.type === 'content');
+
+      expect(headIdx).toBeGreaterThanOrEqual(0);
+      // The head bumper must open the block, not trail the program's last segment.
+      expect(headIdx).toBeLessThan(firstContentIdx);
+    },
+  );
+
+  test('uniform-ordered filler never exceeds the time available to it', async () => {
+    const bumperList = randomUUID();
+
+    const schedule: TimeSlotSchedule = {
+      type: 'time',
+      period: 'day',
+      maxDays: 1,
+      flexPreference: 'end',
+      padMs: oneMin,
+      latenessMs: 0,
+      timeZoneOffset: 0,
+      // 30 minute slots covering the whole day, so that no slot is wide
+      // enough for the oversized filler to legitimately fit.
+      slots: Array.from({ length: 48 }, (_, i) => ({
+        id: randomUUID(),
+        startTime: i * 30 * oneMin,
+        type: 'show',
+        showId: `show${(i % 3) + 1}`,
+        order: 'next',
+        direction: 'asc',
+        seasonFilter: [],
+        filler: [
+          {
+            types: ['pre', 'post', 'head', 'tail'],
+            fillerListId: bumperList,
+            fillerOrder: 'uniform',
+          },
+        ],
+      })),
+    };
+
+    const result = await scheduleTimeSlots(
+      schedule,
+      [
+        ...['show1', 'show2', 'show3'].flatMap((s) => makeShortEpisodes(s, 12)),
+        // Deliberately mixes tiny bumpers with one item longer than any slot,
+        // which must never be selected to bracket or separate programs.
+        ...makeFillers(bumperList, 'bumper', 4, 15 * 1000),
+        ...makeFillers(bumperList, 'huge', 1, 45 * oneMin),
+      ],
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    const lineup = result.lineup as LineupItem[];
+    const oversized = lineup.filter(
+      (p) => p.type === 'filler' && p.id?.startsWith('huge-'),
+    );
+    expect(oversized).toHaveLength(0);
+  });
+});
+
+describe('slot filler budgeting', () => {
+  const oneMin = 60 * 1000;
+  const midnight = dayjs('2024-01-01T00:00:00.000Z').utc();
+  const slotMs = 30 * oneMin;
+
+  const makeEpisodesOfLength = (
+    showId: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `${showId}-ep${i + 1}`,
+        title: `${showId} Episode ${i + 1}`,
+        type: 'episode',
+        duration: durationMs,
+        episode: i + 1,
+        tvShowUuid: showId,
+        show: { uuid: showId },
+      }),
+      parentFillerLists: [],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  const makeFillersOfLength = (
+    fillerListId: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `bumper-${i}`,
+        title: `Bumper ${i}`,
+        type: 'movie',
+        duration: durationMs,
+      }),
+      parentFillerLists: [fillerListId],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  /**
+   * Returns the items that straddle a slot boundary. Flex is allowed to span
+   * one (it is what carries the lineup to the next slot start); anything else
+   * doing so means the slot overflowed.
+   */
+  const straddlingItems = (
+    lineup: { type: string; id?: string; duration: number }[],
+    horizonMs: number,
+  ) => {
+    const straddlers: { id?: string; start: number; end: number }[] = [];
+    let offset = 0;
+    for (const item of lineup) {
+      if (offset >= horizonMs) break;
+      const end = offset + item.duration;
+      const crosses =
+        Math.floor(offset / slotMs) !== Math.floor((end - 1) / slotMs);
+      if (crosses && item.type !== 'flex') {
+        straddlers.push({ id: item.id, start: offset, end });
+      }
+      offset = end;
+    }
+    return straddlers;
+  };
+
+  test('post-roll filler on a later program cannot overflow the slot', async () => {
+    const bumperList = randomUUID();
+
+    const schedule: TimeSlotSchedule = {
+      type: 'time',
+      period: 'day',
+      maxDays: 1,
+      flexPreference: 'end',
+      padMs: oneMin,
+      latenessMs: 0,
+      timeZoneOffset: 0,
+      slots: Array.from({ length: 48 }, (_, i) => ({
+        id: randomUUID(),
+        startTime: i * slotMs,
+        type: 'show',
+        showId: `show${(i % 2) + 1}`,
+        order: 'next',
+        direction: 'asc',
+        seasonFilter: [],
+        filler: [
+          {
+            types: ['post'],
+            fillerListId: bumperList,
+            fillerOrder: 'shuffle_prefer_short',
+          },
+        ],
+      })),
+    };
+
+    const result = await scheduleTimeSlots(
+      schedule,
+      [
+        ...makeEpisodesOfLength('show1', 12, 5 * oneMin),
+        ...makeEpisodesOfLength('show2', 12, 5 * oneMin),
+        // Long enough that it only fits early in a slot. Once a couple of
+        // programs are placed there is no longer room for it, and budgeting
+        // it against the whole slot rather than the remaining time pushes
+        // the block past the slot boundary.
+        ...makeFillersOfLength(bumperList, 3, 12 * oneMin),
+      ],
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    const straddlers = straddlingItems(
+      result.lineup as { type: string; id?: string; duration: number }[],
+      6 * 60 * oneMin,
+    );
+    expect(straddlers).toEqual([]);
+  });
+});

--- a/server/src/services/scheduling/TimeSlotService.ts
+++ b/server/src/services/scheduling/TimeSlotService.ts
@@ -301,7 +301,7 @@ export async function scheduleTimeSlots(
       maybeAddPrePostFiller(
         currSlot,
         nextPadded,
-        slotDuration - nextPadded.totalDuration,
+        slotDuration - totalAddedDuration - nextPadded.totalDuration,
         +timeCursor + totalAddedDuration,
       );
       totalAddedDuration += nextPadded.totalDuration;

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -22,6 +22,7 @@ import type { OfflineFillerConfig } from '@tunarr/types/schemas';
 import { FillerTypes } from '@tunarr/types/schemas';
 import type { Duration } from 'dayjs/plugin/duration.js';
 import {
+  first,
   forEach,
   isEmpty,
   isNil,
@@ -32,6 +33,7 @@ import {
   reject,
   sortBy,
   sumBy,
+  toPairs,
   uniq,
   uniqBy,
   values,
@@ -740,57 +742,32 @@ export function addHeadAndTailFillerToSlot(
   contentPrograms: NonEmptyArray<PaddedProgram>,
   timeCursor: number,
 ): number {
-  if (remainingTime <= 0) {
+  const lastProgram = contentPrograms[contentPrograms.length - 1];
+  if (lastProgram === undefined) {
     return remainingTime;
   }
 
-  if (remainingTime > 0 && slot.hasFillerOfType(FillerTypes.head)) {
-    const filler = retrySimple(
-      () =>
-        slot.getFillerOfType(FillerTypes.head, {
-          slotDuration: remainingTime,
-          timeCursor,
-          cooldownMs: 0,
-        }),
-      3,
-    );
+  // Head and tail filler draw from the same budget as pre/post filler: the
+  // slot's unallocated time _plus_ the adjacent program's padding. That
+  // padding is flex time, so reclaiming it for a bumper keeps the slot's
+  // total duration unchanged. Without it, a slot whose programs are all
+  // padded out to the schedule's pad boundary looks "full" and never gets
+  // head or tail filler at all.
+  remainingTime = maybeAddFillerOfType(
+    FillerTypes.head,
+    remainingTime,
+    slot,
+    contentPrograms[0],
+    timeCursor,
+  );
 
-    if (filler) {
-      remainingTime -= filler.duration;
-      contentPrograms[0].filler.head = filler;
-    }
-  }
-
-  // Save the last item's pad.
-  const lastItemPad = contentPrograms[contentPrograms.length - 1]!.padMs;
-  // Temporarily add it to the remaining time
-  // remainingTime += lastItemPad;
-  if (
-    remainingTime + lastItemPad > 0 &&
-    slot.hasFillerOfType(FillerTypes.tail)
-  ) {
-    const filler = retrySimple(
-      () =>
-        slot.getFillerOfType(FillerTypes.tail, {
-          slotDuration: remainingTime + lastItemPad,
-          timeCursor,
-          cooldownMs: 0,
-        }),
-      3,
-    );
-
-    if (filler) {
-      // Play the tail filler right after
-      contentPrograms[contentPrograms.length - 1]!.padMs = 0;
-      remainingTime = remainingTime + lastItemPad - filler.duration;
-      contentPrograms[contentPrograms.length - 1]!.filler.tail = filler;
-    }
-  } else {
-    // Remove the extra pad if necessary
-    remainingTime -= lastItemPad;
-  }
-
-  return remainingTime;
+  return maybeAddFillerOfType(
+    FillerTypes.tail,
+    remainingTime,
+    slot,
+    lastProgram,
+    timeCursor,
+  );
 }
 
 export function maybeAddPrePostFiller(
@@ -816,7 +793,7 @@ export function maybeAddPrePostFiller(
 }
 
 function maybeAddFillerOfType(
-  fillerType: 'pre' | 'post',
+  fillerType: 'head' | 'pre' | 'post' | 'tail',
   remainingTime: number,
   slot: SlotImpl<BaseSlot>,
   program: PaddedProgram,
@@ -997,9 +974,11 @@ function buildEagerBreaks(
       startOffsetMs: baseOffset + segmentStart,
     },
     paddedProgram.padMs,
-    { ...paddedProgram.filler },
+    {},
   );
   result.push(lastSegment);
+
+  distributeFillerAcrossSegments(paddedProgram.filler, result);
 
   return result;
 }
@@ -1054,11 +1033,41 @@ function buildLazyBreaks(
       startOffsetMs: baseOffset + segmentStart,
     },
     paddedProgram.padMs,
-    { ...paddedProgram.filler },
+    {},
   );
   result.push(lastSegment);
 
+  distributeFillerAcrossSegments(paddedProgram.filler, result);
+
   return result;
+}
+
+/**
+ * Mid-roll breaks split one program into several segments. Filler that brackets
+ * the program has to follow the split: head/pre belong before the first
+ * segment, post/tail after the last. Attaching all of it to the last segment
+ * plays the head bumper after the program instead of before it.
+ */
+function distributeFillerAcrossSegments(
+  filler: Partial<Record<SlotFillerTypes, CondensedChannelProgram>>,
+  segments: PaddedProgram[],
+): void {
+  const firstSegment = first(segments);
+  const lastSegment = last(segments);
+  if (!firstSegment || !lastSegment) {
+    return;
+  }
+
+  for (const [type, program] of toPairs(filler) as [
+    SlotFillerTypes,
+    CondensedChannelProgram,
+  ][]) {
+    const target =
+      type === FillerTypes.head || type === FillerTypes.pre
+        ? firstSegment
+        : lastSegment;
+    target.filler[type] = program;
+  }
 }
 
 function fillDurationWithFiller(


### PR DESCRIPTION
1. properly emit head/tail filler for padded programs
2. mid-roll wrongly pushed head/pre filler to end of programs
3. pre/post budget calculation was wrong for >= second program in slot
4. uniform filler now respects the time budget in a slot
5. properly stamp fillerType when creating schedules

Example:

Before/after for a 30-min slot at 15-min padding:

before:  bumper(pre) ep1 bumper(post) FLEX ... bumper(pre) ep2 bumper(post) FLEX
after:   head PRE ep1 POST FLEX PRE ep2 POST TAIL FLEX  →  head (next slot)
