### PR TITLE
feat: accelerate VAAPI watermark overlays

### DIFF
--- a/docs/configure/channels/watermarks.md
+++ b/docs/configure/channels/watermarks.md
@@ -18,6 +18,16 @@ When using intermittent watermarks, use this option to control whether the water
 
 This option controls the absolute duration the watermark can be displayed for a given program segment of a channel. Its value takes precedence over the 'watermark period' but does not disable it. For instance, you could configure a watermark period of 5 minutes with total duration of 45 mins. On a show that is one hour, the watermark will fade in/out for the first 45 minutes and then be hidden for the final 15 minutes.
 
+## Hardware-accelerated overlays
+
+When VAAPI hardware filters are enabled and FFmpeg provides the
+`overlay_vaapi` filter, Tunarr keeps the main video on the GPU while compositing
+still-image watermarks. Opacity, fades, and total watermark duration are
+applied to the watermark input before it is uploaded. Tunarr falls back to the
+software overlay when the hardware filter is unavailable, hardware filters are
+disabled, the VAAPI driver is incompatible, subtitles also require an overlay,
+or the watermark is animated.
+
 ## Overrides
 
 Global settings, such as target resolution, bit rate, and buffer size can be overridden per-channel.

--- a/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.test.ts
@@ -1,0 +1,39 @@
+import { OverlayWatermarkVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.js';
+import type { Watermark } from '@tunarr/types';
+import { describe, expect, it } from 'vitest';
+import { FrameSize } from '../../types.ts';
+
+function makeWatermark(overrides: Partial<Watermark> = {}): Watermark {
+  return {
+    duration: 0,
+    enabled: true,
+    horizontalMargin: 2,
+    opacity: 100,
+    position: 'bottom-left',
+    verticalMargin: 6,
+    width: 75,
+    ...overrides,
+  } as Watermark;
+}
+
+describe('OverlayWatermarkVaapiFilter', () => {
+  it('positions a persistent watermark without finite-duration options', () => {
+    const filter = new OverlayWatermarkVaapiFilter(
+      makeWatermark(),
+      FrameSize.FHD,
+    );
+
+    expect(filter.filter).toBe('overlay_vaapi=x=38:y=H-h-65');
+  });
+
+  it('passes through the main video when a finite watermark input ends', () => {
+    const filter = new OverlayWatermarkVaapiFilter(
+      makeWatermark({ duration: 5 }),
+      FrameSize.FHD,
+    );
+
+    expect(filter.filter).toBe(
+      'overlay_vaapi=x=38:y=H-h-65:eof_action=pass:repeatlast=0',
+    );
+  });
+});

--- a/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.ts
+++ b/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.ts
@@ -1,0 +1,24 @@
+import { OverlayWatermarkFilter } from '@/ffmpeg/builder/filter/watermark/OverlayWatermarkFilter.js';
+import { PixelFormatUnknown } from '@/ffmpeg/builder/format/PixelFormat.js';
+import type { FrameState } from '@/ffmpeg/builder/state/FrameState.js';
+import type { FrameSize } from '@/ffmpeg/builder/types.js';
+import { FrameDataLocation } from '@/ffmpeg/builder/types.js';
+import type { Watermark } from '@tunarr/types';
+
+export class OverlayWatermarkVaapiFilter extends OverlayWatermarkFilter {
+  public affectsFrameState = true;
+
+  constructor(watermark: Watermark, resolution: FrameSize) {
+    super(watermark, resolution, resolution, PixelFormatUnknown());
+  }
+
+  nextState(currentState: FrameState): FrameState {
+    return currentState.updateFrameLocation(FrameDataLocation.Hardware);
+  }
+
+  public get filter() {
+    const durationOptions =
+      this.watermark.duration > 0 ? ':eof_action=pass:repeatlast=0' : '';
+    return `overlay_vaapi=${this.getPosition()}${durationOptions}`;
+  }
+}

--- a/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.test.ts
@@ -1,0 +1,10 @@
+import { WatermarkDurationFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.js';
+import { describe, expect, it } from 'vitest';
+
+describe('WatermarkDurationFilter', () => {
+  it('trims and rebases the watermark input timeline', () => {
+    expect(new WatermarkDurationFilter(5).filter).toBe(
+      'trim=duration=5,setpts=PTS-STARTPTS',
+    );
+  });
+});

--- a/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.ts
+++ b/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.ts
@@ -1,0 +1,11 @@
+import { FilterOption } from '@/ffmpeg/builder/filter/FilterOption.js';
+
+export class WatermarkDurationFilter extends FilterOption {
+  constructor(private durationSeconds: number) {
+    super();
+  }
+
+  get filter() {
+    return `trim=duration=${this.durationSeconds},setpts=PTS-STARTPTS`;
+  }
+}

--- a/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
+++ b/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
@@ -12,5 +12,6 @@ export const KnownFfmpegFilters = {
   Libplacebo: 'libplacebo',
   PadVaapi: 'pad_vaapi',
   PadOpencl: 'pad_opencl',
+  OverlayVaapi: 'overlay_vaapi',
   OverlayQsv: 'overlay_qsv',
 };

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
@@ -539,6 +539,8 @@ describe('VaapiPipelineBuilder pad', () => {
     disableHardwareDecoding?: boolean;
     disableHardwareEncoding?: boolean;
     watermarkStream?: StillImageStream;
+    watermarkDuration?: number;
+    watermarkAnimated?: boolean;
   }) {
     const capabilities = new VaapiHardwareCapabilities([
       new VaapiProfileEntrypoint(
@@ -556,7 +558,7 @@ describe('VaapiPipelineBuilder pad', () => {
       new FfmpegCapabilities(
         new Set(),
         new Map(),
-        new Set([KnownFfmpegFilters.PadVaapi]),
+        new Set([KnownFfmpegFilters.PadVaapi, KnownFfmpegFilters.OverlayVaapi]),
         new Set(),
       );
 
@@ -571,8 +573,9 @@ describe('VaapiPipelineBuilder pad', () => {
         new FileStreamSource('/path/to/watermark.png'),
         opts.watermarkStream,
         {
-          duration: 0,
+          duration: opts.watermarkDuration ?? 0,
           enabled: true,
+          animated: opts.watermarkAnimated ?? false,
           horizontalMargin: 0,
           opacity: 1,
           position: 'top-left',
@@ -773,7 +776,7 @@ describe('VaapiPipelineBuilder pad', () => {
     expect(args).not.toContain('pad=');
   });
 
-  test('hardware download after pad_vaapi with watermark', () => {
+  test('keeps frames on hardware for a VAAPI watermark overlay', () => {
     const pipeline = buildWithPad({
       videoStream: VideoStream.create({
         index: 0,
@@ -794,16 +797,68 @@ describe('VaapiPipelineBuilder pad', () => {
     const args = pipeline.getCommandArgs().join(' ');
     // pad_vaapi must be present
     expect(args).toContain('pad_vaapi');
-    // hwdownload must appear after pad_vaapi (before the software overlay)
-    expect(args).toContain('hwdownload');
+    expect(args).toContain('overlay_vaapi=x=0:y=0');
+    expect(args).toContain('-loop 1');
+    expect(args).not.toContain('hwdownload');
     const padIdx = args.indexOf('pad_vaapi');
-    const dlIdx = args.indexOf('hwdownload');
-    expect(dlIdx).toBeGreaterThan(padIdx);
-    // any second hwupload (to re-enter hw for encoding) must come AFTER hwdownload
-    const secondHwuploadIdx = args.indexOf('hwupload', dlIdx);
-    if (secondHwuploadIdx !== -1) {
-      expect(secondHwuploadIdx).toBeGreaterThan(dlIdx);
-    }
+    const overlayIdx = args.indexOf('overlay_vaapi');
+    expect(overlayIdx).toBeGreaterThan(padIdx);
+  });
+
+  test('ends a finite-duration VAAPI watermark without downloading video frames', () => {
+    const pipeline = buildWithPad({
+      videoStream: create169FhdVideoStream(),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkDuration: 5,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('trim=duration=5,setpts=PTS-STARTPTS');
+    expect(args).toContain(
+      'overlay_vaapi=x=0:y=0:eof_action=pass:repeatlast=0',
+    );
+    expect(args).not.toContain('hwdownload');
+  });
+
+  test('falls back to software overlay when overlay_vaapi is unavailable', () => {
+    const pipeline = buildWithPad({
+      videoStream: create43VideoStream(),
+      binaryCapabilities: new FfmpegCapabilities(
+        new Set(),
+        new Map(),
+        new Set([KnownFfmpegFilters.PadVaapi]),
+        new Set(),
+      ),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkDuration: 5,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('hwdownload');
+    expect(args).toContain("overlay=x=0:y=0:format=0:enable='between(t,0,5)'");
+    expect(args).not.toContain('overlay_vaapi');
+  });
+
+  test('falls back to software overlay for animated watermarks', () => {
+    const pipeline = buildWithPad({
+      videoStream: create43VideoStream(),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkAnimated: true,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('hwdownload');
+    expect(args).toContain('overlay=x=0:y=0:format=0');
+    expect(args).not.toContain('overlay_vaapi');
   });
 });
 

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
@@ -18,6 +18,7 @@ import { ScaleVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/ScaleVaapiFilter
 import { TonemapVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/TonemapVaapiFilter.js';
 import { VaapiFormatFilter } from '@/ffmpeg/builder/filter/vaapi/VaapiFormatFilter.js';
 import { OverlayWatermarkFilter } from '@/ffmpeg/builder/filter/watermark/OverlayWatermarkFilter.js';
+import { WatermarkDurationFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.js';
 import { WatermarkOpacityFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkOpacityFilter.js';
 import { WatermarkScaleFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkScaleFilter.js';
 import type { AudioInputSource } from '@/ffmpeg/builder/input/AudioInputSource.js';
@@ -47,6 +48,7 @@ import { PadOpenclFilter } from '../../filter/opencl/PadOpenclFilter.ts';
 import { SubtitleFilter } from '../../filter/SubtitleFilter.ts';
 import { SubtitleOverlayFilter } from '../../filter/SubtitleOverlayFilter.ts';
 import { PadVaapiFilter } from '../../filter/vaapi/PadVaapiFilter.ts';
+import { OverlayWatermarkVaapiFilter } from '../../filter/vaapi/OverlayWatermarkVaapiFilter.ts';
 import { ScaleSubtitlesVaapiFilter } from '../../filter/vaapi/ScaleSubtitlesVaapiFilter.ts';
 import { VaapiOverlayFilter } from '../../filter/vaapi/VaapiOverlayFilter.ts';
 import { VaapiSubtitlePixelFormatFilter } from '../../filter/vaapi/VaapiSubtitlePixelFormatFilter.ts';
@@ -206,13 +208,14 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       this.context.pipelineOptions?.disableHardwareFilters ||
       (this.context.hasWatermark && this.context.hasSubtitleOverlay()) ||
       ffmpegState.vaapiDriver === 'radeonsi';
+    const useHardwareWatermarkOverlay = this.canUseHardwareWatermarkOverlay();
 
     currentState.forceSoftwareOverlay = forceSoftwareOverlay;
 
     if (
       currentState.frameDataLocation === FrameDataLocation.Software &&
-      this.context.hasSubtitleOverlay() &&
-      !forceSoftwareOverlay
+      ((this.context.hasSubtitleOverlay() && !forceSoftwareOverlay) ||
+        useHardwareWatermarkOverlay)
     ) {
       const filter = new HardwareUploadVaapiFilter(true);
       currentState = this.addFilterToVideoChain(currentState, filter);
@@ -220,7 +223,8 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     } else if (
       currentState.frameDataLocation === FrameDataLocation.Hardware &&
       (!this.context.hasSubtitleOverlay() || forceSoftwareOverlay) &&
-      this.context.hasWatermark
+      this.context.hasWatermark &&
+      !useHardwareWatermarkOverlay
     ) {
       // download for watermark (or forced software subtitle)
       const filter = new HardwareDownloadFilter(currentState);
@@ -595,17 +599,30 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       return currentState;
     }
 
-    if (currentState.frameDataLocation === FrameDataLocation.Hardware) {
+    const useHardwareOverlay =
+      currentState.frameDataLocation === FrameDataLocation.Hardware &&
+      this.canUseHardwareWatermarkOverlay();
+
+    if (
+      currentState.frameDataLocation === FrameDataLocation.Hardware &&
+      !useHardwareOverlay
+    ) {
       const hwdownload = new HardwareDownloadFilter(currentState);
       currentState = this.addFilterToVideoChain(currentState, hwdownload);
     }
 
-    const watermarkInput = this.watermarkInputSource!;
+    const watermarkInput = this.watermarkInputSource;
+    if (!watermarkInput) {
+      return currentState;
+    }
 
     for (const watermark of watermarkInput.streams ?? []) {
       if (watermark.inputKind !== 'stillimage') {
         watermarkInput.addOption(new DoNotIgnoreLoopInputOption());
-      } else if (isDefined(head(watermarkInput.watermark.fadeConfig))) {
+      } else if (
+        useHardwareOverlay ||
+        isDefined(head(watermarkInput.watermark.fadeConfig))
+      ) {
         // TODO: Needs hwaccel option here
         watermarkInput.addOption(new InfiniteLoopInputOption());
       }
@@ -632,6 +649,12 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       ...this.getWatermarkFadeFilters(watermarkInput.watermark),
     );
 
+    if (useHardwareOverlay && watermarkInput.watermark.duration > 0) {
+      watermarkInput.filterSteps.push(
+        new WatermarkDurationFilter(watermarkInput.watermark.duration),
+      );
+    }
+
     watermarkInput.filterSteps.push(
       new PixelFormatFilter(new PixelFormatYuva420P()),
     );
@@ -639,6 +662,17 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     const fadeConfig = head(watermarkInput.watermark.fadeConfig);
     if (isDefined(fadeConfig)) {
       // Fades
+    }
+
+    if (useHardwareOverlay) {
+      watermarkInput.filterSteps.push(new HardwareUploadVaapiFilter(false));
+
+      const overlayFilter = new OverlayWatermarkVaapiFilter(
+        watermarkInput.watermark,
+        this.desiredState.paddedSize,
+      );
+      this.context.filterChain.watermarkOverlayFilterSteps.push(overlayFilter);
+      return overlayFilter.nextState(currentState);
     }
 
     if (this.desiredState.pixelFormat) {
@@ -694,6 +728,25 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     return (
       this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.PadVaapi) ||
       this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.PadOpencl)
+    );
+  }
+
+  private canUseHardwareWatermarkOverlay() {
+    if (
+      !this.context.hasWatermark ||
+      !this.watermarkInputSource ||
+      this.context.pipelineOptions.disableHardwareFilters ||
+      this.context.hasSubtitleOverlay() ||
+      this.ffmpegState.vaapiDriver === 'radeonsi' ||
+      this.watermarkInputSource.watermark.animated === true ||
+      !this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.OverlayVaapi)
+    ) {
+      return false;
+    }
+
+    return every(
+      this.watermarkInputSource.streams,
+      (stream) => stream.inputKind === 'stillimage',
     );
   }
 }


### PR DESCRIPTION
## Summary

- use `overlay_vaapi` for non-animated still-image channel watermarks when the installed FFmpeg exposes the filter
- keep the main video on VAAPI surfaces and upload only the scaled RGBA watermark
- trim finite-duration watermark inputs and pass through the main video after EOF
- retain the existing software path when hardware filters are disabled, subtitles need a software overlay, the driver is incompatible, the watermark is animated, or `overlay_vaapi` is unavailable

## Validation

- `pnpm lint-changed`
- `pnpm turbo typecheck --filter=@tunarr/server`
- full server suite: 1,141 passed, 2 skipped
- live Intel N100 / FFmpeg 7.1.1 validation on a 1080p VAAPI channel, including a five-second watermark cutoff and a graph with no full-frame `hwdownload`
