### PR TITLE
feat: add current program title overlays

### DIFF
--- a/docs/configure/channels/watermarks.md
+++ b/docs/configure/channels/watermarks.md
@@ -6,6 +6,15 @@ Channels can have watermarks to aid in recreating a classic TV experience.
 
 There are many ways to customize watermarks for a channel. Here are some details on specific options:
 
+## Program title overlays
+
+Set the overlay source to **Current program title** to show program metadata
+instead of an image. Episodes are formatted as
+`Show name · S01E02 · Episode title`; movies and other videos use their title.
+The overlay is rebuilt for each program, so a total duration of 5 seconds shows
+the title for the first five seconds after every cutover. Program title overlays
+require a transcoding stream mode.
+
 ### Watermark Period
 
 This value can be used to fade a channel's watermark in/out every N minutes.

--- a/docs/configure/channels/watermarks.md
+++ b/docs/configure/channels/watermarks.md
@@ -18,6 +18,16 @@ When using intermittent watermarks, use this option to control whether the water
 
 This option controls the absolute duration the watermark can be displayed for a given program segment of a channel. Its value takes precedence over the 'watermark period' but does not disable it. For instance, you could configure a watermark period of 5 minutes with total duration of 45 mins. On a show that is one hour, the watermark will fade in/out for the first 45 minutes and then be hidden for the final 15 minutes.
 
+## Hardware-accelerated overlays
+
+When VAAPI hardware filters are enabled and FFmpeg provides the
+`overlay_vaapi` filter, Tunarr keeps the main video on the GPU while compositing
+still-image watermarks. Opacity, fades, and total watermark duration are
+applied to the watermark input before it is uploaded. Tunarr falls back to the
+software overlay when the hardware filter is unavailable, hardware filters are
+disabled, the VAAPI driver is incompatible, subtitles also require an overlay,
+or the watermark is animated.
+
 ## Overrides
 
 Global settings, such as target resolution, bit rate, and buffer size can be overridden per-channel.

--- a/server/src/db/schema/base.ts
+++ b/server/src/db/schema/base.ts
@@ -78,6 +78,7 @@ export type ChannelTranscodingSettings = z.infer<
 >;
 
 export const ChannelWatermarkSchema = z.object({
+  source: z.enum(['image', 'program-title']).optional().catch(undefined),
   url: z.string().optional().catch(undefined),
   enabled: z.boolean().catch(false),
   position: z

--- a/server/src/ffmpeg/FfmpegStreamFactory.ts
+++ b/server/src/ffmpeg/FfmpegStreamFactory.ts
@@ -40,6 +40,7 @@ import { loggingDef } from '../util/logging/loggingDef.ts';
 import type { FfmpegPlaybackParams } from './FfmpegPlaybackParamsCalculator.ts';
 import { FfmpegPlaybackParamsCalculator } from './FfmpegPlaybackParamsCalculator.ts';
 import { FfmpegProcess } from './FfmpegProcess.ts';
+import { createProgramTitleOverlayInput } from './ProgramTitleOverlay.ts';
 import { FfmpegTranscodeSession } from './FfmpegTrancodeSession.ts';
 import { StreamSelector } from './StreamSelector.ts';
 import { SubtitleStreamPicker } from './SubtitleStreamPicker.ts';
@@ -591,18 +592,34 @@ export class FfmpegStreamFactory {
 
     let watermarkSource: Nullable<WatermarkInputSource> = null;
     if (watermark?.enabled) {
-      const watermarkUrl = watermark.url ?? makeLocalUrl('/images/tunarr.png');
-      watermarkSource = new WatermarkInputSource(
-        new HttpStreamSource(watermarkUrl),
-        StillImageStream.create({
-          frameSize: FrameSize.fromResolution({
-            widthPx: watermark.width,
-            heightPx: -1,
+      if (
+        watermark.source === 'program-title' &&
+        lineupItem.type === 'program'
+      ) {
+        try {
+          watermarkSource =
+            (await createProgramTitleOverlayInput(
+              lineupItem.program,
+              watermark,
+            )) ?? null;
+        } catch (e) {
+          this.logger.warn(e, 'Unable to create program title overlay');
+        }
+      } else if (watermark.source !== 'program-title') {
+        const watermarkUrl =
+          watermark.url ?? makeLocalUrl('/images/tunarr.png');
+        watermarkSource = new WatermarkInputSource(
+          new HttpStreamSource(watermarkUrl),
+          StillImageStream.create({
+            frameSize: FrameSize.fromResolution({
+              widthPx: watermark.width,
+              heightPx: -1,
+            }),
+            index: 0,
           }),
-          index: 0,
-        }),
-        { ...watermark, url: watermarkUrl },
-      );
+          { ...watermark, url: watermarkUrl },
+        );
+      }
     }
 
     return { audioInput, subtitleSource, subtitleRendition, watermarkSource };

--- a/server/src/ffmpeg/ProgramTitleOverlay.test.ts
+++ b/server/src/ffmpeg/ProgramTitleOverlay.test.ts
@@ -1,0 +1,135 @@
+import type { StreamLineupProgram } from '@/db/derived_types/StreamLineup.js';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createProgramTitleOverlayInput,
+  escapeDrawtextFilePath,
+  formatProgramTitle,
+  programTitleLavfiSource,
+} from './ProgramTitleOverlay.ts';
+
+const temporaryDirectories: string[] = [];
+
+function makeProgram(
+  overrides: Partial<StreamLineupProgram> = {},
+): StreamLineupProgram {
+  return {
+    duration: 30_000,
+    externalIds: [],
+    externalKey: 'external-key',
+    externalSourceId: 'external-source-id',
+    mediaSourceId: 'media-source-id',
+    sourceType: 'jellyfin',
+    title: 'Episode title',
+    type: 'episode',
+    uuid: 'program-id',
+    ...overrides,
+  } as StreamLineupProgram;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe('formatProgramTitle', () => {
+  it('formats an episode as show, season and episode number, and title', () => {
+    const title = formatProgramTitle(
+      makeProgram({
+        episode: 7,
+        seasonNumber: 8,
+        showTitle: 'The Simpsons',
+        title: "Lisa's Date with Density",
+      }),
+    );
+
+    expect(title).toBe("The Simpsons · S08E07 · Lisa's Date with Density");
+  });
+
+  it('uses joined grouping metadata when it is available', () => {
+    const title = formatProgramTitle(
+      makeProgram({
+        episode: 2,
+        season: { index: 11 },
+        show: { title: 'Bob’s Burgers' },
+        showTitle: 'Stale show title',
+        title: 'The Belchies',
+      }),
+    );
+
+    expect(title).toBe('Bob’s Burgers · S11E02 · The Belchies');
+  });
+
+  it('uses the title alone for movies and other videos', () => {
+    expect(
+      formatProgramTitle(makeProgram({ title: 'Alien', type: 'movie' })),
+    ).toBe('Alien');
+  });
+});
+
+describe('program title input', () => {
+  it('escapes a textfile path for the drawtext filter', () => {
+    expect(escapeDrawtextFilePath("C:\\Tunarr's,data[1];x\\title.txt")).toBe(
+      "C\\:/Tunarr\\'s\\,data\\[1\\]\\;x/title.txt",
+    );
+  });
+
+  it('disables drawtext expansion and keeps the canvas transparent', () => {
+    const source = programTitleLavfiSource('/cache/title.txt');
+    expect(source).toContain('color=c=black@0.0:s=1600x96,format=rgba');
+    expect(source).toContain("textfile='/cache/title.txt':expansion=none");
+  });
+
+  it('writes metadata to a cache file and returns a lavfi watermark input', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'tunarr-program-title-test-'),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+
+    const input = await createProgramTitleOverlayInput(
+      makeProgram({
+        episode: 7,
+        seasonNumber: 8,
+        showTitle: 'The Simpsons',
+        title: "Lisa's Date with 100% Density",
+      }),
+      {
+        duration: 5,
+        enabled: true,
+        horizontalMargin: 2,
+        opacity: 100,
+        position: 'bottom-left',
+        source: 'program-title',
+        verticalMargin: 6,
+        width: 75,
+      },
+      temporaryDirectory,
+    );
+
+    expect(input).toBeDefined();
+    expect(input?.source.type).toBe('filter');
+    expect(input?.streams[0]?.inputKind).toBe('filter');
+    expect(input?.getInputOptions()).toEqual(['-f', 'lavfi']);
+    expect(input?.path).toContain('expansion=none');
+
+    const cacheDirectory = path.join(
+      temporaryDirectory,
+      'cache',
+      'program-title-overlays',
+    );
+    const files = await fs.readdir(cacheDirectory);
+    expect(files).toHaveLength(1);
+    const titleFile = files[0];
+    if (!titleFile) {
+      throw new Error('Expected a cached program title file');
+    }
+    expect(
+      await fs.readFile(path.join(cacheDirectory, titleFile), 'utf8'),
+    ).toBe("The Simpsons · S08E07 · Lisa's Date with 100% Density");
+  });
+});

--- a/server/src/ffmpeg/ProgramTitleOverlay.ts
+++ b/server/src/ffmpeg/ProgramTitleOverlay.ts
@@ -1,0 +1,136 @@
+import type { StreamLineupProgram } from '@/db/derived_types/StreamLineup.js';
+import { globalOptions } from '@/globals.js';
+import { VideoStream } from '@/ffmpeg/builder/MediaStream.js';
+import { ColorFormat } from '@/ffmpeg/builder/format/ColorFormat.js';
+import { PixelFormatUnknown } from '@/ffmpeg/builder/format/PixelFormat.js';
+import { WatermarkInputSource } from '@/ffmpeg/builder/input/WatermarkInputSource.js';
+import { LavfiInputOption } from '@/ffmpeg/builder/options/input/LavfiInputOption.js';
+import { FrameSize } from '@/ffmpeg/builder/types.js';
+import { FilterStreamSource } from '@/stream/types.js';
+import { isNonEmptyString } from '@/util/index.js';
+import type { Watermark } from '@tunarr/types';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ProgramTitleOverlaySize = FrameSize.create({ width: 1600, height: 96 });
+const ProgramTitleOverlayCacheFolder = 'program-title-overlays';
+
+function episodeNumberLabel(
+  seasonNumber: number | null | undefined,
+  episodeNumber: number | null | undefined,
+): string | undefined {
+  const season =
+    typeof seasonNumber === 'number' && Number.isInteger(seasonNumber)
+      ? `S${seasonNumber.toString().padStart(2, '0')}`
+      : '';
+  const episode =
+    typeof episodeNumber === 'number' && Number.isInteger(episodeNumber)
+      ? `E${episodeNumber.toString().padStart(2, '0')}`
+      : '';
+  const label = `${season}${episode}`;
+  return label.length > 0 ? label : undefined;
+}
+
+function joinTitleParts(
+  parts: (string | null | undefined)[],
+): string | undefined {
+  const result: string[] = [];
+  for (const part of parts) {
+    if (isNonEmptyString(part) && result.at(-1) !== part) {
+      result.push(part);
+    }
+  }
+  return result.length > 0 ? result.join(' · ') : undefined;
+}
+
+export function formatProgramTitle(
+  program: StreamLineupProgram,
+): string | undefined {
+  switch (program.type) {
+    case 'episode':
+      return joinTitleParts([
+        program.show?.title ?? program.showTitle,
+        episodeNumberLabel(
+          program.season?.index ?? program.seasonNumber,
+          program.episode,
+        ),
+        program.title,
+      ]);
+    case 'track':
+      return joinTitleParts([
+        program.artist?.title ?? program.artistName,
+        program.album?.title ?? program.albumName,
+        program.title,
+      ]);
+    default:
+      return isNonEmptyString(program.title) ? program.title : undefined;
+  }
+}
+
+export function escapeDrawtextFilePath(filePath: string): string {
+  return filePath
+    .replaceAll('\\', '/')
+    .replaceAll("'", "\\'")
+    .replaceAll(':', '\\:')
+    .replaceAll(',', '\\,')
+    .replaceAll(';', '\\;')
+    .replaceAll('[', '\\[')
+    .replaceAll(']', '\\]');
+}
+
+export function programTitleLavfiSource(textFilePath: string): string {
+  const escapedPath = escapeDrawtextFilePath(textFilePath);
+  return [
+    `color=c=black@0.0:s=${ProgramTitleOverlaySize.width}x${ProgramTitleOverlaySize.height}`,
+    'format=rgba',
+    `drawtext=textfile='${escapedPath}':expansion=none:fontsize=48:fontcolor=white:borderw=3:bordercolor=black:x=8:y=(h-text_h)/2`,
+  ].join(',');
+}
+
+async function cacheProgramTitleText(
+  title: string,
+  databaseDirectory: string,
+): Promise<string> {
+  const cacheDirectory = path.join(
+    databaseDirectory,
+    'cache',
+    ProgramTitleOverlayCacheFolder,
+  );
+  const cacheKey = createHash('sha256').update(title).digest('hex');
+  const titleFilePath = path.join(cacheDirectory, `${cacheKey}.txt`);
+
+  await fs.mkdir(cacheDirectory, { recursive: true });
+  await fs.writeFile(titleFilePath, title, 'utf8');
+  return titleFilePath;
+}
+
+export async function createProgramTitleOverlayInput(
+  program: StreamLineupProgram,
+  watermark: Watermark,
+  databaseDirectory = globalOptions().databaseDirectory,
+): Promise<WatermarkInputSource | undefined> {
+  const title = formatProgramTitle(program);
+  if (!title) {
+    return;
+  }
+
+  const titleFilePath = await cacheProgramTitleText(title, databaseDirectory);
+  const stream = VideoStream.create({
+    codec: 'generated',
+    colorFormat: ColorFormat.unknown,
+    displayAspectRatio: '50:3',
+    frameSize: ProgramTitleOverlaySize,
+    index: 0,
+    inputKind: 'filter',
+    pixelFormat: PixelFormatUnknown(),
+    providedSampleAspectRatio: '1:1',
+  });
+  const input = new WatermarkInputSource(
+    new FilterStreamSource(programTitleLavfiSource(titleFilePath)),
+    stream,
+    { ...watermark, animated: false },
+  );
+  input.addOption(new LavfiInputOption());
+  return input;
+}

--- a/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.test.ts
@@ -1,0 +1,39 @@
+import { OverlayWatermarkVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.js';
+import type { Watermark } from '@tunarr/types';
+import { describe, expect, it } from 'vitest';
+import { FrameSize } from '../../types.ts';
+
+function makeWatermark(overrides: Partial<Watermark> = {}): Watermark {
+  return {
+    duration: 0,
+    enabled: true,
+    horizontalMargin: 2,
+    opacity: 100,
+    position: 'bottom-left',
+    verticalMargin: 6,
+    width: 75,
+    ...overrides,
+  } as Watermark;
+}
+
+describe('OverlayWatermarkVaapiFilter', () => {
+  it('positions a persistent watermark without finite-duration options', () => {
+    const filter = new OverlayWatermarkVaapiFilter(
+      makeWatermark(),
+      FrameSize.FHD,
+    );
+
+    expect(filter.filter).toBe('overlay_vaapi=x=38:y=H-h-65');
+  });
+
+  it('passes through the main video when a finite watermark input ends', () => {
+    const filter = new OverlayWatermarkVaapiFilter(
+      makeWatermark({ duration: 5 }),
+      FrameSize.FHD,
+    );
+
+    expect(filter.filter).toBe(
+      'overlay_vaapi=x=38:y=H-h-65:eof_action=pass:repeatlast=0',
+    );
+  });
+});

--- a/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.ts
+++ b/server/src/ffmpeg/builder/filter/vaapi/OverlayWatermarkVaapiFilter.ts
@@ -1,0 +1,24 @@
+import { OverlayWatermarkFilter } from '@/ffmpeg/builder/filter/watermark/OverlayWatermarkFilter.js';
+import { PixelFormatUnknown } from '@/ffmpeg/builder/format/PixelFormat.js';
+import type { FrameState } from '@/ffmpeg/builder/state/FrameState.js';
+import type { FrameSize } from '@/ffmpeg/builder/types.js';
+import { FrameDataLocation } from '@/ffmpeg/builder/types.js';
+import type { Watermark } from '@tunarr/types';
+
+export class OverlayWatermarkVaapiFilter extends OverlayWatermarkFilter {
+  public affectsFrameState = true;
+
+  constructor(watermark: Watermark, resolution: FrameSize) {
+    super(watermark, resolution, resolution, PixelFormatUnknown());
+  }
+
+  nextState(currentState: FrameState): FrameState {
+    return currentState.updateFrameLocation(FrameDataLocation.Hardware);
+  }
+
+  public get filter() {
+    const durationOptions =
+      this.watermark.duration > 0 ? ':eof_action=pass:repeatlast=0' : '';
+    return `overlay_vaapi=${this.getPosition()}${durationOptions}`;
+  }
+}

--- a/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.test.ts
@@ -1,0 +1,10 @@
+import { WatermarkDurationFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.js';
+import { describe, expect, it } from 'vitest';
+
+describe('WatermarkDurationFilter', () => {
+  it('trims and rebases the watermark input timeline', () => {
+    expect(new WatermarkDurationFilter(5).filter).toBe(
+      'trim=duration=5,setpts=PTS-STARTPTS',
+    );
+  });
+});

--- a/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.ts
+++ b/server/src/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.ts
@@ -1,0 +1,11 @@
+import { FilterOption } from '@/ffmpeg/builder/filter/FilterOption.js';
+
+export class WatermarkDurationFilter extends FilterOption {
+  constructor(private durationSeconds: number) {
+    super();
+  }
+
+  get filter() {
+    return `trim=duration=${this.durationSeconds},setpts=PTS-STARTPTS`;
+  }
+}

--- a/server/src/ffmpeg/builder/input/WatermarkInputSource.ts
+++ b/server/src/ffmpeg/builder/input/WatermarkInputSource.ts
@@ -1,12 +1,12 @@
-import type { StillImageStream } from '@/ffmpeg/builder/MediaStream.js';
+import type { VideoStream } from '@/ffmpeg/builder/MediaStream.js';
 import type { Watermark } from '@tunarr/types';
 import type { StreamSource } from './InputSource.ts';
 import { VideoInputSource } from './VideoInputSource.ts';
 
-export class WatermarkInputSource extends VideoInputSource<StillImageStream> {
+export class WatermarkInputSource extends VideoInputSource<VideoStream> {
   constructor(
     source: StreamSource,
-    imageStream: StillImageStream,
+    imageStream: VideoStream,
     public watermark: Watermark,
   ) {
     super(source, [imageStream]);

--- a/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
+++ b/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
@@ -12,5 +12,6 @@ export const KnownFfmpegFilters = {
   Libplacebo: 'libplacebo',
   PadVaapi: 'pad_vaapi',
   PadOpencl: 'pad_opencl',
+  OverlayVaapi: 'overlay_vaapi',
   OverlayQsv: 'overlay_qsv',
 };

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
@@ -539,6 +539,8 @@ describe('VaapiPipelineBuilder pad', () => {
     disableHardwareDecoding?: boolean;
     disableHardwareEncoding?: boolean;
     watermarkStream?: StillImageStream;
+    watermarkDuration?: number;
+    watermarkAnimated?: boolean;
   }) {
     const capabilities = new VaapiHardwareCapabilities([
       new VaapiProfileEntrypoint(
@@ -556,7 +558,7 @@ describe('VaapiPipelineBuilder pad', () => {
       new FfmpegCapabilities(
         new Set(),
         new Map(),
-        new Set([KnownFfmpegFilters.PadVaapi]),
+        new Set([KnownFfmpegFilters.PadVaapi, KnownFfmpegFilters.OverlayVaapi]),
         new Set(),
       );
 
@@ -571,8 +573,9 @@ describe('VaapiPipelineBuilder pad', () => {
         new FileStreamSource('/path/to/watermark.png'),
         opts.watermarkStream,
         {
-          duration: 0,
+          duration: opts.watermarkDuration ?? 0,
           enabled: true,
+          animated: opts.watermarkAnimated ?? false,
           horizontalMargin: 0,
           opacity: 1,
           position: 'top-left',
@@ -773,7 +776,7 @@ describe('VaapiPipelineBuilder pad', () => {
     expect(args).not.toContain('pad=');
   });
 
-  test('hardware download after pad_vaapi with watermark', () => {
+  test('keeps frames on hardware for a VAAPI watermark overlay', () => {
     const pipeline = buildWithPad({
       videoStream: VideoStream.create({
         index: 0,
@@ -794,16 +797,68 @@ describe('VaapiPipelineBuilder pad', () => {
     const args = pipeline.getCommandArgs().join(' ');
     // pad_vaapi must be present
     expect(args).toContain('pad_vaapi');
-    // hwdownload must appear after pad_vaapi (before the software overlay)
-    expect(args).toContain('hwdownload');
+    expect(args).toContain('overlay_vaapi=x=0:y=0');
+    expect(args).toContain('-loop 1');
+    expect(args).not.toContain('hwdownload');
     const padIdx = args.indexOf('pad_vaapi');
-    const dlIdx = args.indexOf('hwdownload');
-    expect(dlIdx).toBeGreaterThan(padIdx);
-    // any second hwupload (to re-enter hw for encoding) must come AFTER hwdownload
-    const secondHwuploadIdx = args.indexOf('hwupload', dlIdx);
-    if (secondHwuploadIdx !== -1) {
-      expect(secondHwuploadIdx).toBeGreaterThan(dlIdx);
-    }
+    const overlayIdx = args.indexOf('overlay_vaapi');
+    expect(overlayIdx).toBeGreaterThan(padIdx);
+  });
+
+  test('ends a finite-duration VAAPI watermark without downloading video frames', () => {
+    const pipeline = buildWithPad({
+      videoStream: create169FhdVideoStream(),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkDuration: 5,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('trim=duration=5,setpts=PTS-STARTPTS');
+    expect(args).toContain(
+      'overlay_vaapi=x=0:y=0:eof_action=pass:repeatlast=0',
+    );
+    expect(args).not.toContain('hwdownload');
+  });
+
+  test('falls back to software overlay when overlay_vaapi is unavailable', () => {
+    const pipeline = buildWithPad({
+      videoStream: create43VideoStream(),
+      binaryCapabilities: new FfmpegCapabilities(
+        new Set(),
+        new Map(),
+        new Set([KnownFfmpegFilters.PadVaapi]),
+        new Set(),
+      ),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkDuration: 5,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('hwdownload');
+    expect(args).toContain("overlay=x=0:y=0:format=0:enable='between(t,0,5)'");
+    expect(args).not.toContain('overlay_vaapi');
+  });
+
+  test('falls back to software overlay for animated watermarks', () => {
+    const pipeline = buildWithPad({
+      videoStream: create43VideoStream(),
+      watermarkStream: StillImageStream.create({
+        frameSize: FrameSize.withDimensions(100, 100),
+        index: 0,
+      }),
+      watermarkAnimated: true,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('hwdownload');
+    expect(args).toContain('overlay=x=0:y=0:format=0');
+    expect(args).not.toContain('overlay_vaapi');
   });
 });
 

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.test.ts
@@ -1,6 +1,10 @@
 import { ColorFormat } from '@/ffmpeg/builder/format/ColorFormat.js';
 import { TONEMAP_ENABLED, TUNARR_ENV_VARS } from '@/util/env.js';
-import { FileStreamSource } from '../../../../stream/types.ts';
+import {
+  FileStreamSource,
+  FilterStreamSource,
+  type StreamSource,
+} from '../../../../stream/types.ts';
 import {
   EmptyFfmpegCapabilities,
   FfmpegCapabilities,
@@ -38,6 +42,7 @@ import { LavfiVideoInputSource } from '../../input/LavfiVideoInputSource.ts';
 import { SubtitlesInputSource } from '../../input/SubtitlesInputSource.ts';
 import { VideoInputSource } from '../../input/VideoInputSource.ts';
 import { WatermarkInputSource } from '../../input/WatermarkInputSource.ts';
+import { LavfiInputOption } from '../../options/input/LavfiInputOption.ts';
 import {
   AudioStream,
   EmbeddedSubtitleStream,
@@ -538,7 +543,8 @@ describe('VaapiPipelineBuilder pad', () => {
     binaryCapabilities?: FfmpegCapabilities;
     disableHardwareDecoding?: boolean;
     disableHardwareEncoding?: boolean;
-    watermarkStream?: StillImageStream;
+    watermarkSource?: StreamSource;
+    watermarkStream?: VideoStream;
     watermarkDuration?: number;
     watermarkAnimated?: boolean;
   }) {
@@ -570,7 +576,7 @@ describe('VaapiPipelineBuilder pad', () => {
     let wm: WatermarkInputSource | null = null;
     if (opts.watermarkStream) {
       wm = new WatermarkInputSource(
-        new FileStreamSource('/path/to/watermark.png'),
+        opts.watermarkSource ?? new FileStreamSource('/path/to/watermark.png'),
         opts.watermarkStream,
         {
           duration: opts.watermarkDuration ?? 0,
@@ -583,6 +589,9 @@ describe('VaapiPipelineBuilder pad', () => {
           width: 100,
         },
       );
+      if (opts.watermarkSource?.type === 'filter') {
+        wm.addOption(new LavfiInputOption());
+      }
     }
 
     const builder = new VaapiPipelineBuilder(
@@ -821,6 +830,32 @@ describe('VaapiPipelineBuilder pad', () => {
       'overlay_vaapi=x=0:y=0:eof_action=pass:repeatlast=0',
     );
     expect(args).not.toContain('hwdownload');
+  });
+
+  test('keeps generated program-title inputs on the VAAPI overlay path', () => {
+    const pipeline = buildWithPad({
+      videoStream: create169FhdVideoStream(),
+      watermarkSource: new FilterStreamSource(
+        'color=c=black@0.0:s=1600x96,format=rgba',
+      ),
+      watermarkStream: VideoStream.create({
+        codec: 'generated',
+        colorFormat: ColorFormat.unknown,
+        displayAspectRatio: '50:3',
+        frameSize: FrameSize.withDimensions(1600, 96),
+        index: 0,
+        inputKind: 'filter',
+        pixelFormat: new PixelFormatRgba(),
+        providedSampleAspectRatio: '1:1',
+      }),
+      watermarkDuration: 5,
+    });
+
+    const args = pipeline.getCommandArgs().join(' ');
+    expect(args).toContain('-f lavfi');
+    expect(args).toContain('overlay_vaapi');
+    expect(args).not.toContain('hwdownload');
+    expect(args).not.toContain('-loop 1');
   });
 
   test('falls back to software overlay when overlay_vaapi is unavailable', () => {

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
@@ -746,7 +746,8 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
 
     return every(
       this.watermarkInputSource.streams,
-      (stream) => stream.inputKind === 'stillimage',
+      (stream) =>
+        stream.inputKind === 'stillimage' || stream.inputKind === 'filter',
     );
   }
 }

--- a/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
+++ b/server/src/ffmpeg/builder/pipeline/hardware/VaapiPipelineBuilder.ts
@@ -18,6 +18,7 @@ import { ScaleVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/ScaleVaapiFilter
 import { TonemapVaapiFilter } from '@/ffmpeg/builder/filter/vaapi/TonemapVaapiFilter.js';
 import { VaapiFormatFilter } from '@/ffmpeg/builder/filter/vaapi/VaapiFormatFilter.js';
 import { OverlayWatermarkFilter } from '@/ffmpeg/builder/filter/watermark/OverlayWatermarkFilter.js';
+import { WatermarkDurationFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkDurationFilter.js';
 import { WatermarkOpacityFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkOpacityFilter.js';
 import { WatermarkScaleFilter } from '@/ffmpeg/builder/filter/watermark/WatermarkScaleFilter.js';
 import type { AudioInputSource } from '@/ffmpeg/builder/input/AudioInputSource.js';
@@ -47,6 +48,7 @@ import { PadOpenclFilter } from '../../filter/opencl/PadOpenclFilter.ts';
 import { SubtitleFilter } from '../../filter/SubtitleFilter.ts';
 import { SubtitleOverlayFilter } from '../../filter/SubtitleOverlayFilter.ts';
 import { PadVaapiFilter } from '../../filter/vaapi/PadVaapiFilter.ts';
+import { OverlayWatermarkVaapiFilter } from '../../filter/vaapi/OverlayWatermarkVaapiFilter.ts';
 import { ScaleSubtitlesVaapiFilter } from '../../filter/vaapi/ScaleSubtitlesVaapiFilter.ts';
 import { VaapiOverlayFilter } from '../../filter/vaapi/VaapiOverlayFilter.ts';
 import { VaapiSubtitlePixelFormatFilter } from '../../filter/vaapi/VaapiSubtitlePixelFormatFilter.ts';
@@ -206,13 +208,14 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       this.context.pipelineOptions?.disableHardwareFilters ||
       (this.context.hasWatermark && this.context.hasSubtitleOverlay()) ||
       ffmpegState.vaapiDriver === 'radeonsi';
+    const useHardwareWatermarkOverlay = this.canUseHardwareWatermarkOverlay();
 
     currentState.forceSoftwareOverlay = forceSoftwareOverlay;
 
     if (
       currentState.frameDataLocation === FrameDataLocation.Software &&
-      this.context.hasSubtitleOverlay() &&
-      !forceSoftwareOverlay
+      ((this.context.hasSubtitleOverlay() && !forceSoftwareOverlay) ||
+        useHardwareWatermarkOverlay)
     ) {
       const filter = new HardwareUploadVaapiFilter(true);
       currentState = this.addFilterToVideoChain(currentState, filter);
@@ -220,7 +223,8 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     } else if (
       currentState.frameDataLocation === FrameDataLocation.Hardware &&
       (!this.context.hasSubtitleOverlay() || forceSoftwareOverlay) &&
-      this.context.hasWatermark
+      this.context.hasWatermark &&
+      !useHardwareWatermarkOverlay
     ) {
       // download for watermark (or forced software subtitle)
       const filter = new HardwareDownloadFilter(currentState);
@@ -595,17 +599,30 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       return currentState;
     }
 
-    if (currentState.frameDataLocation === FrameDataLocation.Hardware) {
+    const useHardwareOverlay =
+      currentState.frameDataLocation === FrameDataLocation.Hardware &&
+      this.canUseHardwareWatermarkOverlay();
+
+    if (
+      currentState.frameDataLocation === FrameDataLocation.Hardware &&
+      !useHardwareOverlay
+    ) {
       const hwdownload = new HardwareDownloadFilter(currentState);
       currentState = this.addFilterToVideoChain(currentState, hwdownload);
     }
 
-    const watermarkInput = this.watermarkInputSource!;
+    const watermarkInput = this.watermarkInputSource;
+    if (!watermarkInput) {
+      return currentState;
+    }
 
     for (const watermark of watermarkInput.streams ?? []) {
       if (watermark.inputKind !== 'stillimage') {
         watermarkInput.addOption(new DoNotIgnoreLoopInputOption());
-      } else if (isDefined(head(watermarkInput.watermark.fadeConfig))) {
+      } else if (
+        useHardwareOverlay ||
+        isDefined(head(watermarkInput.watermark.fadeConfig))
+      ) {
         // TODO: Needs hwaccel option here
         watermarkInput.addOption(new InfiniteLoopInputOption());
       }
@@ -632,6 +649,12 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
       ...this.getWatermarkFadeFilters(watermarkInput.watermark),
     );
 
+    if (useHardwareOverlay && watermarkInput.watermark.duration > 0) {
+      watermarkInput.filterSteps.push(
+        new WatermarkDurationFilter(watermarkInput.watermark.duration),
+      );
+    }
+
     watermarkInput.filterSteps.push(
       new PixelFormatFilter(new PixelFormatYuva420P()),
     );
@@ -639,6 +662,17 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     const fadeConfig = head(watermarkInput.watermark.fadeConfig);
     if (isDefined(fadeConfig)) {
       // Fades
+    }
+
+    if (useHardwareOverlay) {
+      watermarkInput.filterSteps.push(new HardwareUploadVaapiFilter(false));
+
+      const overlayFilter = new OverlayWatermarkVaapiFilter(
+        watermarkInput.watermark,
+        this.desiredState.paddedSize,
+      );
+      this.context.filterChain.watermarkOverlayFilterSteps.push(overlayFilter);
+      return overlayFilter.nextState(currentState);
     }
 
     if (this.desiredState.pixelFormat) {
@@ -694,6 +728,25 @@ export class VaapiPipelineBuilder extends SoftwarePipelineBuilder {
     return (
       this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.PadVaapi) ||
       this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.PadOpencl)
+    );
+  }
+
+  private canUseHardwareWatermarkOverlay() {
+    if (
+      !this.context.hasWatermark ||
+      !this.watermarkInputSource ||
+      this.context.pipelineOptions.disableHardwareFilters ||
+      this.context.hasSubtitleOverlay() ||
+      this.ffmpegState.vaapiDriver === 'radeonsi' ||
+      this.watermarkInputSource.watermark.animated === true ||
+      !this.ffmpegCapabilities.hasFilter(KnownFfmpegFilters.OverlayVaapi)
+    ) {
+      return false;
+    }
+
+    return every(
+      this.watermarkInputSource.streams,
+      (stream) => stream.inputKind === 'stillimage',
     );
   }
 }

--- a/server/src/stream/ProgramStream.ts
+++ b/server/src/stream/ProgramStream.ts
@@ -358,6 +358,15 @@ export class ProgramStream extends events.EventEmitter<ProgramStreamEvents> {
 
     if (channel.watermark?.enabled) {
       const watermark = { ...channel.watermark };
+      if (watermark.source === 'program-title') {
+        return {
+          ...watermark,
+          animated: false,
+          enabled: true,
+          url: undefined,
+        };
+      }
+
       let icon: string;
       // Capture this so it can't change asynchronously.
       const watermarkUrl = watermark.url;

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -6,6 +6,7 @@ import { SubtitlePreference } from './subtitleSchema.js';
 import { ChannelIconSchema, ContentProgramTypeSchema } from './utilSchemas.js';
 
 export const WatermarkSchema = z.object({
+  source: z.enum(['image', 'program-title']).optional().catch(undefined),
   url: z.string().optional(),
   enabled: z.boolean(),
   position: z

--- a/web/src/components/channel_config/ChannelTranscodingConfig.tsx
+++ b/web/src/components/channel_config/ChannelTranscodingConfig.tsx
@@ -44,6 +44,14 @@ const watermarkPositionOptions: {
   { value: 'top-left', label: 'Top Left' },
 ];
 
+const watermarkSourceOptions: {
+  value: NonNullable<Watermark['source']>;
+  label: string;
+}[] = [
+  { value: 'image', label: 'Image' },
+  { value: 'program-title', label: 'Current program title' },
+];
+
 const ChannelStreamModeOptions: {
   value: ChannelStreamMode;
   label: string;
@@ -120,6 +128,7 @@ export default function ChannelTranscodingConfig() {
     watermark?.position === 'bottom-left' ||
     watermark?.position === 'bottom-right';
   const watermarkPath = watch('watermark.url');
+  const watermarkSource = watermark?.source ?? 'image';
 
   return (
     channel && (
@@ -129,7 +138,10 @@ export default function ChannelTranscodingConfig() {
             <Trans>Transcoding Settings</Trans>
           </Typography>
           <Typography variant="subtitle1">
-            <Trans>Use these settings to override global ffmpeg settings for this channel.</Trans>
+            <Trans>
+              Use these settings to override global ffmpeg settings for this
+              channel.
+            </Trans>
           </Typography>
           <Stack direction={{ sm: 'column', md: 'row' }} useFlexGap spacing={2}>
             <FormControl margin="normal">
@@ -172,7 +184,10 @@ export default function ChannelTranscodingConfig() {
                 control={control}
                 name="transcodeConfigId"
                 render={({ field }) => (
-                  <Select<string> label={t`Channel Transcode Config`} {...field}>
+                  <Select<string>
+                    label={t`Channel Transcode Config`}
+                    {...field}
+                  >
                     {transcodeConfigs.data.map((opt) => (
                       <MenuItem key={opt.id} value={opt.id}>
                         {opt.name}
@@ -200,7 +215,9 @@ export default function ChannelTranscodingConfig() {
               <Trans>Audio &amp; Subtitles</Trans>
             </Typography>
             <Typography variant="subtitle1">
-              <Trans>Override global audio and subtitle settings for this channel.</Trans>
+              <Trans>
+                Override global audio and subtitle settings for this channel.
+              </Trans>
             </Typography>
             <Divider sx={{ my: 2 }} />
             <FormControlLabel
@@ -232,7 +249,9 @@ export default function ChannelTranscodingConfig() {
           </Stack>
         </Stack>
         <Box>
-          <Typography variant="h5"><Trans>Watermark</Trans></Typography>
+          <Typography variant="h5">
+            <Trans>Watermark</Trans>
+          </Typography>
           <FormControl fullWidth>
             <FormControlLabel
               control={
@@ -249,8 +268,8 @@ export default function ChannelTranscodingConfig() {
             />
             <FormHelperText>
               <Trans>
-                Renders a channel icon (also known as bug or Digital On-screen
-                Graphic) on top of the channel's stream.
+                Renders an image or the current program title on top of the
+                channel's stream.
               </Trans>
             </FormHelperText>
           </FormControl>
@@ -271,26 +290,51 @@ export default function ChannelTranscodingConfig() {
                       overflow: 'hidden',
                     }}
                   >
-                    <Box
-                      component="img"
-                      sx={{
-                        position: 'absolute',
-                        width:
-                          watermark?.width && !watermark?.fixedSize
-                            ? `${watermark.width}%`
-                            : null,
-                        opacity: opacity ? opacity / 100 : 1.0,
-                        [isBottom ? 'bottom' : 'top']:
-                          `${watermark?.verticalMargin}%`,
-                        [isRight ? 'right' : 'left']:
-                          `${watermark?.horizontalMargin}%`,
-                      }}
-                      src={
-                        [watermarkPath, channel.icon.path].find(
-                          isNonEmptyString,
-                        ) ?? `${backendUri}/images/tunarr.png`
-                      }
-                    />
+                    {watermarkSource === 'program-title' ? (
+                      <Typography
+                        sx={{
+                          color: 'white',
+                          fontSize: 'clamp(8px, 1.35vw, 18px)',
+                          fontWeight: 700,
+                          lineHeight: 1,
+                          maxWidth: `${watermark?.width ?? 75}%`,
+                          opacity: opacity ? opacity / 100 : 1.0,
+                          overflow: 'hidden',
+                          position: 'absolute',
+                          textOverflow: 'ellipsis',
+                          textShadow:
+                            '-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000',
+                          whiteSpace: 'nowrap',
+                          [isBottom ? 'bottom' : 'top']:
+                            `${watermark?.verticalMargin}%`,
+                          [isRight ? 'right' : 'left']:
+                            `${watermark?.horizontalMargin}%`,
+                        }}
+                      >
+                        The Simpsons · S08E02 · You Only Move Twice
+                      </Typography>
+                    ) : (
+                      <Box
+                        component="img"
+                        sx={{
+                          position: 'absolute',
+                          width:
+                            watermark?.width && !watermark?.fixedSize
+                              ? `${watermark.width}%`
+                              : null,
+                          opacity: opacity ? opacity / 100 : 1.0,
+                          [isBottom ? 'bottom' : 'top']:
+                            `${watermark?.verticalMargin}%`,
+                          [isRight ? 'right' : 'left']:
+                            `${watermark?.horizontalMargin}%`,
+                        }}
+                        src={
+                          [watermarkPath, channel.icon.path].find(
+                            isNonEmptyString,
+                          ) ?? `${backendUri}/images/tunarr.png`
+                        }
+                      />
+                    )}
                     {safeTitleIndicatorVisible && (
                       <Box
                         sx={{
@@ -334,28 +378,81 @@ export default function ChannelTranscodingConfig() {
                   sx={{ flexGrow: 1, height: 'fit-content' }}
                 >
                   <Grid size={{ xs: 12 }}>
-                    <Controller
-                      name="watermark.url"
-                      control={control}
-                      render={({ field }) => (
-                        <ImageUploadInput
-                          // TODO: This should be something like {channel.id}_fallback_picture.ext
-                          fileRenamer={typedProperty('name')}
-                          label={t`Watermark Image URL`}
-                          onFormValueChange={(newPath) =>
-                            field.onChange(newPath)
-                          }
-                          onUploadError={console.error}
-                          FormControlProps={{ fullWidth: true }}
-                          value={field.value ?? ''}
-                        >
-                          <FormHelperText>
-                            <Trans>Leave blank to use the channel's icon.</Trans>
-                          </FormHelperText>
-                        </ImageUploadInput>
-                      )}
-                    />
+                    <FormControl fullWidth>
+                      <InputLabel>{t`Overlay source`}</InputLabel>
+                      <Controller
+                        name="watermark.source"
+                        control={control}
+                        render={({ field }) => (
+                          <Select<NonNullable<Watermark['source']>>
+                            label={t`Overlay source`}
+                            {...field}
+                            value={field.value ?? 'image'}
+                            onChange={(event) => {
+                              field.onChange(event);
+                              if (event.target.value === 'program-title') {
+                                setValue('watermark.animated', false, {
+                                  shouldDirty: true,
+                                });
+                                setValue('watermark.fixedSize', false, {
+                                  shouldDirty: true,
+                                });
+                                if (getValues('watermark.duration') === 0) {
+                                  setValue('watermark.duration', 5, {
+                                    shouldDirty: true,
+                                  });
+                                }
+                                if (getValues('watermark.width') === 10) {
+                                  setValue('watermark.width', 75, {
+                                    shouldDirty: true,
+                                  });
+                                }
+                              }
+                            }}
+                          >
+                            {watermarkSourceOptions.map((option) => (
+                              <MenuItem key={option.value} value={option.value}>
+                                {option.label}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        )}
+                      />
+                      <FormHelperText>
+                        <Trans>
+                          Program titles use each item's metadata and restart at
+                          every program cutover.
+                        </Trans>
+                      </FormHelperText>
+                    </FormControl>
                   </Grid>
+                  {watermarkSource === 'image' && (
+                    <Grid size={{ xs: 12 }}>
+                      <Controller
+                        name="watermark.url"
+                        control={control}
+                        render={({ field }) => (
+                          <ImageUploadInput
+                            // TODO: This should be something like {channel.id}_fallback_picture.ext
+                            fileRenamer={typedProperty('name')}
+                            label={t`Watermark Image URL`}
+                            onFormValueChange={(newPath) =>
+                              field.onChange(newPath)
+                            }
+                            onUploadError={console.error}
+                            FormControlProps={{ fullWidth: true }}
+                            value={field.value ?? ''}
+                          >
+                            <FormHelperText>
+                              <Trans>
+                                Leave blank to use the channel's icon.
+                              </Trans>
+                            </FormHelperText>
+                          </ImageUploadInput>
+                        )}
+                      />
+                    </Grid>
+                  )}
                   <Grid size={{ xs: 12 }}>
                     <FormControl fullWidth margin="normal">
                       <InputLabel>{t`Position`}</InputLabel>
@@ -412,7 +509,9 @@ export default function ChannelTranscodingConfig() {
                   </Grid>
                   <Grid size={{ xs: 12 }}>
                     <FormControl fullWidth>
-                      <Typography gutterBottom><Trans>Opacity</Trans></Typography>
+                      <Typography gutterBottom>
+                        <Trans>Opacity</Trans>
+                      </Typography>
                       <Box sx={{ px: 2 }}>
                         <Slider
                           min={0}
@@ -435,43 +534,51 @@ export default function ChannelTranscodingConfig() {
                   <Grid size={{ xs: 12 }}>
                     <Divider />
                   </Grid>
-                  <Grid size={{ xs: 12, lg: 6 }}>
-                    <FormControl fullWidth>
-                      <FormControlLabel
-                        control={
-                          <CheckboxFormController
-                            control={control}
-                            name="watermark.fixedSize"
-                          />
-                        }
-                        label={t`Disable Image Scaling`}
-                      />
-                      <FormHelperText>
-                        <Trans>The image will be rendered at its actual size without any scaling applied.</Trans>
-                      </FormHelperText>
-                    </FormControl>
-                  </Grid>
-                  <Grid size={{ xs: 12, lg: 6 }}>
-                    <FormControl fullWidth>
-                      <FormControlLabel
-                        control={
-                          <CheckboxFormController
-                            control={control}
-                            name="watermark.animated"
-                          />
-                        }
-                        label={t`Enable Animation`}
-                      />
-                      <FormHelperText>
-                        <Trans>
-                          Enable if the watermark is an animated GIF or PNG. The
-                          watermark will loop according to the image's
-                          configuration. If this option is enabled and the image
-                          is not animated, there will be playback errors.
-                        </Trans>
-                      </FormHelperText>
-                    </FormControl>
-                  </Grid>
+                  {watermarkSource === 'image' && (
+                    <Grid size={{ xs: 12, lg: 6 }}>
+                      <FormControl fullWidth>
+                        <FormControlLabel
+                          control={
+                            <CheckboxFormController
+                              control={control}
+                              name="watermark.fixedSize"
+                            />
+                          }
+                          label={t`Disable Image Scaling`}
+                        />
+                        <FormHelperText>
+                          <Trans>
+                            The image will be rendered at its actual size
+                            without any scaling applied.
+                          </Trans>
+                        </FormHelperText>
+                      </FormControl>
+                    </Grid>
+                  )}
+                  {watermarkSource === 'image' && (
+                    <Grid size={{ xs: 12, lg: 6 }}>
+                      <FormControl fullWidth>
+                        <FormControlLabel
+                          control={
+                            <CheckboxFormController
+                              control={control}
+                              name="watermark.animated"
+                            />
+                          }
+                          label={t`Enable Animation`}
+                        />
+                        <FormHelperText>
+                          <Trans>
+                            Enable if the watermark is an animated GIF or PNG.
+                            The watermark will loop according to the image's
+                            configuration. If this option is enabled and the
+                            image is not animated, there will be playback
+                            errors.
+                          </Trans>
+                        </FormHelperText>
+                      </FormControl>
+                    </Grid>
+                  )}
 
                   <Grid size={{ xs: 12, lg: 6 }}>
                     <NumericFormControllerText

--- a/web/src/components/channel_config/EditChannelForm.tsx
+++ b/web/src/components/channel_config/EditChannelForm.tsx
@@ -56,6 +56,7 @@ function getDefaultFormValues(channel: Channel): DeepRequired<SaveableChannel> {
     },
     watermark: {
       ...(channel.watermark ?? {}),
+      source: channel.watermark?.source ?? 'image',
       enabled: channel.watermark?.enabled ?? false,
       url: channel.watermark?.url ?? '',
       width: channel.watermark?.width ?? 10,


### PR DESCRIPTION
Depends on #1986. This is the second PR in the stack; its hardware-overlay commit will disappear from this diff when #1986 merges.

## Summary

- add **Current program title** as a channel overlay source alongside the existing image source
- format episodes as `Show · S01E02 · Episode title`, with sensible movie, video, and track fallbacks
- generate a small transparent lavfi/drawtext input per program, using a cache-backed `textfile` and `expansion=none` so metadata punctuation and percent signs remain data
- reuse the existing position, width, margin, opacity, fade, and duration controls; selecting program titles defaults an untouched duration to 5 seconds and width to 75%
- fail open by skipping the title overlay if its metadata asset cannot be created

## Validation

- `pnpm lint-changed`
- server and web typechecks
- full server suite: 1,141 passed, 2 skipped
- live Intel N100 / FFmpeg 7.1.1 validation on the Simpsons channel: title visible at 2 seconds, absent at 9 seconds, `overlay_vaapi` active, and no full-frame `hwdownload`
