### PR TITLE
fix: parse air dates written in any timezone

### DIFF
--- a/server/src/api/ApiProgramConverters.ts
+++ b/server/src/api/ApiProgramConverters.ts
@@ -35,6 +35,7 @@ import type { Maybe, Nullable } from '../types/util.ts';
 import { isNonEmptyString } from '../util/index.ts';
 import type { Logger } from '../util/logging/LoggerFactory.ts';
 import { LoggerFactory } from '../util/logging/LoggerFactory.ts';
+import { parseAirDate } from '../util/airDate.ts';
 import { titleToSortTitle } from '../util/programs.ts';
 
 export class ApiProgramConverters {
@@ -77,18 +78,12 @@ export class ApiProgramConverters {
       return null;
     }
 
-    const parsed = dayjs(
-      program.originalAirDate,
-      [`YYYY-MM-DDTHH:mm:ssZ`, `YYYY-MM-DD`],
-      true,
-    );
-    const releaseDate = parsed.isValid() ? +parsed : null;
+    const parsed = parseAirDate(program.originalAirDate);
+    const releaseDate = parsed ? +parsed : null;
     const year =
       program.year && program.year > 0
         ? program.year
-        : parsed.isValid()
-          ? parsed.year()
-          : null;
+        : (parsed?.year() ?? null);
 
     const identifiers =
       program.externalIds?.map((eid) => ({

--- a/server/src/services/XmlTvWriter.ts
+++ b/server/src/services/XmlTvWriter.ts
@@ -12,7 +12,6 @@ import {
   type XmltvProgramme,
 } from '@iptv/xmltv';
 import { Mutex } from 'async-mutex';
-import dayjs from 'dayjs';
 import { inject, injectable } from 'inversify';
 import { compact, escape, flatMap, isNil, map, round } from 'lodash-es';
 import { writeFile } from 'node:fs/promises';
@@ -20,6 +19,7 @@ import { match } from 'ts-pattern';
 import { type ArtworkType } from '../db/schema/Artwork.ts';
 import { ProgramWithRelationsOrm } from '../db/schema/derivedTypes.ts';
 import { MaterializedGuideItem } from '../types/guide.ts';
+import { parseAirDate } from '../util/airDate.ts';
 import { loggingDef } from '../util/logging/loggingDef.ts';
 
 const lock = new Mutex();
@@ -201,15 +201,9 @@ export class XmlTvWriter {
         ];
       }
 
-      if (program.originalAirDate) {
-        const parsed = dayjs(
-          program.originalAirDate,
-          [`YYYY-MM-DDTHH:mm:ssZ`, `YYYY-MM-DD`],
-          true,
-        );
-        if (parsed.isValid()) {
-          partial.date ??= parsed.toDate();
-        }
+      const airDate = parseAirDate(program.originalAirDate);
+      if (airDate) {
+        partial.date ??= airDate.toDate();
       }
 
       partial.category = [];

--- a/server/src/util/airDate.test.ts
+++ b/server/src/util/airDate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+import dayjs from './dayjs.ts';
+import { parseAirDate } from './airDate.ts';
+
+/**
+ * The parser these replaced. Kept here so the widening can be proven safe
+ * rather than asserted: every input the strict form accepted must still parse
+ * to the same instant, or release dates would move for programs that were
+ * working before.
+ */
+const strictImplementation = (value: string) =>
+  dayjs(value, [`YYYY-MM-DDTHH:mm:ssZ`, `YYYY-MM-DD`], true);
+
+/** The offset the running machine would itself write for this date. */
+const localOffset = dayjs('2020-05-04').format('Z');
+
+describe('parseAirDate', () => {
+  describe('offsets other than the server’s own', () => {
+    /**
+     * The bug this fixes. Air dates are stored as `dayjs(d).format()`, which
+     * embeds the writing machine's offset, and the strict parser only accepted
+     * an offset equal to the reading machine's. Changing the server timezone,
+     * moving the database or setting TZ on a container that had been running
+     * UTC therefore emptied every release date at once.
+     *
+     * These offsets are fixed rather than derived precisely because they are
+     * foreign to whatever zone the suite runs in — that is the case that broke.
+     */
+    test.each([
+      '-08:00',
+      '-05:00',
+      '-04:00',
+      '+00:00',
+      '+01:00',
+      '+05:30',
+      '+09:00',
+      '+12:45',
+    ])('parses an air date written at %s', (offset) => {
+      const value = `2020-05-04T00:00:00${offset}`;
+
+      const parsed = parseAirDate(value);
+
+      expect(parsed).toBeDefined();
+      // Same instant the offset denotes, independent of where this runs.
+      expect(+parsed!).toBe(Date.parse(value));
+    });
+
+    test('all offsets agree on the instant they name', () => {
+      const instants = ['-05:00', '+00:00', '+05:30'].map(
+        (o) => +parseAirDate(`2020-05-04T00:00:00${o}`)!,
+      );
+
+      expect(new Set(instants).size).toBe(3);
+    });
+  });
+
+  describe('forms the strict parser never accepted anywhere', () => {
+    test.each([
+      ['literal Z suffix', '2020-05-04T10:00:00Z'],
+      ['no offset at all', '2020-05-04T10:00:00'],
+      ['milliseconds', '2020-05-04T10:00:00.000Z'],
+    ])('parses %s', (_label, value) => {
+      expect(strictImplementation(value).isValid()).toBe(false);
+      expect(parseAirDate(value)).toBeDefined();
+    });
+  });
+
+  describe('the widening does not move dates that already worked', () => {
+    test.each([
+      '2020-05-04',
+      '1970-01-01',
+      '2020-12-31',
+      `2020-05-04T00:00:00${localOffset}`,
+      `2020-12-31T23:00:00${dayjs('2020-12-31').format('Z')}`,
+    ])('%s parses to the same instant as before', (value) => {
+      const before = strictImplementation(value);
+      // Guard: if this stopped being an input the strict parser accepts, the
+      // case is no longer testing what it claims to.
+      expect(before.isValid()).toBe(true);
+
+      const after = parseAirDate(value);
+
+      expect(after).toBeDefined();
+      expect(+after!).toBe(+before);
+      expect(after!.year()).toBe(before.year());
+    });
+  });
+
+  describe('absent and unparseable input', () => {
+    test.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['whitespace', '   '],
+      ['not a date', 'not a date'],
+    ])('returns undefined for %s', (_label, value) => {
+      // The callers distinguish these with `parsed ? ... : null`, so an invalid
+      // dayjs instance here would read as a valid date.
+      expect(parseAirDate(value)).toBeUndefined();
+    });
+  });
+});

--- a/server/src/util/airDate.ts
+++ b/server/src/util/airDate.ts
@@ -1,0 +1,45 @@
+import type { Dayjs } from 'dayjs';
+import type { Maybe, Nullable } from '../types/util.ts';
+import dayjs from './dayjs.ts';
+import { isNonEmptyString } from './index.ts';
+
+/**
+ * Parses a program's `originalAirDate`, or returns undefined when it is absent
+ * or unparseable.
+ *
+ * Deliberately not `dayjs(value, ['YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DD'], true)`,
+ * which is what the call sites used to do. Under strict customParseFormat the
+ * `Z` token matches a numeric offset and requires it to equal the *server's own*
+ * UTC offset, so a value only parsed on a machine in the timezone that wrote it.
+ * Verified across America/New_York, UTC and Asia/Kolkata: of seven offsets,
+ * exactly one parsed in each zone, always the local one.
+ *
+ * Air dates are stored by ProgramMinter as `dayjs(releaseDate).format()`, which
+ * embeds the offset. So the values round-trip on the machine that scanned them
+ * and stop resolving the moment the server's timezone changes — moving the
+ * database, setting TZ on a container that had been running UTC, or restoring a
+ * backup elsewhere silently emptied every release date and every XMLTV `date`.
+ * The strict `Z` token also never matched a literal "Z" suffix, so the most
+ * common ISO form never parsed anywhere.
+ *
+ * Plain `dayjs(value)` handles any offset, the "Z" suffix and bare dates. It is
+ * also what ProgramConverter and ProgramIterator already use on this same
+ * field, so this makes the readers agree rather than introducing a fourth
+ * interpretation. Every input the strict form accepted parses to a byte
+ * identical instant; only inputs that previously failed change.
+ *
+ * It is faster, too, which matters because this runs once per program:
+ *
+ *   "2020-05-04"                 44.14us -> 1.84us
+ *   "2020-05-04T00:00:00-04:00"   9.78us -> 3.09us
+ *   "2020-05-04T10:00:00Z"       14.00us -> 1.49us
+ */
+export function parseAirDate(
+  value: Nullable<string> | undefined,
+): Maybe<Dayjs> {
+  if (!isNonEmptyString(value)) {
+    return undefined;
+  }
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed : undefined;
+}


### PR DESCRIPTION
## The bug

Air dates are stored by `ProgramMinter` as `dayjs(releaseDate).format()`, which embeds the offset — `2020-05-04T00:00:00-04:00`. Both readers then parsed them with strict `customParseFormat`, where the `Z` token matches a *numeric offset* and requires it to equal the reading machine's own UTC offset.

So a stored value only resolves on a server in the timezone that wrote it. Probing seven offsets across three zones, exactly one parsed in each — always the local one:

| stored offset | read under `America/New_York` | under `UTC` | under `Asia/Kolkata` |
|---|---|---|---|
| `-05:00` | ✗ | ✗ | ✗ |
| `-04:00` | ✓ | ✗ | ✗ |
| `+00:00` | ✗ | ✓ | ✗ |
| `+05:30` | ✗ | ✗ | ✓ |

**Impact:** change the server's timezone and every release date and every XMLTV `date` attribute empties at once — moving the database to another machine, setting `TZ` on a container that had been running UTC, or restoring a backup elsewhere. DST does *not* trigger it, because the stored offset tracks the air date rather than the scan time.

Separately, the strict `Z` token never matched a literal `Z` suffix, so `2020-05-04T10:00:00Z` — the most common ISO form — failed in every timezone.

## The fix

The bug had two copies, `ApiProgramConverters` and `XmlTvWriter`, each with its own format array. Both now share `src/util/airDate.ts`, which uses plain `dayjs(value)`.

That is already what `ProgramConverter` and `ProgramIterator` do with this same field — there were four readers using three interpretations, and two of them were never affected. This makes them agree rather than introducing a fourth.

## Why the widening is safe

Every input the strict parser accepted parses to an identical instant. The tests assert this against the old implementation kept as a reference, rather than assuming it, so only previously-failing inputs change behaviour.

## Performance

This runs once per program, so it is on a hot path:

| input | before | after |
|---|---|---|
| `2020-05-04` | 44.14µs | 1.84µs |
| `2020-05-04T00:00:00-04:00` | 9.78µs | 3.09µs |
| `2020-05-04T10:00:00Z` | 14.00µs | 1.49µs |

## Testing

22 new tests, green under `America/New_York`, `UTC`, `Asia/Kolkata` and `Pacific/Auckland`. Full server suite green under `UTC` and `America/New_York` (1153 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)