### PR TITLE
fix: four bugs that silently do nothing

### DIFF
--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -63,14 +63,14 @@ import { transcodeConfigOrmToDto } from '../db/converters/transcodeConfigConvert
 import type { ChannelAndLineup } from '../db/interfaces/IChannelDB.ts';
 import type { ChannelOrmWithRelations } from '../db/schema/derivedTypes.ts';
 import { Result } from '../types/result.ts';
-import { PagingParams } from '../types/schemas.ts';
+import { PagingParams, TruthyQueryParam } from '../types/schemas.ts';
 
 dayjs.extend(duration);
 
 const ChannelLineupQuery = z.object({
   from: z.iso.datetime().optional().pipe(z.coerce.date()),
   to: z.iso.datetime().optional().pipe(z.coerce.date()),
-  includePrograms: z.coerce.boolean().default(false),
+  includePrograms: TruthyQueryParam.default(false),
 });
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -68,8 +68,12 @@ import { PagingParams, TruthyQueryParam } from '../types/schemas.ts';
 dayjs.extend(duration);
 
 const ChannelLineupQuery = z.object({
-  from: z.iso.datetime().optional().pipe(z.coerce.date()),
-  to: z.iso.datetime().optional().pipe(z.coerce.date()),
+  // `.optional()` must sit outside the pipe. Inside, it only lets `undefined`
+  // through the left half and `z.coerce.date()` still runs on it; and because
+  // the pipe's output is non-optional, zod does not treat the key as optional
+  // either, so omitting the query string is a 400.
+  from: z.iso.datetime().pipe(z.coerce.date()).optional(),
+  to: z.iso.datetime().pipe(z.coerce.date()).optional(),
   includePrograms: TruthyQueryParam.default(false),
 });
 

--- a/server/src/api/debugApi.ts
+++ b/server/src/api/debugApi.ts
@@ -7,6 +7,7 @@ import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { LogLevels, tag } from '@tunarr/types';
 import { ChannelLineupQuery } from '@tunarr/types/api';
+import { TruthyQueryParam } from '../types/schemas.ts';
 import { ChannelLineupSchema } from '@tunarr/types/schemas';
 import dayjs from 'dayjs';
 import { isUndefined } from 'lodash-es';
@@ -118,7 +119,7 @@ export const debugApi: RouterPluginAsyncCallback = async (fastify) => {
   );
 
   const CreateLineupSchema = ChannelQuerySchema.extend({
-    live: z.coerce.boolean(),
+    live: TruthyQueryParam,
     startTime: z.coerce.number().optional(),
     endTime: z.coerce.number().optional(),
   });

--- a/server/src/api/programmingApi.ts
+++ b/server/src/api/programmingApi.ts
@@ -693,7 +693,7 @@ export const programmingApi: RouterPluginAsyncCallback = async (fastify) => {
         tags: ['Programs'],
         params: BasicIdParamSchema,
         querystring: z.object({
-          forward: z.coerce.boolean().default(true),
+          forward: TruthyQueryParam.default(true),
         }),
         response: {
           200: z.object({ url: z.string() }),

--- a/server/src/api/tasksApi.ts
+++ b/server/src/api/tasksApi.ts
@@ -2,9 +2,10 @@ import { GlobalScheduler } from '@/services/Scheduler.js';
 import type { RouterPluginAsyncCallback } from '@/types/serverType.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { seq } from '@tunarr/shared/util';
+import { TruthyQueryParam } from '../types/schemas.ts';
 import { TaskSchema } from '@tunarr/types/schemas';
 import dayjs from 'dayjs';
-import { ServiceIdentifier } from 'inversify';
+import type { ServiceIdentifier } from 'inversify';
 import { isFunction } from 'lodash-es';
 import { z } from 'zod/v4';
 import { container } from '../container.ts';
@@ -78,11 +79,7 @@ export const tasksApiRouter: RouterPluginAsyncCallback = async (fastify) => {
           id: z.string(),
         }),
         querystring: z.object({
-          background: z.coerce
-            .boolean()
-            .or(z.stringbool())
-            .optional()
-            .default(true),
+          background: TruthyQueryParam.optional().default(true),
         }),
         body: z.any(),
         response: {

--- a/server/src/services/TvGuideService.test.ts
+++ b/server/src/services/TvGuideService.test.ts
@@ -56,8 +56,6 @@ function makeChannelWithLineup(overrides?: Partial<ChannelOrm>) {
   return { channel, lineup: makeEmptyLineup() };
 }
 
-
-
 describe('TVGuideService', () => {
   describe('buildAllChannels', () => {
     it('removes a deleted channel from XMLTV output on the next guide build', async () => {
@@ -121,6 +119,81 @@ describe('TVGuideService', () => {
       ).map((entry) => entry.channel.uuid);
       expect(secondWriteChannelIds).toContain(channelA.channel.uuid);
       expect(secondWriteChannelIds).not.toContain(channelB.channel.uuid);
+    });
+  });
+
+  describe('concurrent guide builds', () => {
+    /**
+     * withGuideContext keeps its per-build context — channelsById and
+     * accumulateTable — on the instance and clears it in a finally. Two builds
+     * that overlap share one slot, so whichever finished first wiped the
+     * context out from under the other, which then found no entry for the
+     * channel it was building and threw. buildChannelGuideWithRetries logs and
+     * swallows that, so the only symptom was a guide quietly missing channels.
+     *
+     * This asserts the invariant that prevents it — that two builds never hold
+     * the context at once — rather than the corruption itself. Reproducing the
+     * corruption needs a second build to finish inside a specific window of the
+     * first, which depends on how many yields the lineups happen to produce and
+     * is not something to pin a regression test to.
+     */
+    it('serializes builds so one cannot clear another’s context', async () => {
+      const channelA = makeChannelWithLineup({ number: 1, name: 'Channel A' });
+      const lineups = { [channelA.channel.uuid]: channelA };
+
+      // Park the first build inside its context, at the last await before the
+      // finally that clears it.
+      let releaseFirstWrite: () => void = () => {};
+      let writeCalls = 0;
+      let inFirstWrite: (() => void) | undefined;
+      const firstWriteEntered = new Promise<void>((r) => (inFirstWrite = r));
+      const heldWrite = new Promise<void>((r) => (releaseFirstWrite = r));
+      const mockWrite = vi.fn().mockImplementation(async () => {
+        if (++writeCalls === 1) {
+          inFirstWrite?.();
+          await heldWrite;
+        }
+      });
+
+      const mockLoadAllLineups = vi.fn().mockResolvedValue(lineups);
+      const service = new TVGuideService(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { write: mockWrite } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { push: vi.fn() } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { loadAllLineups: mockLoadAllLineups } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { getProgramsByIds: vi.fn().mockResolvedValue([]) } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+      );
+
+      const guideDuration = dayjs.duration({ hours: 4 });
+      const first = service.buildAllChannels(guideDuration, true);
+      await firstWriteEntered;
+
+      const second = service.buildAllChannels(guideDuration, true);
+      // Give the second build every chance to start. Unserialized it would
+      // load its own context here and clear it on the way out, while the first
+      // build is still holding one.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      expect(mockLoadAllLineups).toHaveBeenCalledTimes(1);
+
+      releaseFirstWrite();
+      await Promise.all([first, second]);
+
+      expect(mockLoadAllLineups).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/server/src/services/TvGuideService.ts
+++ b/server/src/services/TvGuideService.ts
@@ -1,3 +1,4 @@
+import { Mutex } from 'async-mutex';
 import { ChannelDB } from '@/db/ChannelDB.js';
 import { ProgramDB } from '@/db/ProgramDB.js';
 import { ProgramConverter } from '@/db/converters/ProgramConverter.js';
@@ -149,8 +150,9 @@ export class TVGuideService {
   // generation.
   private accumulateTable: Record<string, number[]> = {};
   private channelsById?: Record<string, ChannelWithLineup>;
+  private guideBuildLock = new Mutex();
 
-  @InjectLogger() private declare readonly logger: Logger;
+  @InjectLogger() declare private readonly logger: Logger;
 
   constructor(
     @inject(XmlTvWriter) xmltv: XmlTvWriter,
@@ -389,8 +391,30 @@ export class TVGuideService {
     return this.getChannelGuides(dateRange);
   }
 
-  // Initializes per-build context and then clears it
+  /**
+   * Initializes per-build context, runs the build, and clears the context.
+   *
+   * Serialized, because the context lives on the instance rather than in the
+   * call. Two overlapping builds share one `channelsById`/`accumulateTable`
+   * slot, so whichever finished first cleared it out from under the other,
+   * which then found no entry for the channel it was building and threw.
+   * buildChannelGuideWithRetries logs and swallows that, so the only symptom
+   * was a guide quietly missing channels.
+   *
+   * A channel save calling refreshGuide while the scheduled UpdateXmlTvTask
+   * runs buildAllChannels is enough to overlap, and the yields inside
+   * getChannelPrograms give the second build room to run.
+   *
+   * Safe to serialize: nothing reachable from a builder re-enters this, so
+   * there is no path that would deadlock on the lock it already holds.
+   */
   private async withGuideContext<T>(builder: () => Promise<T>) {
+    return this.guideBuildLock.runExclusive(async () => {
+      return await this.buildWithContext(builder);
+    });
+  }
+
+  private async buildWithContext<T>(builder: () => Promise<T>) {
     try {
       this.channelsById = await this.channelDB.loadAllLineups();
       this.accumulateTable = mapValues(this.channelsById, (channel) => {

--- a/server/src/types/schemas.test.ts
+++ b/server/src/types/schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import z from 'zod/v4';
+import { TruthyQueryParam } from './schemas.ts';
+
+describe('TruthyQueryParam', () => {
+  /**
+   * The bug this replaced. `z.coerce.boolean()` is `Boolean(value)`, and every
+   * non-empty string is truthy, so a parameter declared that way could never be
+   * turned off — `?flag=false` read as true with no validation error to show
+   * for it.
+   */
+  test.each(['false', '0'])(
+    'z.coerce.boolean() would wrongly read %s as true',
+    (value) => {
+      expect(z.coerce.boolean().parse(value)).toBe(true);
+
+      expect(TruthyQueryParam.parse(value)).not.toBe(true);
+    },
+  );
+
+  test('a union branch after z.coerce.boolean() is unreachable', () => {
+    // The previous fix attempt was `z.coerce.boolean().or(z.stringbool())`.
+    // z.coerce.boolean() never fails, so the second branch never runs and the
+    // parameter stayed broken.
+    const neverFails = z.coerce.boolean().or(z.stringbool());
+
+    expect(neverFails.parse('false')).toBe(true);
+  });
+
+  test.each([
+    ['true', true],
+    ['false', false],
+    ['1', true],
+    ['0', false],
+    [true, true],
+    [false, false],
+    // A bare "?flag" arrives as the empty string, which coerces to 0.
+    ['', false],
+  ])('parses %s as %s', (input, expected) => {
+    expect(TruthyQueryParam.parse(input)).toBe(expected);
+  });
+
+  test.each(['abc', 'maybe', 'no', 'yes', {}])('rejects %s', (input) => {
+    expect(() => TruthyQueryParam.parse(input)).toThrow();
+  });
+});

--- a/server/src/types/schemas.test.ts
+++ b/server/src/types/schemas.test.ts
@@ -40,6 +40,30 @@ describe('TruthyQueryParam', () => {
     expect(TruthyQueryParam.parse(input)).toBe(expected);
   });
 
+  /**
+   * The `z.coerce.number()` branch accepts any numeric, but the transform then
+   * compared strictly against 1, so every other number read as false. That is
+   * the same failure this schema exists to prevent, one union branch over:
+   * `?background=2` ran the task in the background with no validation error.
+   */
+  test.each([
+    ['2', true],
+    ['10', true],
+    ['-1', true],
+    ['0.5', true],
+    [2, true],
+    [-1, true],
+  ])('parses the non-1 number %s as %s', (input, expected) => {
+    expect(TruthyQueryParam.parse(input)).toBe(expected);
+  });
+
+  test.each(['0', '', ' ', 0, -0])(
+    'parses the zero-valued %s as false',
+    (input) => {
+      expect(TruthyQueryParam.parse(input)).toBe(false);
+    },
+  );
+
   test.each(['abc', 'maybe', 'no', 'yes', {}])('rejects %s', (input) => {
     expect(() => TruthyQueryParam.parse(input)).toThrow();
   });

--- a/server/src/types/schemas.ts
+++ b/server/src/types/schemas.ts
@@ -3,14 +3,9 @@ import z from 'zod/v4';
 import { programSourceTypeFromString } from '../db/custom_types/ProgramSourceType.ts';
 import type { Nilable } from './util.ts';
 
-export const TruthyQueryParam = z
-  .union([
-    z.boolean(),
-    z.literal('true'),
-    z.literal('false'),
-    z.coerce.number(),
-  ])
-  .transform((value) => value === 1 || value === true || value === 'true');
+// Defined in @tunarr/types so the schemas that live there can use it too, and
+// re-exported here so existing server-side imports keep resolving.
+export { TruthyQueryParam } from '@tunarr/types/schemas';
 
 export const PagingParams = z.object({
   limit: z.coerce.number().min(-1).default(-1),

--- a/server/tests/channels.test.ts
+++ b/server/tests/channels.test.ts
@@ -83,6 +83,74 @@ describe('POST /channels - transcode config validation', () => {
   });
 });
 
+/**
+ * `from`/`to` were declared `z.iso.datetime().optional().pipe(z.coerce.date())`.
+ * The `.optional()` sits inside the pipe, so it only lets `undefined` through
+ * the left half; `z.coerce.date()` then runs `new Date(undefined)` and fails.
+ * Because the pipe's output is non-optional, zod does not treat the object key
+ * as optional either, so omitting the query string was a 400 — even though the
+ * published OpenAPI contract declares both as optional, and the handlers pass
+ * them to `OpenDateTimeRange.create`, which accepts `undefined` on both sides.
+ */
+describe('GET /channels/:id/lineup - optional date range', () => {
+  let existingChannelId: string;
+
+  beforeAll(async () => {
+    const channelDB = container.get<ChannelDB>(KEYS.ChannelDB);
+    const result = await channelDB.saveChannel({
+      ...makeChannelPayload(validTranscodeConfigId),
+      number: 998,
+      name: 'Lineup Query Channel',
+    } as SaveableChannel);
+    existingChannelId = result.channel.uuid;
+  });
+
+  // `/lineup` can legitimately answer 500 ("Still waiting for guide to
+  // generate") against a freshly-booted server, which has nothing to do with
+  // query validation. What must not happen is a 400.
+  test('accepts no query string at all', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/channels/${existingChannelId}/lineup`,
+    });
+
+    expect(res.statusCode, res.body).not.toBe(400);
+    // The route blocks until the guide has generated, which on a cold test
+    // server takes longer than vitest's 5s default.
+  }, 30_000);
+
+  test('accepts only one side of the range', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/channels/${existingChannelId}/lineup`,
+      query: { from: new Date(0).toISOString() },
+    });
+
+    expect(res.statusCode, res.body).not.toBe(400);
+  }, 30_000);
+
+  test('still rejects a malformed date', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/channels/${existingChannelId}/lineup`,
+      query: { from: 'notadate' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  // `/fallbacks` never reads `from`/`to` at all, yet could not be called
+  // without them.
+  test('accepts no query string on the fallbacks route', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/channels/${existingChannelId}/fallbacks`,
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
 describe('PUT /channels/:id - transcode config validation', () => {
   let existingChannelId: string;
 

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -9,6 +9,7 @@ import {
   SystemSettingsSchema,
 } from '../SystemSettings.js';
 import { JellyfinItemFields, JellyfinItemKind } from '../jellyfin/index.js';
+import { TruthyQueryParam } from '../schemas/utilSchemas.js';
 import { SearchRequestSchema } from '../schemas/SearchRequest.js';
 import {
   ChannelConcatStreamModes,
@@ -71,7 +72,7 @@ export const ChannelNumberParamSchema = z.object({
 export const ChannelLineupQuery = z.object({
   from: z.coerce.date().optional(),
   to: z.coerce.date().optional(),
-  includePrograms: z.coerce.boolean().default(false),
+  includePrograms: TruthyQueryParam.default(false),
 });
 
 export const LookupExternalProgrammingSchema = z.object({

--- a/types/src/schemas/utilSchemas.ts
+++ b/types/src/schemas/utilSchemas.ts
@@ -156,6 +156,11 @@ export type Schedule = z.infer<typeof ScheduleSchema>;
  * Accepts "true"/"false" and any number, where 0 is false. An absent value
  * ("?flag" with no "=") arrives as the empty string and coerces to 0, so it is
  * false; declare `.default(true)` if a bare flag should mean something else.
+ *
+ * The number test is `!== 0` rather than `=== 1`. Comparing against 1 would
+ * accept any numeric through the coercion branch and then quietly read every
+ * value but 1 as false, so `?background=2` would run in the background — the
+ * same silent-false failure this schema exists to prevent.
  */
 export const TruthyQueryParam = z
   .union([
@@ -164,4 +169,9 @@ export const TruthyQueryParam = z
     z.literal('false'),
     z.coerce.number(),
   ])
-  .transform((value) => value === 1 || value === true || value === 'true');
+  .transform(
+    (value) =>
+      value === true ||
+      value === 'true' ||
+      (typeof value === 'number' && value !== 0),
+  );

--- a/types/src/schemas/utilSchemas.ts
+++ b/types/src/schemas/utilSchemas.ts
@@ -142,3 +142,26 @@ export const ContentProgramTypeSchema = z.enum([
 ]);
 
 export type Schedule = z.infer<typeof ScheduleSchema>;
+
+/**
+ * A boolean carried in a query string.
+ *
+ * Not `z.coerce.boolean()`, which is `Boolean(value)` and so returns true for
+ * every non-empty string — including "false" and "0". A parameter declared that
+ * way cannot be turned off: `?flag=false` reads as true, silently, with no
+ * validation error to indicate it. Nor is it `.or(z.stringbool())` as a
+ * fallback, because `z.coerce.boolean()` never fails, so a following union
+ * branch is unreachable.
+ *
+ * Accepts "true"/"false" and any number, where 0 is false. An absent value
+ * ("?flag" with no "=") arrives as the empty string and coerces to 0, so it is
+ * false; declare `.default(true)` if a bare flag should mean something else.
+ */
+export const TruthyQueryParam = z
+  .union([
+    z.boolean(),
+    z.literal('true'),
+    z.literal('false'),
+    z.coerce.number(),
+  ])
+  .transform((value) => value === 1 || value === true || value === 'true');


### PR DESCRIPTION
Four bugs with the same failure mode: the feature doesn't work, and nothing says so. No error, no log, no validation failure.

---

## 1. Boolean query parameters ignore `false`

`z.coerce.boolean()` is `Boolean(value)`, and every non-empty string is truthy. A parameter declared that way can never be turned off — `?flag=false` and `?flag=0` both read as `true`, silently.

The worst case is `POST /tasks/:id/run?background=false`, the documented way to run a task and wait for its result. It always ran in the background and returned 202, so callers could not await a task at all. Verified against a running server:

| query | before | after |
|---|---|---|
| `background=true` | 202 background | 202 background |
| `background=false` | **202 background** | **200 synchronous** |
| `background=0` | **202 background** | **200 synchronous** |
| `background=1` | 202 background | 202 background |
| omitted | 202 background | 202 background |

That parameter had already been noticed once and patched as `z.coerce.boolean().or(z.stringbool())`. **The fallback is unreachable** — `z.coerce.boolean()` never fails, so a following union branch never runs, and the parameter stayed broken. Both the original bug and the failed fix are pinned by tests.

Also affected: `?includePrograms=false` on the channel lineup routes (declared in both `server` and `@tunarr/types`), `?forward=false` on the program external-link route, and `live` on a debug lineup route.

All now use `TruthyQueryParam`, which was already the convention — 25 other parameters use it, including `includeEpisodes` twelve lines from one of the broken ones. It moves to `@tunarr/types` so the schemas defined there share one definition, and is re-exported from the server so existing imports resolve unchanged.

The one remaining `z.coerce.boolean()` is in the Plex library schema, where the input is a JSON number and coercion is correct. Left alone deliberately.

---

## 2. Overlapping guide builds clear each other's context

`withGuideContext` keeps its per-build state — `channelsById` and `accumulateTable` — on the instance and clears it in a `finally`. Two overlapping builds share that one slot, so whichever finishes first wipes the context out from under the other, which then finds no entry for the channel it is building and throws. `buildChannelGuideWithRetries` logs and swallows it, so the only symptom is a guide quietly missing channels.

Both entry points are public and neither took a lock. A channel save calling `refreshGuide` while the scheduled `UpdateXmlTvTask` runs `buildAllChannels` is enough to overlap.

Now serialized with a mutex. Safe here: nothing reachable from a builder re-enters `withGuideContext`, so there is no path that deadlocks on the lock it holds.

**On the test:** it asserts the invariant — two builds never hold the context at once — rather than the corruption itself. Reproducing the corruption requires the second build to finish inside a specific window of the first, which depends on how many yields the lineups happen to produce; that is too fragile to pin a regression test to. The test was checked against the unfixed code and **fails there**, so it guards the fix rather than restating it.

---

## 3. `TruthyQueryParam` only accepts the literal `1`

Found while reviewing #1: the schema added above has a `z.coerce.number()` union branch that accepts any numeric, but the transform then compared strictly against `1`, so every other number read as **false**. `"2"`, `"10"` and `"-1"` all resolved to false.

`POST /tasks/:id/run?background=2` therefore ran **synchronously** — the exact failure #1 set out to remove, one union branch over. The doc comment added in that commit already promised *"any number, where 0 is false"*; the implementation contradicted its own documented contract.

The test is now `!== 0`. `"2"`/`"10"`/`"-1"` → true, `"0"`/`""`/`" "` → false, `"abc"` still rejected.

---

## 4. `.optional()` inside `.pipe()` makes `from`/`to` required

`ChannelLineupQuery` — modified in #1 for `includePrograms` — declared its dates as `z.iso.datetime().optional().pipe(z.coerce.date())`. The `.optional()` sits **inside** the pipe, so it only lets `undefined` through the left half and `z.coerce.date()` still runs on it. And because the pipe's output is non-optional, zod does not treat the object key as optional either.

So `GET /api/channels/{id}/lineup` with no query string returned **400**, with the self-contradictory message *"Invalid input: expected date, received Date"*.

That query object is the `querystring` for three routes — `/channels/:id/lineup`, `/channels/:id/fallbacks` and `/channels/all/lineups`. The handlers were written for the opposite: they pass both values to `OpenDateTimeRange.create`, whose signature takes `| undefined` on each side. `/fallbacks` never reads either one, yet could not be called without them.

The published contract disagreed with the runtime too — `web/src/generated/types.gen.ts` declares `query?: { from?: string; to?: string }`, so any consumer following the OpenAPI spec got a 400. Tunarr's own `useTvGuide` always passes both, which is why it went unnoticed.

Moving `.optional()` outside the pipe fixes it. This was the only `.optional().pipe(` site in the repo.

**On the tests:** the `/lineup` assertions are `not.toBe(400)` rather than `toBe(200)`. That route can legitimately answer 500 (*"Still waiting for guide to generate"*) against a cold test server, which has nothing to do with query validation. `/fallbacks` is asserted at a strict 200, and a malformed date is asserted to still be a 400.

---

## Testing

Full server suite green (1162 passed, 2 skipped). `pnpm turbo typecheck` and `pnpm lint-changed` clean. The `background` behaviour in #1 was verified end-to-end against a spawned server, not just at the schema level. The new tests for #3 and #4 were each confirmed red against the pre-fix code — 6 schema cases and 3 route cases respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
