### PR TITLE
fix(db): stop a failed lineup read from erasing the lineup

### DIFF
--- a/server/src/db/channel/LineupRepository.ts
+++ b/server/src/db/channel/LineupRepository.ts
@@ -7,7 +7,7 @@ import { Nullable } from '@/types/util.js';
 import { Timer } from '@/util/Timer.js';
 import { asyncPool } from '@/util/asyncPool.js';
 import dayjs from '@/util/dayjs.js';
-import { fileExists } from '@/util/fsUtil.js';
+import { fileExists, writeFileAtomic } from '@/util/fsUtil.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { MutexMap } from '@/util/mutexMap.js';
 import { seq } from '@tunarr/shared/util';
@@ -205,7 +205,7 @@ export class LineupRepository {
   // Bypasses Low
   async saveChannelLineupDirect(channelId: string, lineup: Lineup) {
     const outPath = this.fileSystemService.getChannelLineupPath(channelId);
-    await fs.writeFile(outPath, JSON.stringify(lineup));
+    await writeFileAtomic(outPath, JSON.stringify(lineup));
   }
 
   async markLineupFileForDeletion(

--- a/server/src/db/json/SchemaBackedJsonDBAdapter.test.ts
+++ b/server/src/db/json/SchemaBackedJsonDBAdapter.test.ts
@@ -1,0 +1,135 @@
+import type { Adapter } from 'lowdb';
+import { z } from 'zod/v4';
+import { SchemaBackedDbAdapter } from './SchemaBackedJsonDBAdapter.ts';
+
+const LineupSchema = z.object({
+  items: z.array(z.object({ id: z.string() })),
+  startTimeOffsets: z.array(z.number()),
+});
+
+type Lineup = z.output<typeof LineupSchema>;
+
+const emptyLineup: Lineup = { items: [], startTimeOffsets: [] };
+
+const populatedLineup: Lineup = {
+  items: [{ id: 'program-1' }, { id: 'program-2' }],
+  startTimeOffsets: [0, 1000],
+};
+
+/**
+ * An in-memory stand-in for lowdb's TextFile. Mirrors its contract exactly:
+ * `read` resolves null when the file does not exist, and rejects for any other
+ * failure. That distinction is the whole subject of these tests.
+ */
+class FakeTextFile implements Adapter<string> {
+  writes: string[] = [];
+  #readError: Error | undefined;
+
+  constructor(private contents: string | null) {}
+
+  failReadsWith(error: Error) {
+    this.#readError = error;
+    return this;
+  }
+
+  read(): Promise<string | null> {
+    if (this.#readError !== undefined) {
+      return Promise.reject(this.#readError);
+    }
+    return Promise.resolve(this.contents);
+  }
+
+  write(str: string): Promise<void> {
+    this.writes.push(str);
+    this.contents = str;
+    return Promise.resolve();
+  }
+}
+
+const ioError = () =>
+  Object.assign(new Error('EIO: i/o error'), { code: 'EIO' });
+
+test('reads through the adapter it was given', async () => {
+  const file = new FakeTextFile(JSON.stringify(populatedLineup));
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/does/not/exist.json',
+    emptyLineup,
+    file,
+  );
+
+  await expect(subject.read()).resolves.toEqual(populatedLineup);
+});
+
+test('does not overwrite the file when the read fails', async () => {
+  const onDisk = JSON.stringify(populatedLineup);
+  const file = new FakeTextFile(onDisk).failReadsWith(ioError());
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/lineup.json',
+    emptyLineup,
+    file,
+  );
+
+  await subject.read().catch(() => null);
+
+  expect(file.writes).toEqual([]);
+});
+
+test('surfaces the read failure to the caller instead of returning defaults', async () => {
+  const file = new FakeTextFile(JSON.stringify(populatedLineup)).failReadsWith(
+    ioError(),
+  );
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/lineup.json',
+    emptyLineup,
+    file,
+  );
+
+  await expect(subject.read()).rejects.toThrow(/EIO/);
+});
+
+test('initializes an absent file from the defaults', async () => {
+  const file = new FakeTextFile(null);
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/lineup.json',
+    emptyLineup,
+    file,
+  );
+
+  await expect(subject.read()).resolves.toEqual(emptyLineup);
+  expect(file.writes).toHaveLength(1);
+});
+
+test('leaves a valid file untouched', async () => {
+  const file = new FakeTextFile(JSON.stringify(populatedLineup));
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/lineup.json',
+    emptyLineup,
+    file,
+  );
+
+  await expect(subject.read()).resolves.toEqual(populatedLineup);
+  expect(file.writes).toEqual([]);
+});
+
+test('repairs a file that is missing fields by merging the defaults in', async () => {
+  const file = new FakeTextFile(
+    JSON.stringify({ items: [{ id: 'program-1' }] }),
+  );
+  const subject = new SchemaBackedDbAdapter(
+    LineupSchema,
+    '/lineup.json',
+    emptyLineup,
+    file,
+  );
+
+  await expect(subject.read()).resolves.toEqual({
+    items: [{ id: 'program-1' }],
+    startTimeOffsets: [],
+  });
+  expect(file.writes).toHaveLength(1);
+});

--- a/server/src/db/json/SchemaBackedJsonDBAdapter.ts
+++ b/server/src/db/json/SchemaBackedJsonDBAdapter.ts
@@ -24,14 +24,15 @@ export class SchemaBackedDbAdapter<T extends z.ZodTypeAny>
   ) {
     this.schema = schema;
     this.path = filename;
-    this.adapter = new TextFile(filename);
   }
 
   async read(): Promise<z.output<T> | null> {
-    const data = await this.adapter.read().catch((e) => {
-      this.logger.error(e);
-      return null;
-    });
+    // A rejection here means the file exists but could not be read (EACCES,
+    // EIO, EMFILE...). It must propagate: treating it as "no data" sends us
+    // down the merge-with-defaults path below, which flushes those defaults
+    // back to disk and destroys the file we failed to read. Only a genuinely
+    // absent file yields null -- TextFile maps ENOENT, and nothing else, to it.
+    const data = await this.adapter.read();
 
     if (data === null && this.defaultValue === null) {
       this.logger.debug('Unexpected null data at %s', this.path.toString());

--- a/server/src/util/fsUtil.ts
+++ b/server/src/util/fsUtil.ts
@@ -1,4 +1,4 @@
-import fs, { constants } from 'node:fs/promises';
+import fs, { constants, type FileHandle } from 'node:fs/promises';
 import path from 'node:path';
 import { isNodeError } from './index.js';
 
@@ -12,6 +12,75 @@ export async function fileExists(path: string) {
     }
 
     // Re-throw any other error type
+    throw e;
+  }
+}
+
+/**
+ * Writes to a scratch file in the destination's directory and renames it into
+ * place. A plain write truncates the destination first, so an interrupted one
+ * leaves a zero-length or partially-written file behind; rename(2) is atomic
+ * within a filesystem, so the destination only ever holds the complete old or
+ * the complete new contents.
+ *
+ * Calls for the same destination are serialized through a per-path queue, so
+ * concurrent callers cannot clobber each other's scratch file (the scratch
+ * name embeds only the pid, so it is shared within a process).
+ *
+ * Durability notes: the scratch file is flushed to disk before the rename so
+ * its contents survive a power loss, but the containing directory is not
+ * synced, so the rename itself is only guaranteed against process
+ * interruption. This matches the write path lowdb uses (steno). The rename
+ * also replaces the destination's inode, so an existing file's permissions
+ * are not preserved: the new file is created with the umask default
+ * (typically 0644).
+ */
+const pendingWrites = new Map<string, Promise<void>>();
+
+export function writeFileAtomic(
+  filePath: string,
+  contents: string,
+): Promise<void> {
+  const queueKey = path.resolve(filePath);
+  const prior = pendingWrites.get(queueKey);
+
+  const write = (prior ?? Promise.resolve())
+    // A failed write does not poison the queue -- the next caller still runs.
+    .catch(() => void 0)
+    .then(() => writeFileAtomicInternal(filePath, contents));
+
+  pendingWrites.set(queueKey, write);
+  return write.finally(() => {
+    if (pendingWrites.get(queueKey) === write) {
+      pendingWrites.delete(queueKey);
+    }
+  });
+}
+
+async function writeFileAtomicInternal(filePath: string, contents: string) {
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.tmp`,
+  );
+
+  let fileHandle: FileHandle | undefined;
+  try {
+    fileHandle = await fs.open(tempPath, 'w');
+    await fileHandle.writeFile(contents);
+    // Flush the data to disk before renaming into place. Without this, a
+    // power loss after the rename can still surface an empty or partial
+    // destination on filesystems with delayed allocation (e.g. ext4).
+    await fileHandle.sync();
+    await fileHandle.close();
+    fileHandle = undefined;
+    await fs.rename(tempPath, filePath);
+  } catch (e) {
+    if (fileHandle !== undefined) {
+      await fileHandle.close().catch(() => void 0);
+    }
+
+    // Best-effort cleanup; the write already failed and is being rethrown.
+    await fs.unlink(tempPath).catch(() => void 0);
     throw e;
   }
 }

--- a/server/src/util/writeFileAtomic.test.ts
+++ b/server/src/util/writeFileAtomic.test.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { writeFileAtomic } from './fsUtil.ts';
+
+// Deliberately kept out of fsUtil.test.ts: that file mocks node:fs/promises
+// module-wide, and these tests need the real filesystem to say anything
+// meaningful about atomicity.
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tunarr-atomic-write-'));
+});
+
+afterEach(async () => {
+  await fs.chmod(dir, 0o700).catch(() => void 0);
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('writes the content to the destination', async () => {
+  const dest = path.join(dir, 'lineup.json');
+
+  await writeFileAtomic(dest, '{"items":[]}');
+
+  await expect(fs.readFile(dest, 'utf-8')).resolves.toEqual('{"items":[]}');
+});
+
+test('replaces existing content', async () => {
+  const dest = path.join(dir, 'lineup.json');
+  await fs.writeFile(dest, '{"items":["old"]}');
+
+  await writeFileAtomic(dest, '{"items":["new"]}');
+
+  await expect(fs.readFile(dest, 'utf-8')).resolves.toEqual(
+    '{"items":["new"]}',
+  );
+});
+
+test('does not leave the scratch file behind', async () => {
+  const dest = path.join(dir, 'lineup.json');
+
+  await writeFileAtomic(dest, '{"items":[]}');
+
+  await expect(fs.readdir(dir)).resolves.toEqual(['lineup.json']);
+});
+
+// A non-atomic write truncates the destination before writing, so a failure
+// part-way through leaves a zero-length or partial file. Writing to a scratch
+// file and renaming into place means a failed write cannot touch the
+// destination at all. Read-only directory permissions discriminate the two:
+// they block creating the scratch file, but not overwriting an existing file.
+// Verified: with a plain fs.writeFile this test fails on both assertions.
+test('leaves the previous contents intact when the write fails', async () => {
+  if (process.getuid?.() === 0) {
+    return; // root ignores the permission bits this relies on
+  }
+
+  const dest = path.join(dir, 'lineup.json');
+  const original = '{"items":["original"]}';
+  await fs.writeFile(dest, original);
+  await fs.chmod(dir, 0o500);
+
+  await expect(
+    writeFileAtomic(dest, '{"items":["replacement"]}'),
+  ).rejects.toThrow();
+
+  await expect(fs.readFile(dest, 'utf-8')).resolves.toEqual(original);
+});
+
+// The scratch name embeds only the pid, so concurrent writes for the same
+// destination share a temp path. They are serialized through a per-path
+// queue: every call must land atomically, with the last queued write winning.
+test('serializes concurrent writes to the same destination', async () => {
+  const dest = path.join(dir, 'lineup.json');
+  const payloads = Array.from({ length: 25 }, (_, i) =>
+    JSON.stringify({ i, padding: 'x'.repeat(4096) }),
+  );
+
+  await Promise.all(payloads.map((payload) => writeFileAtomic(dest, payload)));
+
+  await expect(fs.readFile(dest, 'utf-8')).resolves.toEqual(
+    payloads[payloads.length - 1],
+  );
+  await expect(fs.readdir(dir)).resolves.toEqual(['lineup.json']);
+});
+
+test('a failed write does not block subsequent writes', async () => {
+  if (process.getuid?.() === 0) {
+    return; // root ignores the permission bits this relies on
+  }
+
+  const dest = path.join(dir, 'lineup.json');
+  await writeFileAtomic(dest, '{"n":1}');
+  await fs.chmod(dir, 0o500);
+  await expect(writeFileAtomic(dest, '{"n":2}')).rejects.toThrow();
+  await fs.chmod(dir, 0o700);
+
+  await writeFileAtomic(dest, '{"n":3}');
+
+  await expect(fs.readFile(dest, 'utf-8')).resolves.toEqual('{"n":3}');
+});


### PR DESCRIPTION
## The bug

`SchemaBackedDbAdapter.read()` caught every error from the underlying adapter and returned `null`:

```ts
const data = await this.adapter.read().catch((e) => {
  this.logger.error(e);
  return null;
});
```

lowdb's `TextFile.read()` returns `null` **only** for `ENOENT` and throws for everything else, so that catch collapsed *"this file could not be read"* into *"this file does not exist"*.

`LineupRepository` constructs this adapter with a `defaultValue` for every channel, so the `null` did not hit the early return. It reached `parsed = {}`, failed schema validation, took the merge-with-defaults branch, succeeded, set `needsWriteFlush`, and **wrote the defaults back over the file that had just failed to read** — during the failed read itself, not on a later save.

A transient `EACCES`/`EIO`/`EMFILE` therefore erased a channel's programming. The channel still appeared in the UI with an empty schedule, the guide showed nothing, and streams fell back to flex. The only trace was one `debug`-level line.

## The fix

Read errors propagate. `null` (a genuinely absent file) still initialises from defaults exactly as before.

Three behaviours are pinned by tests so this cannot overshoot into "never write defaults":

- an absent file is still initialised from the defaults, and still written
- a valid file is returned untouched, with no write
- a file missing fields is still repaired by merging the defaults in

## Two related fixes in the same path

**The constructor discarded its injected adapter.**

```ts
constructor(..., private adapter: Adapter<string> = new TextFile(filename)) {
  this.adapter = new TextFile(filename);   // overwrites the parameter
}
```

The `adapter` parameter silently did nothing. The sync variant does not have this. Honouring it is also what makes the class testable at all.

**`saveChannelLineupDirect` wrote non-atomically.** A plain `fs.writeFile` truncates before writing, so an interrupted write leaves a zero-length lineup file — which the adapter path above then treated as empty and overwrote with defaults. It now goes through a new `writeFileAtomic` helper that writes a scratch file and renames it into place.

## Testing

- `SchemaBackedJsonDBAdapter.test.ts` (new, 6 tests) — the failed-read case plus the three regression guards above.
- `writeFileAtomic.test.ts` (new, 4 tests) — kept separate from `fsUtil.test.ts` because that file mocks `node:fs/promises` module-wide and these need the real filesystem.
- The atomicity test was verified to be a genuine discriminator: with a plain `fs.writeFile` it fails on both assertions (the write succeeds *and* the destination is clobbered).
- Full monorepo suite: 1467 passed, 2 skipped. Typecheck and lint clean.

## Notes for review

`SchemaBackedDbAdapter` also backs the settings JSON (`SettingsDBFactory.ts:72`). Propagating read errors there is deliberate: the previous behaviour silently reset a user's settings to defaults on a transient read failure. A genuinely missing settings file is unaffected, since that is the `ENOENT`/`null` path.

Found by a sweep for constructs that fail open rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)