### PR TITLE
fix(guide): make the guide build retry actually retry, and stop hiding failures

### DIFF
--- a/server/src/services/TvGuideService.test.ts
+++ b/server/src/services/TvGuideService.test.ts
@@ -56,8 +56,6 @@ function makeChannelWithLineup(overrides?: Partial<ChannelOrm>) {
   return { channel, lineup: makeEmptyLineup() };
 }
 
-
-
 describe('TVGuideService', () => {
   describe('buildAllChannels', () => {
     it('removes a deleted channel from XMLTV output on the next guide build', async () => {
@@ -417,6 +415,129 @@ describe('TVGuideService', () => {
       ).map((entry) => entry.channel.uuid);
       expect(writeChannelIds).toContain(channelA.channel.uuid);
       expect(writeChannelIds).not.toContain(channelB.channel.uuid);
+    });
+  });
+
+  describe('buildChannelGuideWithRetries', () => {
+    // Production backs off for up to 30s before giving up, which is not
+    // something to sit through in a unit test.
+    class FastRetryGuideService extends TVGuideService {
+      protected readonly guideBuildRetryOptions = {
+        retries: 3,
+        factor: 1,
+        minTimeout: 1,
+        maxTimeout: 2,
+        maxRetryTime: 500,
+      };
+    }
+
+    // A channel that throws part-way through the build: it has lineup items but
+    // zero total duration, so the binary search finds no anchor and
+    // getChannelPrograms raises "General algorithm error" -- the failure a real
+    // guide build hits when a lineup is inconsistent.
+    function makeUnbuildableChannel() {
+      const channel = makeChannelOrm({
+        number: 2,
+        name: 'Broken',
+        duration: 0,
+      });
+      return {
+        channel,
+        lineup: {
+          version: 4,
+          lastUpdated: Date.now(),
+          items: [{ type: 'offline' as const, durationMs: 0 }],
+          startTimeOffsets: [0, 0],
+        } as unknown as Lineup,
+      };
+    }
+
+    function makeService(channels: Record<string, unknown>) {
+      const mockWrite = vi.fn().mockResolvedValue(undefined);
+      // Called once per build attempt on the failing path, so it counts attempts.
+      const syncChannelDuration = vi.fn().mockResolvedValue(false);
+      const service = new FastRetryGuideService(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { write: mockWrite } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { push: vi.fn() } as any,
+        {
+          loadAllLineups: vi.fn().mockResolvedValue(channels),
+          syncChannelDuration,
+          loadChannelWithProgamsAndLineup: vi.fn().mockResolvedValue(undefined),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { getProgramsByIds: vi.fn().mockResolvedValue([]) } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+      );
+      return { service, mockWrite, syncChannelDuration };
+    }
+
+    const guideDuration = dayjs.duration({ hours: 4 });
+
+    it('retries a channel whose guide build fails', async () => {
+      const healthy = makeChannelWithLineup({ number: 1, name: 'Healthy' });
+      const { service, mockWrite } = makeService({
+        [healthy.channel.uuid]: healthy,
+      });
+      // refreshGuide writes XMLTV inside the per-channel build, so a failing
+      // write fails that build. One call per attempt makes it an attempt count.
+      mockWrite.mockRejectedValue(new Error('xmltv write failed'));
+
+      await service.refreshGuide(
+        guideDuration,
+        healthy.channel.uuid,
+        true,
+        true,
+      );
+
+      expect(mockWrite.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('does not record a channel as built when its build failed', async () => {
+      const broken = makeUnbuildableChannel();
+      const healthy = makeChannelWithLineup({ number: 1, name: 'Healthy' });
+      const { service } = makeService({
+        [healthy.channel.uuid]: healthy,
+        [broken.channel.uuid]: broken,
+      });
+
+      await service.buildAllChannels(guideDuration, true);
+
+      // lastUpdateTime is what getChannelLineup consults to decide whether the
+      // cached guide covers a requested range. Advancing it for a build that
+      // produced nothing is what makes the failure invisible downstream.
+      const status = await service.getStatus();
+      expect(Object.keys(status.lastUpdate)).toContain(healthy.channel.uuid);
+      expect(Object.keys(status.lastUpdate)).not.toContain(broken.channel.uuid);
+    });
+
+    it('still builds and writes the other channels', async () => {
+      const broken = makeUnbuildableChannel();
+      const healthy = makeChannelWithLineup({ number: 1, name: 'Healthy' });
+      const { service, mockWrite } = makeService({
+        [healthy.channel.uuid]: healthy,
+        [broken.channel.uuid]: broken,
+      });
+
+      await service.buildAllChannels(guideDuration, true);
+
+      expect(mockWrite).toHaveBeenCalled();
+      const written = (
+        mockWrite.mock.calls.at(-1)![0] as MaterializedChannelPrograms[]
+      ).map((entry) => entry.channel.uuid);
+      expect(written).toContain(healthy.channel.uuid);
+      expect(written).not.toContain(broken.channel.uuid);
     });
   });
 });

--- a/server/src/services/TvGuideService.ts
+++ b/server/src/services/TvGuideService.ts
@@ -133,6 +133,15 @@ const PlaceholderChannelId = v4();
 export class TVGuideService {
   private timer: Timer;
   private locks = new MutexMap();
+
+  // Bounded by maxRetryTime rather than by the retry count: buildChannelGuide
+  // holds this channel's lock for the whole of it, so the ceiling on how long a
+  // failing channel can block its own rebuilds is what matters.
+  protected readonly guideBuildRetryOptions: retry.Options = {
+    retries: 15,
+    factor: 2,
+    maxRetryTime: 30_000,
+  };
   private xmltv: XmlTvWriter;
   private eventService: EventService;
   private programConverter: ProgramConverter;
@@ -150,7 +159,7 @@ export class TVGuideService {
   private accumulateTable: Record<string, number[]> = {};
   private channelsById?: Record<string, ChannelWithLineup>;
 
-  @InjectLogger() private declare readonly logger: Logger;
+  @InjectLogger() declare private readonly logger: Logger;
 
   constructor(
     @inject(XmlTvWriter) xmltv: XmlTvWriter,
@@ -991,36 +1000,43 @@ export class TVGuideService {
       this.currentEndTime[channelId]! - this.currentUpdateTime[channelId]!;
     const dur = dayjs.duration(thisGuideLength).humanize();
     this.logger.debug('Building Channel %s for %s', channelId, dur);
-    await retry(
-      async () => {
-        try {
-          await this.timer.timeAsync(
-            `Built Channel ${channelId} TV Guide for ${dur}`,
-            async () => {
-              this.cachedGuide[channelId] =
-                await this.buildGuideInternal(channelId);
-              if (
-                writeXmlTv &&
-                !this.channelsById![channelId]!.channel.stealth
-              ) {
-                await this.writeXmlTv();
-              }
-            },
-          );
-        } catch (err) {
-          this.logger.error(err, 'Unable to update internal guide data');
-        } finally {
-          this.lastUpdateTime[channelId] = this.currentUpdateTime[channelId]!;
-          this.lastEndTime[channelId] = this.currentEndTime[channelId]!;
-          this.currentUpdateTime[channelId] = -1;
-        }
-      },
-      {
-        retries: 15,
-        factor: 2,
-        maxRetryTime: 30000,
-      },
-    );
+
+    try {
+      // The catch has to live outside retry(): a callback that swallows its own
+      // errors never rejects, so retry() sees success on the first attempt and
+      // the retries never happen.
+      await retry(async () => {
+        await this.timer.timeAsync(
+          `Built Channel ${channelId} TV Guide for ${dur}`,
+          async () => {
+            this.cachedGuide[channelId] =
+              await this.buildGuideInternal(channelId);
+            if (writeXmlTv && !this.channelsById![channelId]!.channel.stealth) {
+              await this.writeXmlTv();
+            }
+          },
+        );
+      }, this.guideBuildRetryOptions);
+
+      this.lastUpdateTime[channelId] = this.currentUpdateTime[channelId]!;
+      this.lastEndTime[channelId] = this.currentEndTime[channelId]!;
+    } catch (err) {
+      // Deliberately leave lastUpdateTime and lastEndTime where they were.
+      // getChannelLineup consults lastEndTime to decide whether the cached
+      // guide covers a requested range, so advancing them for a build that
+      // produced nothing tells every downstream consumer the guide is fresh
+      // when there is no guide at all.
+      this.logger.error(
+        err,
+        'Unable to update guide data for channel %s; giving up after retries',
+        channelId,
+      );
+    } finally {
+      // Not swallowed silently but not rethrown either: buildAllChannels fans
+      // out over Promise.all, so letting this escape would abort every other
+      // channel's build and skip the XMLTV write entirely.
+      this.currentUpdateTime[channelId] = -1;
+    }
   }
 
   private async writeXmlTv() {


### PR DESCRIPTION
## The bug

`buildChannelGuideWithRetries` wraps its work in `retry({retries: 15, factor: 2, maxRetryTime: 30000})` — but the callback catches its own errors:

```ts
await retry(async () => {
  try { ... build ... }
  catch (err) { this.logger.error(err, 'Unable to update internal guide data'); }
  finally {
    this.lastUpdateTime[channelId] = this.currentUpdateTime[channelId]!;
    this.lastEndTime[channelId]   = this.currentEndTime[channelId]!;
    this.currentUpdateTime[channelId] = -1;
  }
}, { retries: 15, ... });
```

A callback that never rejects looks like success on attempt 1, so **the 15 retries never happened**.

The `finally` is the more damaging half. It advanced `lastUpdateTime` and `lastEndTime` to the *intended* window end regardless of whether `cachedGuide[channelId]` was ever assigned.

`getChannelLineup` consults `lastEndTime` to decide whether the cached guide covers a requested range. So a failed build told every downstream consumer the guide was fresh when there was no guide at all:

- the "end time exceeds what the current cached guide generation" warning was skipped
- the lookup fell through to `isNil(channelAndLineup) → return`, yielding `undefined`
- the channel rendered as an **empty row** in the web guide and was **omitted from XMLTV**

One `error` line was the only trace, and it said nothing about which consumers were now serving nothing.

## The fix

The `catch` moves outside `retry()` so failures are actually retried, and the timestamps are advanced only when the build produced a guide. Leaving them behind is what makes the failure visible downstream and gets the channel rebuilt next cycle.

The catch is **deliberately not rethrown**. `buildAllChannels` fans out over `Promise.all`, so letting one channel's failure escape would abort every other channel's build and skip the XMLTV write entirely. There's a test for that.

## On the retry ceiling

Retry options move to a `protected readonly` field. Worth being explicit about the trade-off, since this code now retries where it previously did not:

`buildChannelGuide` takes the channel's lock **before** calling this, so the retry sequence is held under that lock. The bound that matters is therefore `maxRetryTime` (30s), not the retry count. I confirmed `maxRetryTime` is genuinely honoured — `retry_operation.js:52` compares elapsed time against it and stops — so 15 retries at `factor: 2` cannot run away; the sequence is capped at 30s.

The lock is per-channel (`MutexMap`), so a failing channel delays only its own rebuilds. Other channels are unaffected.

## Testing

Three tests in the existing `TvGuideService.test.ts`:

- **retries a channel whose guide build fails** — verified red against the original implementation: exactly 1 attempt, `expected 1 to be greater than 1`
- **does not record a channel as built when its build failed** — asserts through the public `getStatus()` that the failed channel is absent from `lastUpdate`
- **still builds and writes the other channels** — the guard on not rethrowing

The test subclass lowers the retry timings; sitting through the 30s production ceiling in a unit test would be silly.

Full monorepo suite: 1460 passed, 2 skipped. Typecheck and lint clean.

## Deliberately not in this PR

The sweep also found that `LineupRepository.loadLineup` returns `Low.data` **by reference**, so a guide build reads the same object a concurrent `saveLineup` mutates — the same shape as febfd898, which its lock does not cover because the conflicting writer is `saveLineup`.

I left it out. The fix has to change aliasing semantics across ~10 call sites, at least one of which (`removeProgramsFromLineup`) mutates the returned object in place and relies on that. Getting it wrong silently drops lineup edits, which does not belong bundled into this PR. It gets its own branch.

Found by a sweep for constructs that fail open rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)