### PR TITLE
fix(scheduling): make the random slot cooldown actually apply

### DIFF
--- a/docs/configure/scheduling/random-slots.md
+++ b/docs/configure/scheduling/random-slots.md
@@ -17,7 +17,9 @@ When creating a programming slot, you choose between "Fixed" and "Dynamic" lengt
 * **Fixed** length slots run for an absolute duration (e.g. 30 mins)
 * **Dynamic** length slots run for an absolute _count_ of programs (e.g. 3 episodes)
 
-The **Cooldown** parameter controls a frequency cooldown; it is used when using "random" mode scheduling, which picks slots at random during schedule generation.
+The **Cooldown** parameter sets the minimum amount of time that must pass before the same slot can be scheduled again. Once a slot places programming, it becomes ineligible until its cooldown has elapsed. If no slot is eligible at a given point, the scheduler fills the gap with Flex until the next one becomes available, so a long cooldown on every slot will produce Flex rather than repeats.
+
+Cooldown only applies to the "random" slot choice modes (uniform and weighted), which pick slots at random during schedule generation. Sequential ("none") mode walks the slots in order and ignores cooldown. A cooldown of 0 places no restriction.
 
 Some programming types also allow configuration of the **order** in which their constituents are scheduled. This controls the playback order; for example, if using "Next" ordering for a TV Show, episodes will be iterated over in episode order during scheduling.
 

--- a/server/src/services/scheduling/RandomSlotsService.test.ts
+++ b/server/src/services/scheduling/RandomSlotsService.test.ts
@@ -291,3 +291,121 @@ describe('random slot filler budgeting', () => {
     ]);
   });
 });
+
+describe('random slot cooldown', () => {
+  const oneMin = 60 * 1000;
+  const midnight = dayjs('2024-01-01T00:00:00.000Z');
+
+  const makeEpisodes = (
+    showId: string,
+    count: number,
+    durationMs: number,
+  ): SlotSchedulerProgram[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...createFakeProgramOrm({
+        uuid: `${showId}-ep${i + 1}`,
+        title: `${showId} Episode ${i + 1}`,
+        type: 'episode',
+        duration: durationMs,
+        episode: i + 1,
+        tvShowUuid: showId,
+        show: { uuid: showId },
+      }),
+      parentFillerLists: [],
+      parentCustomShows: [],
+      parentSmartCollections: [],
+    }));
+
+  test('a slot is not scheduled again within its cooldown', () => {
+    const slotMs = 30 * oneMin;
+    const cooldownMs = 2 * 60 * oneMin;
+
+    const scheduler = new RandomSlotScheduler({
+      type: 'random',
+      flexPreference: 'end',
+      maxDays: 1,
+      padMs: oneMin,
+      padStyle: 'episode',
+      randomDistribution: 'uniform',
+      lockWeights: false,
+      slots: [
+        {
+          weight: 100,
+          cooldownMs,
+          durationSpec: { type: 'fixed', durationMs: slotMs },
+          type: 'show',
+          showId: 'show1',
+          order: 'next',
+          direction: 'asc',
+          seasonFilter: [],
+        },
+      ],
+    });
+
+    const result = scheduler.generateSchedule(
+      makeEpisodes('show1', 24, slotMs),
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    // Walk the lineup and record the offset at which each content program
+    // starts. With a single slot, every content start is that slot playing.
+    let offset = 0;
+    const contentStarts: number[] = [];
+    for (const item of result.lineup) {
+      if (item.type === 'content') {
+        contentStarts.push(offset);
+      }
+      offset += item.duration;
+    }
+
+    expect(contentStarts.length).toBeGreaterThan(1);
+    for (let i = 1; i < contentStarts.length; i++) {
+      expect(contentStarts[i]! - contentStarts[i - 1]!).toBeGreaterThanOrEqual(
+        cooldownMs,
+      );
+    }
+  });
+  test('a zero cooldown schedules back to back, as before', () => {
+    const slotMs = 30 * oneMin;
+
+    const scheduler = new RandomSlotScheduler({
+      type: 'random',
+      flexPreference: 'end',
+      maxDays: 1,
+      padMs: oneMin,
+      padStyle: 'episode',
+      randomDistribution: 'uniform',
+      lockWeights: false,
+      slots: [
+        {
+          weight: 100,
+          cooldownMs: 0,
+          durationSpec: { type: 'fixed', durationMs: slotMs },
+          type: 'show',
+          showId: 'show1',
+          order: 'next',
+          direction: 'asc',
+          seasonFilter: [],
+        },
+      ],
+    });
+
+    const result = scheduler.generateSchedule(
+      makeEpisodes('show1', 24, slotMs),
+      [42, 99],
+      undefined,
+      midnight,
+    );
+
+    // Every existing schedule in the wild uses cooldownMs: 0, so honouring
+    // cooldown must not start inserting flex into any of them.
+    expect(result.lineup.slice(0, 4).map((item) => item.type)).toEqual([
+      'content',
+      'content',
+      'content',
+      'content',
+    ]);
+  });
+});

--- a/server/src/services/scheduling/RandomSlotsService.ts
+++ b/server/src/services/scheduling/RandomSlotsService.ts
@@ -161,6 +161,13 @@ class ScheduleContext {
     return this.#slotLastPlayed.get(slotIndex);
   }
 
+  // Indexed into the sorted slots array. Recorded when a slot actually places
+  // programs, not when it is picked: a slot that yields nothing and is skipped
+  // has not played, and must stay eligible.
+  recordSlotPlayed(slotIndex: number, timeMs: number) {
+    this.#slotLastPlayed.set(slotIndex, timeMs);
+  }
+
   getNextSequentialSlot() {
     const slot = this.#sortedSlots[this.#currentSlotIndex]!;
     this.#currentSlotIndex =
@@ -205,6 +212,7 @@ export class RandomSlotScheduler {
 
     while (context.timeCursor.isBefore(upperLimit)) {
       let currSlot: RandomSlotImpl | null = null;
+      let currSlotIndex: number | null = null;
 
       let minNextTime = context.timeCursor.add(24, 'days');
       // Pad time
@@ -219,6 +227,7 @@ export class RandomSlotScheduler {
         case 'weighted': {
           const result = this.getRandomSlot(context);
           currSlot = result.currSlot;
+          currSlotIndex = result.currSlotIndex;
           minNextTime = result.minNextTime;
           break;
         }
@@ -258,6 +267,15 @@ export class RandomSlotScheduler {
           continue;
         }
         paddedPrograms = maybePrograms;
+      }
+
+      // The slot has committed programs, so it counts as played from the point
+      // the cursor is at now -- the slot's start, before its programs advance
+      // it. getRandomSlot compares this against timeCursor to apply cooldownMs.
+      // Only the random distributions consult it; 'none' walks the slots in
+      // order and ignores cooldown entirely.
+      if (currSlotIndex !== null) {
+        context.recordSlotPlayed(currSlotIndex, +context.timeCursor);
       }
 
       let midRollOffset = 0;
@@ -557,6 +575,7 @@ export class RandomSlotScheduler {
   private getRandomSlot(context: ScheduleContext) {
     let n = 0;
     let currSlot: RandomSlotImpl | null = null;
+    let currSlotIndex: number | null = null;
     let minNextTime = context.timeCursor.add(24, 'days');
     for (const [slot, i] of zipWithIndex(context.sortedSlots)) {
       const slotLastPlayed = context.getSlotLastPlayedTime(i);
@@ -576,11 +595,13 @@ export class RandomSlotScheduler {
 
       if (random.bool(slot.weight, n)) {
         currSlot = slot;
+        currSlotIndex = i;
       }
     }
 
     return {
       currSlot,
+      currSlotIndex,
       minNextTime,
     };
   }


### PR DESCRIPTION
## The bug

The **Cooldown** field on a random slot never did anything.

`ScheduleContext` declares `#slotLastPlayed` and exposes `getSlotLastPlayedTime`, but **nothing ever writes to the map** — no `.set`, no `delete`, no reassignment anywhere in the repo. The identifier appears exactly five times in total: the declaration (`RandomSlotsService.ts:61`), the getter (`:161`), and three reads inside `getRandomSlot` (`:562`, `:564`, `:565`).

So `getSlotLastPlayedTime` always returned `undefined`, the `!isNil(slotLastPlayed)` branch never executed, and `slot.cooldownMs` never influenced slot selection.

That branch is also the only thing that lowers `minNextTime`, so the "no slot is eligible" flex fallback was degenerate as well — `minNextTime` stayed pinned at `timeCursor + 24 days`.

**User-visible:** set a Cooldown in the slot editor (`EditRandomSlotDialogContent.tsx:485`), see it in the slot table (`RandomSlotTable.tsx:324`), save, regenerate the schedule — and the same slot can still be picked back to back. Nothing changes.

## The fix

`getRandomSlot` now reports which slot index it chose, and the generation loop records the play time against it.

Two details that matter:

- **Recorded when the slot commits programs, not when it is picked.** A slot that yields nothing and hits a `continue` has not played and must stay eligible.
- **The recorded time is the cursor at the slot's start**, before its programs advance it — that is what `getRandomSlot` compares `timeCursor` against.

Only the random distributions consult cooldown. Sequential (`'none'`) walks the slots in order and ignores it, which is why that path does not record — and matches the UI, which only shows the Cooldown field when `distribution !== 'none'`.

## Testing

`RandomSlotsService.test.ts` only ever passed `cooldownMs: 0`, which is why nothing caught this.

- **a slot is not scheduled again within its cooldown** — walks the generated lineup and asserts every consecutive pair of content starts is at least `cooldownMs` apart. Red before the fix with `expected 1800000 to be greater than or equal to 7200000`: consecutive starts were one slot duration apart, not one cooldown.
- **a zero cooldown schedules back to back, as before** — the regression guard that matters. Every schedule in the wild uses `cooldownMs: 0`, and honouring cooldown must not start inserting Flex into any of them.

Full monorepo suite: 1459 passed, 2 skipped. Typecheck and lint clean.

## Behaviour change worth flagging

This makes a previously inert setting live. Anyone who set a non-zero Cooldown expecting it to work will now get what they asked for — including the Flex that appears when no slot is eligible. That is the intended behaviour, but it will visibly change regenerated schedules for those users. Schedules with `cooldownMs: 0` (the default, and what the UI seeds) are unaffected.

## Docs

`docs/configure/scheduling/random-slots.md` only said Cooldown "controls a frequency cooldown". Replaced with what it actually does: the minimum time before the same slot can be scheduled again, that gaps become Flex, that it applies only to the random modes, and that 0 places no restriction.

Found by a sweep for constructs that fail open rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)