### PR TITLE
fix(db): stop handing out the cached lineup by reference

### DIFF
--- a/server/src/db/ChannelDB.test.ts
+++ b/server/src/db/ChannelDB.test.ts
@@ -328,6 +328,111 @@ describe('ChannelDB', () => {
       expect(lineup.items[0].type).toBe('offline');
     });
 
+    test('should not hand out the cached lineup by reference', async ({
+      channelDb,
+      defaultTranscodeConfigId,
+    }) => {
+      const created = await channelDb.saveChannel(
+        createSaveableChannel(defaultTranscodeConfigId, {
+          name: 'Lineup Aliasing Channel',
+          number: 601,
+        }),
+      );
+
+      await channelDb.saveLineup(created.channel.uuid, {
+        items: [
+          { type: 'offline' as const, durationMs: 1000 },
+          { type: 'offline' as const, durationMs: 2000 },
+          { type: 'offline' as const, durationMs: 3000 },
+        ],
+        startTimeOffsets: [0, 1000, 3000],
+      });
+
+      // A reader takes the lineup and then yields, as the guide build does.
+      const readerLineup = await channelDb.loadLineup(created.channel.uuid);
+      const itemsAtReadTime = readerLineup.items;
+      const offsetsAtReadTime = readerLineup.startTimeOffsets;
+
+      // A writer replaces the lineup while the reader still holds its copy.
+      await channelDb.saveLineup(created.channel.uuid, {
+        items: [{ type: 'offline' as const, durationMs: 5000 }],
+        startTimeOffsets: [0],
+      });
+
+      // The reader's view must be the one it read, not the writer's.
+      expect(readerLineup.items).toBe(itemsAtReadTime);
+      expect(readerLineup.items).toHaveLength(3);
+      expect(readerLineup.startTimeOffsets).toBe(offsetsAtReadTime);
+      expect(readerLineup.startTimeOffsets).toHaveLength(3);
+
+      // A fresh load sees the write.
+      const afterWrite = await channelDb.loadLineup(created.channel.uuid);
+      expect(afterWrite).not.toBe(readerLineup);
+      expect(afterWrite.items).toHaveLength(1);
+    });
+
+    test('should not let a mutated loaded lineup leak into the cache', async ({
+      channelDb,
+      defaultTranscodeConfigId,
+    }) => {
+      const created = await channelDb.saveChannel(
+        createSaveableChannel(defaultTranscodeConfigId, {
+          name: 'Lineup Mutation Channel',
+          number: 602,
+        }),
+      );
+
+      await channelDb.saveLineup(created.channel.uuid, {
+        items: [
+          { type: 'offline' as const, durationMs: 1000 },
+          { type: 'offline' as const, durationMs: 2000 },
+        ],
+        startTimeOffsets: [0, 1000],
+      });
+
+      const lineup = await channelDb.loadLineup(created.channel.uuid);
+      lineup.items = [];
+      lineup.startTimeOffsets = [];
+
+      const reloaded = await channelDb.loadLineup(created.channel.uuid);
+      expect(reloaded.items).toHaveLength(2);
+      expect(reloaded.startTimeOffsets).toHaveLength(2);
+    });
+
+    test('should still persist removeProgramsFromLineup edits', async ({
+      channelDb,
+      defaultTranscodeConfigId,
+    }) => {
+      const created = await channelDb.saveChannel(
+        createSaveableChannel(defaultTranscodeConfigId, {
+          name: 'Lineup Removal Channel',
+          number: 603,
+        }),
+      );
+
+      const programId = v4();
+      await channelDb.saveLineup(created.channel.uuid, {
+        items: [
+          {
+            type: 'content' as const,
+            id: programId,
+            durationMs: 1000,
+          } as ContentItem,
+          { type: 'offline' as const, durationMs: 2000 },
+        ],
+        startTimeOffsets: [0, 1000],
+      });
+
+      await channelDb.removeProgramsFromLineup(created.channel.uuid, [
+        programId,
+      ]);
+
+      const reloaded = await channelDb.loadLineup(created.channel.uuid);
+      expect(reloaded.items).toHaveLength(2);
+      expect(reloaded.items[0].type).toBe('offline');
+      expect(reloaded.items[0].durationMs).toBe(1000);
+    });
+
     test('should load channel and lineup together', async ({
       channelDb,
       defaultTranscodeConfigId,

--- a/server/src/db/channel/BasicChannelRepository.ts
+++ b/server/src/db/channel/BasicChannelRepository.ts
@@ -180,7 +180,7 @@ export class BasicChannelRepository {
 
     return {
       channel,
-      lineup: (await this.lineupRepository.getFileDb(channel.uuid)).data,
+      lineup: await this.lineupRepository.loadLineup(channel.uuid),
     };
   }
 

--- a/server/src/db/channel/LineupRepository.ts
+++ b/server/src/db/channel/LineupRepository.ts
@@ -296,7 +296,7 @@ export class LineupRepository {
       const newDur = sum(newLineup.items.map((item) => item.durationMs));
       await this.updateChannelDuration(channelId, newDur);
     }
-    return db.data;
+    return LineupRepository.snapshotLineup(db.data);
   }
 
   static applyUpdateLineupRequest(
@@ -560,7 +560,18 @@ export class LineupRepository {
     forceRead: boolean = false,
   ): Promise<Lineup> {
     const db = await this.getFileDb(channelId, forceRead);
-    return db.data;
+    return LineupRepository.snapshotLineup(db.data);
+  }
+
+  /**
+   * Callers hold a lineup across await boundaries (the guide build reads
+   * `items` and `startTimeOffsets` interleaved with DB writes), so they must
+   * not be handed the cached `Low.data`. Every writer rebinds whole properties
+   * on `Low.data` rather than mutating the arrays in place, so a top-level copy
+   * is enough to pin a caller to the lineup it actually read.
+   */
+  private static snapshotLineup(data: Lineup): Lineup {
+    return { ...data };
   }
 
   async loadLineupConfig(channelId: string): Promise<LineupConfig> {


### PR DESCRIPTION
## Problem

`LineupRepository.loadLineup` returned `Low.data` directly, so every caller shared one mutable object with the lowdb cache. `fileDbLocks` guards only *creation* of the `Low`, not use of it.

The guide build is the reader that gets hurt. `TvGuideService` snapshots `startTimeOffsets` into its `accumulate` table, then re-reads `lineup.items` live off the same object across several awaited DB calls. A `saveLineup` landing in between rebinds both properties on `Low.data` underneath it — `applyUpdateLineupRequest` does `data.items = newLineup.items` and reassigns `data.startTimeOffsets`. The captured offsets are then indexed against a discarded `items` array.

Result is either a thrown "General algorithm error, completely unexpected", or — worse, because it is silent — plausible-looking but wrong airtimes in the guide and XMLTV.

## Fix

`loadLineup` and `saveLineup` now return a top-level copy of the lineup instead of the cached object.

A **shallow** copy is sufficient, and deliberately so. An audit of every writer found that none of them mutates a lineup array in place — `applyUpdateLineupRequest`, `updateLineupConfig` and `removeProgramsFromLineup` all rebind whole top-level properties. So `{...data}` is enough to pin a caller to the lineup it actually read. A structural/deep copy would cost O(items) per channel on `loadAllLineups`, which is on the guide path.

`BasicChannelRepository.createChannel` was returning `getFileDb(...).data` directly; it now routes through `loadLineup` so it gets the same treatment.

## Call-site audit

Checked all callers before changing the contract, since a few could plausibly have relied on the aliasing:

- `removeProgramsFromLineup` assigns `lineup.items = ...` on the object it loaded, then passes that object to `saveLineup`, which copies `items` onto `Low.data`. It never relied on the reference. Covered by a new regression test.
- `removeRedirectReferences`, `removeProgramsFromAllLineups`, `updateLineup` and `copyChannel` all spread into a new object before saving. Unaffected.
- `OnDemandChannelService` only reads and spreads `onDemandConfig`. Unaffected.
- The `onDemandConfig` writes at `BasicChannelRepository.ts:174,257` are inside `db.update(...)` callbacks operating on the live `Low.data`, not on a `loadLineup` result. Unaffected.
- Pure readers (`StreamProgramCalculator`, `TroubleshootService`, `streamApi`, `ReconcileProgramDurationsTask`, `GetMaterializedChannelScheduleCommand`) are unaffected.

## Test plan

Three tests added to `server/src/db/ChannelDB.test.ts`. The first two were confirmed red against the pre-fix code:

- [x] `should not hand out the cached lineup by reference` — a reader holds a lineup, a writer replaces it, the reader's `items` and `startTimeOffsets` must still be the ones it read. Failed before the fix (reader saw the writer's single item).
- [x] `should not let a mutated loaded lineup leak into the cache` — mutating a loaded lineup must not affect a subsequent load. Failed before the fix (subsequent load returned the emptied arrays).
- [x] `should still persist removeProgramsFromLineup edits` — guard test for the aliasing concern above. Passes both before and after.
- [x] Full server suite: 1134 passed, 2 skipped.
- [x] `pnpm turbo typecheck` clean.
- [x] `pnpm lint-changed` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)