### PR TITLE
fix(workers): make the start() guard actually guard

### DIFF
--- a/server/src/services/TunarrWorkerPool.test.ts
+++ b/server/src/services/TunarrWorkerPool.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, test, vi } from 'vitest';
+// container.ts and TunarrWorkerPool.ts import each other. Entering the graph at
+// the pool leaves the class in its temporal dead zone when the container tries
+// to bind it, so the container has to be the entry point.
+import '../container.ts';
+import { TunarrWorkerPool } from './TunarrWorkerPool.ts';
+import type { TunarrSubprocessService } from './TunarrSubprocessService.ts';
+
+class FakeWorker extends EventEmitter {
+  postMessage = vi.fn();
+  terminate = vi.fn(() => {
+    this.emit('exit', 0);
+    return Promise.resolve(0);
+  });
+
+  announceReady() {
+    this.emit('message', { type: 'event', eventType: 'started' });
+  }
+}
+
+/**
+ * The pool attaches its listeners synchronously after `createWorker` returns,
+ * so a worker can only report ready on a later tick.
+ */
+function makeSubprocessService() {
+  const created: FakeWorker[] = [];
+  let readyOnSpawn = true;
+
+  const createWorker = vi.fn(() => {
+    const worker = new FakeWorker();
+    created.push(worker);
+    if (readyOnSpawn) {
+      setImmediate(() => worker.announceReady());
+    }
+    return worker;
+  });
+
+  return {
+    created,
+    service: { createWorker } as unknown as TunarrSubprocessService,
+    createWorker,
+    set spawnHealthy(value: boolean) {
+      readyOnSpawn = value;
+    },
+  };
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('TunarrWorkerPool', () => {
+  /**
+   * `start()` guarded on `#state !== 'pending'` and then assigned
+   * `#state = 'pending'` — it rewrote the one value that passes the check as
+   * itself, so the "already starting" state was never entered. `#state` only
+   * became 'started' inside the `.then()` of the `Promise.all`, an await
+   * boundary later, leaving a window in which a second `start()` built a whole
+   * second set of workers over the first: the originals were orphaned while
+   * `queueTask` round-robined over a half-replaced pool.
+   */
+  test('a second start() while the first is in flight does not build a second pool', async () => {
+    const once = makeSubprocessService();
+    const poolOnce = new TunarrWorkerPool(once.service);
+    poolOnce.start();
+    await poolOnce.allReady();
+    const expected = once.createWorker.mock.calls.length;
+    expect(expected).toBeGreaterThan(0);
+
+    const twice = makeSubprocessService();
+    const poolTwice = new TunarrWorkerPool(twice.service);
+    poolTwice.start();
+    poolTwice.start();
+    await poolTwice.allReady();
+
+    expect(twice.createWorker).toHaveBeenCalledTimes(expected);
+  });
+
+  /**
+   * `#startPromises` was only ever pushed to, never reset. After a failed
+   * startup and a shutdown, a fresh `start()` appended to the same array, so
+   * `allReady()` kept awaiting — and re-throwing — the previous run's already
+   * terminated workers.
+   */
+  test('a fresh start() does not await the previous run of workers', async () => {
+    const subprocess = makeSubprocessService();
+    subprocess.spawnHealthy = false;
+    const pool = new TunarrWorkerPool(subprocess.service);
+
+    pool.start();
+    await tick();
+    subprocess.created.forEach((worker) => worker.emit('exit', 1));
+    await expect(pool.allReady()).rejects.toThrow();
+
+    await pool.shutdown(100);
+
+    subprocess.spawnHealthy = true;
+    pool.start();
+
+    await expect(pool.allReady()).resolves.toBeUndefined();
+  });
+
+  /**
+   * A failed startup went to `console.error` rather than the logger, so it was
+   * absent from the log files that users actually send in.
+   */
+  test('a failed startup is reported through the logger, not console', async () => {
+    const subprocess = makeSubprocessService();
+    subprocess.spawnHealthy = false;
+    const pool = new TunarrWorkerPool(subprocess.service);
+
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    pool.start();
+    await tick();
+    subprocess.created.forEach((worker) => worker.emit('exit', 1));
+    await expect(pool.allReady()).rejects.toThrow();
+    await tick();
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+    await pool.shutdown(100);
+  });
+});

--- a/server/src/services/TunarrWorkerPool.ts
+++ b/server/src/services/TunarrWorkerPool.ts
@@ -117,7 +117,7 @@ class Future<T> implements Promise<T> {
   }
 }
 
-type State = 'pending' | 'started' | 'terminating';
+type State = 'pending' | 'starting' | 'started' | 'terminating';
 
 @injectable()
 export class TunarrWorkerPool implements IWorkerPool {
@@ -129,7 +129,7 @@ export class TunarrWorkerPool implements IWorkerPool {
   #outstandingByIndex = new Map<number, string[]>();
   #startPromises: Promise<boolean>[] = [];
 
-  @InjectLogger() private declare readonly logger: Logger;
+  @InjectLogger() declare private readonly logger: Logger;
 
   constructor(
     @inject(TunarrSubprocessService)
@@ -140,12 +140,23 @@ export class TunarrWorkerPool implements IWorkerPool {
     if (this.#state !== 'pending') {
       return;
     }
-    this.#state = 'pending';
+    // Not 'pending' — that is the value just tested for, so assigning it back
+    // left the guard inert and the "already starting" state unreachable. The
+    // pool only reached 'started' an await boundary later, and a second
+    // start() inside that window built an entire second set of workers over
+    // the first: the originals were orphaned while queueTask round-robined
+    // over a half-replaced pool.
+    this.#state = 'starting';
     this.logger.info('Starting worker pool...');
+    // Replaced rather than appended to. Pushing meant a pool restarted after
+    // a shutdown kept the previous run's promises, so allReady() awaited —
+    // and re-threw for — workers that had already been terminated.
+    const startPromises = new Array<Promise<boolean>>();
     for (let i = 0; i < numWorkers; i++) {
-      this.#startPromises.push(this.setupWorker(i));
+      startPromises.push(this.setupWorker(i));
     }
-    Promise.all(this.#startPromises)
+    this.#startPromises = startPromises;
+    Promise.all(startPromises)
       .then(() => {
         this.logger.debug(
           'Worker pool successfully started %d workers',
@@ -153,7 +164,16 @@ export class TunarrWorkerPool implements IWorkerPool {
         );
         this.#state = 'started';
       })
-      .catch(console.error);
+      .catch((err: unknown) => {
+        // Deliberately not reset to 'pending'. Some workers may have come up,
+        // and a second start() over them would orphan those. shutdown() is
+        // the defined way back to a startable state.
+        this.logger.error(
+          err,
+          'Worker pool failed to start all %d workers',
+          numWorkers,
+        );
+      });
   }
 
   async shutdown(timeout: number = 5_000) {


### PR DESCRIPTION
## Scope note — overlap with #1994

The sweep flagged two worker-pool defects. **#1994 already fixes the second one** (the floating restart promise in the `exit` handler), and fixes it well — `scheduleRestart` with exponential backoff, slot invalidation, and a `.catch` that logs. This PR deliberately does **not** touch that code, to avoid a second, divergent fix for the same bug.

What remains is the `start()` guard, which is present unchanged on both `main` and #1994's branch.

Test-merged against `feat/promote-worker-pool` locally: `TunarrWorkerPool.ts` auto-merges cleanly, and the full suite passes on the merged tree (1179 passed). These two can land in either order.

## 1. The `start()` guard is inert

```ts
start() {
  if (this.#state !== 'pending') { return; }
  this.#state = 'pending';   // re-assigns the value it just tested for
```

The one value that passes the check is rewritten as itself, so the "already starting" state is never entered. `#state` only becomes `'started'` inside the `.then()` of the `Promise.all`, an await boundary later.

A second `start()` inside that window appends another `numWorkers` promises to `#startPromises` and overwrites the `#pool` slots, orphaning the first set of workers — while `queueTask` round-robins `#last` over a half-replaced pool. `shutdown()` resets `#state` to `'pending'` inside a `.then()` too, so a `start()` racing a shutdown's tail builds a second pool over the terminating one.

Confirmed by test: two `start()` calls built **16** workers where 8 were expected.

There is now a distinct `'starting'` state.

## 2. `#startPromises` is never replaced

It was only ever pushed to. A pool restarted after a shutdown kept the previous run's promises, so `allReady()` awaited — and re-threw for — workers that had already been terminated. A healthy restart could never report ready. `start()` now installs a fresh array.

## 3. Startup failure went to `console.error`

So it was absent from the log files users actually send in, and `#state` was stuck at `'pending'` forever. It goes through the logger now.

The state is **deliberately not** rolled back to `'pending'` on failure: some workers may have come up, and a second `start()` over them would orphan those — the very bug fixed above. `shutdown()` is the defined way back to a startable state, and the test covers that path.

## Not changed

The exit-handler log line reads `this.#state === 'started' ? ' Restarting.' : ''`, so during `'starting'` it now says nothing while still restarting. Pre-existing cosmetic mismatch, and #1994 replaces that whole block — left alone rather than creating a conflict.

## Test plan

`server/src/services/TunarrWorkerPool.test.ts`, new. All three were confirmed red against the pre-fix code. They drive the pool through a faked `TunarrSubprocessService`, so no real worker threads are spawned.

- [x] A second `start()` while the first is in flight does not build a second pool. Failed before: 16 workers instead of 8.
- [x] A fresh `start()` after a failed start plus `shutdown()` does not await the previous run's workers. Failed before: `allReady()` re-threw the old `Worker exited with code 1`.
- [x] A failed startup is reported through the logger, not `console.error`. Failed before: `console.error` called once.
- [x] Full server suite on this branch: 1134 passed, 2 skipped.
- [x] Full server suite on the tree merged with #1994: 1179 passed, 2 skipped.
- [x] `pnpm turbo typecheck` and `pnpm lint-changed` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)