### PR TITLE
fix(settings): stop partial updates resetting the fields they omit

### DIFF
--- a/server/src/api/systemApi.ts
+++ b/server/src/api/systemApi.ts
@@ -23,7 +23,7 @@ import {
 } from '@tunarr/types/api';
 import type { BackupSettings } from '@tunarr/types/schemas';
 import { BackupSettingsSchema, HealthCheckSchema } from '@tunarr/types/schemas';
-import { identity, isError, isUndefined, map } from 'lodash-es';
+import { identity, isError, isNil, isUndefined, map } from 'lodash-es';
 import fs from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { join } from 'path/posix';
@@ -47,7 +47,7 @@ import {
   isRunningInContainer,
 } from '../util/containerUtil.ts';
 import { getEnvVar, TUNARR_ENV_VARS } from '../util/env.ts';
-import { FeatureFlagService } from '../services/FeatureFlagService.ts';
+import type { FeatureFlagService } from '../services/FeatureFlagService.ts';
 import { streamFileBackwards } from '../util/fsUtil.ts';
 import { take } from '../util/streams.ts';
 
@@ -187,30 +187,42 @@ export const systemApiRouter: RouterPluginAsyncCallback = async (
     async (req, res) => {
       await req.serverCtx.settings.directUpdate((file) => {
         const { system } = file;
-        system.logging.useEnvVarLevel =
-          req.body.logging?.useEnvVarLevel ?? true;
-        if (system.logging.useEnvVarLevel) {
-          system.logging.logLevel = getDefaultLogLevel(false);
-        } else {
-          system.logging.logLevel =
-            req.body.logging?.logLevel ?? getDefaultLogLevel(false);
-        }
 
-        if (!req.body.logging?.categoryLogLevel?.scheduling) {
-          delete system.logging.categoryLogLevel?.scheduling;
-        } else {
-          system.logging.categoryLogLevel ??= {};
-          system.logging.categoryLogLevel.scheduling =
-            req.body.logging.categoryLogLevel.scheduling;
-        }
+        // Guarded the same way as the backup/cache/server blocks below.
+        // Previously this ran unconditionally, so a request that never
+        // mentioned logging forced useEnvVarLevel back to true, recomputed
+        // logLevel, and deleted both category levels.
+        ifDefined(req.body.logging, (logging) => {
+          if (!isUndefined(logging.useEnvVarLevel)) {
+            system.logging.useEnvVarLevel = logging.useEnvVarLevel;
+          }
 
-        if (!req.body.logging?.categoryLogLevel?.streaming) {
-          delete system.logging.categoryLogLevel?.streaming;
-        } else {
-          system.logging.categoryLogLevel ??= {};
-          system.logging.categoryLogLevel.streaming =
-            req.body.logging.categoryLogLevel.streaming;
-        }
+          if (system.logging.useEnvVarLevel) {
+            system.logging.logLevel = getDefaultLogLevel(false);
+          } else if (!isUndefined(logging.logLevel)) {
+            system.logging.logLevel = logging.logLevel;
+          }
+
+          // categoryLogLevel is declared `LogLevelsSchema.nullish()`, so an
+          // explicit null is the wire signal for "clear this category". A
+          // category the request does not mention is left alone — the previous
+          // `if (!level) delete` conflated the two.
+          ifDefined(logging.categoryLogLevel, (categories) => {
+            for (const category of ['scheduling', 'streaming'] as const) {
+              if (!(category in categories)) {
+                continue;
+              }
+
+              const level = categories[category];
+              if (isNil(level)) {
+                delete system.logging.categoryLogLevel?.[category];
+              } else {
+                system.logging.categoryLogLevel ??= {};
+                system.logging.categoryLogLevel[category] = level;
+              }
+            }
+          });
+        });
 
         if (!isUndefined(req.body.backup)) {
           system.backup = req.body.backup;

--- a/server/src/api/xmltvSettingsApi.ts
+++ b/server/src/api/xmltvSettingsApi.ts
@@ -6,8 +6,27 @@ import type { RouterPluginCallback } from '@/types/serverType.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { BaseErrorSchema } from '@tunarr/types/api';
 import { XmlTvSettingsSchema } from '@tunarr/types/schemas';
-import { isError } from 'lodash-es';
+import { isError, isUndefined } from 'lodash-es';
 import { z } from 'zod/v4';
+
+/**
+ * Declared field by field rather than as `XmlTvSettingsSchema.partial()`.
+ * `.partial()` wraps a field's `.default()` instead of removing it, so a key
+ * the client omitted still arrived populated with that default — a PUT with an
+ * empty body came through as the full default settings object. The handler
+ * could not distinguish "omitted" from "sent" and reset everything it was not
+ * given.
+ *
+ * `outputPath` is accepted but ignored: it is server-owned and deliberately
+ * read-only in the UI.
+ */
+const UpdateXmlTvSettingsRequestSchema = z.object({
+  programmingHours: z.number().optional(),
+  refreshHours: z.number().optional(),
+  outputPath: z.string().optional(),
+  enableImageCache: z.boolean().optional(),
+  useShowPoster: z.boolean().optional(),
+});
 
 export const xmlTvSettingsRouter: RouterPluginCallback = (
   fastify,
@@ -45,7 +64,7 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
     {
       schema: {
         tags: ['Settings'],
-        body: XmlTvSettingsSchema.partial(),
+        body: UpdateXmlTvSettingsRequestSchema,
         response: {
           200: XmlTvSettingsSchema,
           500: BaseErrorSchema,
@@ -56,13 +75,19 @@ export const xmlTvSettingsRouter: RouterPluginCallback = (
       try {
         const settings = req.body;
         let xmltv = req.serverCtx.settings.xmlTvSettings();
+        // The body is `XmlTvSettingsSchema.partial()`, so an omitted field
+        // means "leave this alone". Defaulting an omitted field to a constant
+        // instead silently reset settings the request never mentioned.
+        // outputPath stays server-owned: it is deliberately read-only in the
+        // UI, so it is not taken from the body even when one is sent.
         await req.serverCtx.settings.updateSettings('xmltv', {
-          refreshHours:
-            (settings.refreshHours ?? 0) < 1 ? 1 : settings.refreshHours!,
-          enableImageCache: settings.enableImageCache === true,
+          refreshHours: isUndefined(settings.refreshHours)
+            ? xmltv.refreshHours
+            : Math.max(1, settings.refreshHours),
+          enableImageCache: settings.enableImageCache ?? xmltv.enableImageCache,
           outputPath: xmltv.outputPath,
-          programmingHours: settings.programmingHours ?? 12,
-          useShowPoster: settings.useShowPoster ?? false,
+          programmingHours: settings.programmingHours ?? xmltv.programmingHours,
+          useShowPoster: settings.useShowPoster ?? xmltv.useShowPoster,
         });
         xmltv = req.serverCtx.settings.xmlTvSettings();
         req.serverCtx.eventService.push({

--- a/server/tests/settingsPartialUpdate.test.ts
+++ b/server/tests/settingsPartialUpdate.test.ts
@@ -1,0 +1,189 @@
+import { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { container } from '../src/container.ts';
+import type { ISettingsDB } from '../src/db/interfaces/ISettingsDB.ts';
+import { ScheduleJobsStartupTask } from '../src/services/startup/ScheduleJobsStartupTask.ts';
+import { KEYS } from '../src/types/inject.ts';
+import { getAvailablePort } from '../src/util/net.ts';
+import { initTestApp } from './testServer.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await initTestApp(await getAvailablePort());
+  // The settings handlers kick the corresponding scheduled task after saving,
+  // and the test server does not run the startup task that registers them.
+  await container.get(ScheduleJobsStartupTask).getPromise();
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+async function putXmlTv(payload: Record<string, unknown>) {
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/xmltv-settings',
+    payload,
+  });
+  expect(res.statusCode, res.body).toBe(200);
+  return res.json();
+}
+
+async function getXmlTv() {
+  const res = await app.inject({ method: 'GET', url: '/api/xmltv-settings' });
+  expect(res.statusCode, res.body).toBe(200);
+  return res.json();
+}
+
+/**
+ * The body is `XmlTvSettingsSchema.partial()`, so the declared contract is
+ * "update what I send". The handler instead rebuilt a full object from
+ * hardcoded defaults, so every omitted field was reset.
+ */
+describe('PUT /xmltv-settings - partial update', () => {
+  test('does not reset the fields it was not sent', async () => {
+    // Establish a known non-default state.
+    await putXmlTv({
+      programmingHours: 36,
+      refreshHours: 7,
+      enableImageCache: true,
+      useShowPoster: true,
+    });
+    expect(await getXmlTv()).toMatchObject({
+      programmingHours: 36,
+      refreshHours: 7,
+      enableImageCache: true,
+      useShowPoster: true,
+    });
+
+    // Change exactly one field.
+    await putXmlTv({ programmingHours: 48 });
+
+    expect(await getXmlTv()).toMatchObject({
+      programmingHours: 48,
+      // These were not sent, so they must be untouched.
+      refreshHours: 7,
+      enableImageCache: true,
+      useShowPoster: true,
+    });
+  });
+
+  test('an empty body changes nothing', async () => {
+    await putXmlTv({
+      programmingHours: 20,
+      refreshHours: 5,
+      enableImageCache: true,
+      useShowPoster: true,
+    });
+
+    await putXmlTv({});
+
+    expect(await getXmlTv()).toMatchObject({
+      programmingHours: 20,
+      refreshHours: 5,
+      enableImageCache: true,
+      useShowPoster: true,
+    });
+  });
+
+  test('still clamps a sent refreshHours below 1', async () => {
+    await putXmlTv({ refreshHours: 0 });
+    expect((await getXmlTv()).refreshHours).toBe(1);
+  });
+});
+
+/**
+ * The system settings routes serialize `searchServerAddress` as
+ * `http://localhost:${meilisearchPort}` against a `z.url()` response schema.
+ * The test harness never starts Meilisearch, so the port is undefined and both
+ * GET and PUT fail response serialization with a 500 — unrelated to what is
+ * under test here. The request body is validated and the settings file is
+ * written before that point, so these assert the persisted state directly and
+ * only require that the request itself was accepted.
+ */
+async function putSystem(payload: Record<string, unknown>) {
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/system/settings',
+    payload,
+  });
+  expect(res.statusCode, res.body).not.toBe(400);
+  return res;
+}
+
+function storedLogging() {
+  return container.get<ISettingsDB>(KEYS.SettingsDB).systemSettings().logging;
+}
+
+/**
+ * The sibling blocks in this same handler (backup, cache, server) are guarded
+ * with isUndefined/ifDefined. The logging block was the odd one out: it forced
+ * useEnvVarLevel back to true, recomputed logLevel, and deleted the category
+ * levels whenever `logging` was absent from the body.
+ */
+describe('PUT /system/settings - partial update', () => {
+  const seeded = {
+    logging: {
+      useEnvVarLevel: false,
+      logLevel: 'warn',
+      categoryLogLevel: { scheduling: 'debug', streaming: 'trace' },
+    },
+  };
+
+  test('does not reset logging when the body omits it', async () => {
+    await putSystem(seeded);
+    expect(storedLogging()).toMatchObject({
+      useEnvVarLevel: false,
+      logLevel: 'warn',
+      categoryLogLevel: { scheduling: 'debug', streaming: 'trace' },
+    });
+
+    // A request that says nothing about logging must not touch logging.
+    await putSystem({});
+
+    expect(storedLogging()).toMatchObject({
+      useEnvVarLevel: false,
+      logLevel: 'warn',
+      categoryLogLevel: { scheduling: 'debug', streaming: 'trace' },
+    });
+  });
+
+  test('does not drop category levels when logging is sent without them', async () => {
+    await putSystem(seeded);
+
+    // Sending logging without categoryLogLevel means "I am not changing the
+    // categories", not "delete them".
+    await putSystem({ logging: { logLevel: 'error' } });
+
+    const logging = storedLogging();
+    expect(logging.logLevel).toBe('error');
+    expect(logging.categoryLogLevel).toMatchObject({
+      scheduling: 'debug',
+      streaming: 'trace',
+    });
+  });
+
+  /**
+   * categoryLogLevel is declared `LogLevelsSchema.nullish()`, so null is the
+   * wire signal for "clear this category". That must still work.
+   */
+  test('an explicit null still clears one category', async () => {
+    await putSystem(seeded);
+
+    await putSystem({ logging: { categoryLogLevel: { scheduling: null } } });
+
+    const logging = storedLogging();
+    expect(logging.categoryLogLevel?.scheduling).toBeUndefined();
+    // The category that was not mentioned survives.
+    expect(logging.categoryLogLevel?.streaming).toBe('trace');
+  });
+
+  test('still applies the logging fields it is sent', async () => {
+    await putSystem({ logging: { useEnvVarLevel: false, logLevel: 'info' } });
+
+    const logging = storedLogging();
+    expect(logging.useEnvVarLevel).toBe(false);
+    expect(logging.logLevel).toBe('info');
+  });
+});

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -5,6 +5,7 @@ import {
   LogCategoriesSchema,
   LoggingSettingsSchema,
   LogLevelsSchema,
+  LogRollConfigSchema,
   ServerSettingsSchema,
   SystemSettingsSchema,
 } from '../SystemSettings.js';
@@ -259,18 +260,27 @@ export type SystemSettingsResponse = z.infer<
   typeof SystemSettingsResponseSchema
 >;
 
+/**
+ * Declared field by field rather than as `LoggingSettingsSchema.pick(...)
+ * .partial()`. `.partial()` wraps a field's `.default()` instead of removing
+ * it, so a key the client omitted still arrived populated with its default —
+ * `useEnvVarLevel` came through as `true` on every request, and
+ * `logRollConfig` as the default object. The handler could not distinguish
+ * "omitted" from "sent" and reset settings the request never mentioned.
+ *
+ * `categoryLogLevel` values are nullish: an explicit null clears one category,
+ * while a category that is absent is left alone.
+ */
 export const UpdateSystemSettingsRequestSchema = z.object({
-  logging: LoggingSettingsSchema.pick({
-    logLevel: true,
-    useEnvVarLevel: true,
-    logRollConfig: true,
-  })
-    .extend({
+  logging: z
+    .object({
+      logLevel: LogLevelsSchema.optional(),
+      useEnvVarLevel: z.boolean().optional(),
+      logRollConfig: LogRollConfigSchema.optional(),
       categoryLogLevel: z
         .partialRecord(LogCategoriesSchema, LogLevelsSchema.nullish())
         .optional(),
     })
-    .partial()
     .optional(),
   backup: BackupSettingsSchema.optional(),
   cache: CacheSettingsSchema.optional(),


### PR DESCRIPTION
## Root cause — it is the schemas, not the handlers

Both routes declare a partial body and both reset settings the request never mentioned. The sweep blamed the handlers. The handlers are wrong, but they were also structurally *unable* to be right:

**`.partial()` wraps a field's `.default()` rather than removing it**, so a key the client omitted still arrives populated with that default. Verified against the repo's zod 4.3.6:

```js
z.object({ a: z.number().default(12) }).partial().parse({})   // => { a: 12 }, not {}
```

So `XmlTvSettingsSchema.partial()` turns `PUT /xmltv-settings {}` into the **full default settings object** by the time the handler sees it. No amount of `?? stored.value` in the handler can recover the distinction — it was already lost during validation.

## What that did

**`PUT /xmltv-settings`** — every omitted field reset: `useShowPoster` → `false`, `programmingHours` → `12`, `refreshHours` → `4`, `enableImageCache` → `false`. Only `outputPath` survived, because the handler happened to preserve it explicitly.

**`PUT /system/settings`** — `logging.useEnvVarLevel` arrived as `true` on every request that touched logging, forcing the log level back to the env-var default and discarding a configured one. `logging.logRollConfig` arrived as the default object, which means the `ifDefined(req.body.logging?.logRollConfig, ...)` guard on line 240 **never did anything** — its input was never undefined.

On top of that, the logging block was missing the `isUndefined`/`ifDefined` guards that its own siblings (`backup`, `cache`, `server`) in the same handler already have, and `if (!level) delete` conflated "category absent" with "category explicitly cleared", so any settings update dropped both category log levels.

## Fix

Both request bodies are declared field by field, genuinely optional, no defaults. The handlers are fixed to match.

Category log levels now honour the three cases the schema actually declares (`LogLevelsSchema.nullish()`):
- absent → leave alone
- explicit `null` → clear that category
- a level → set it

Also removes an unguarded non-null assertion on `settings.refreshHours`, per the repo's own rule against them.

`outputPath` stays server-owned and ignored when sent — it is a read-only, disabled field in `XmlTvSettingsPage.tsx`. It is still accepted in the body so existing clients that echo it back are unaffected.

## Contract

The generated web client already declared both bodies as fully optional (`web/src/generated/types.gen.ts:10174`). The runtime disagreed with the published contract; it now matches. **No client regeneration needed** — same pattern as the `from`/`to` bug in #1996.

## Test plan

`server/tests/settingsPartialUpdate.test.ts`, new. 5 of the 7 were confirmed red:

- [x] XMLTV: changing one field leaves the other four untouched. Failed before.
- [x] XMLTV: an empty body changes nothing. Failed before (reset everything to defaults).
- [x] XMLTV: a sent `refreshHours` below 1 is still clamped to 1.
- [x] System: a body that omits `logging` does not touch logging. Failed before.
- [x] System: `logging` sent without `categoryLogLevel` keeps the categories. Failed before.
- [x] System: an explicit `null` still clears one category, and leaves the unmentioned one. Failed before.
- [x] System: the logging fields that *are* sent still apply.
- [x] Full server suite: 1138 passed, 2 skipped. `turbo typecheck` (incl. web) and `lint-changed` clean.

### Note on the system-settings assertions

They read persisted state via `ISettingsDB` rather than a follow-up GET. Both system-settings routes serialize `searchServerAddress` as `http://localhost:${meilisearchPort}` against a `z.url()` response schema, and the test harness never starts Meilisearch, so the port is undefined and *both* GET and PUT fail response serialization with a 500 — unrelated to what is under test. The body is validated and the settings file written before that point. Worth a separate look; not touched here.

The test also has to run `ScheduleJobsStartupTask` in `beforeAll`, because the XMLTV handler kicks `UpdateXmlTvTask` after saving and `initTestApp` does not register scheduled jobs. `Scheduler.getScheduledJob` does `getScheduledJobs(id)[0]!` — an unguarded `!` that throws rather than returning undefined. Also worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)