### PR TITLE
fix(channels): reject bad watermark and icon values instead of rewriting them

### DIFF
--- a/server/src/types/channelWriteValidation.test.ts
+++ b/server/src/types/channelWriteValidation.test.ts
@@ -1,0 +1,159 @@
+import {
+  ChannelIconSchema,
+  SaveableChannelSchema,
+  StrictChannelIconSchema,
+  StrictWatermarkSchema,
+  WatermarkSchema,
+} from '@tunarr/types/schemas';
+import { describe, expect, test } from 'vitest';
+
+const watermarkBase = {
+  enabled: true,
+  width: 10,
+  verticalMargin: 5,
+  horizontalMargin: 5,
+};
+
+/**
+ * These schemas are split: the lenient half is on channel *responses*, which
+ * are serialized from an unvalidated JSON column, and the strict half is on
+ * request bodies. The `.catch()` calls on the lenient half must stay, or a
+ * legacy row becomes a hard 500 on GET /channels.
+ */
+describe('watermark write validation', () => {
+  test.each([150, -10, 50.5, '50'])(
+    'rejects the out-of-contract opacity %p on write',
+    (opacity) => {
+      expect(
+        StrictWatermarkSchema.safeParse({ ...watermarkBase, opacity }).success,
+      ).toBe(false);
+    },
+  );
+
+  test.each([150, -10, 50.5, '50'])(
+    'still coerces the opacity %p to 100 on read',
+    (opacity) => {
+      const parsed = WatermarkSchema.parse({ ...watermarkBase, opacity });
+      expect(parsed.opacity).toBe(100);
+    },
+  );
+
+  test('accepts a valid opacity and defaults a missing one', () => {
+    expect(
+      StrictWatermarkSchema.parse({ ...watermarkBase, opacity: 50 }).opacity,
+    ).toBe(50);
+    expect(StrictWatermarkSchema.parse(watermarkBase).opacity).toBe(100);
+  });
+
+  /**
+   * An unrecognised programType became undefined, which means "no restriction",
+   * so a fade rule scoped to one type silently applied to every program.
+   */
+  test('rejects an unrecognised fadeConfig programType on write', () => {
+    const fadeConfig = [{ programType: 'movies', periodMins: 5 }];
+    expect(
+      StrictWatermarkSchema.safeParse({ ...watermarkBase, fadeConfig }).success,
+    ).toBe(false);
+
+    const lenient = WatermarkSchema.parse({ ...watermarkBase, fadeConfig });
+    expect(lenient.fadeConfig?.[0].programType).toBeUndefined();
+  });
+
+  test('rejects a string leadingEdge on write', () => {
+    const fadeConfig = [{ periodMins: 5, leadingEdge: 'false' }];
+    expect(
+      StrictWatermarkSchema.safeParse({ ...watermarkBase, fadeConfig }).success,
+    ).toBe(false);
+
+    const lenient = WatermarkSchema.parse({ ...watermarkBase, fadeConfig });
+    expect(lenient.fadeConfig?.[0].leadingEdge).toBe(true);
+  });
+
+  test('still accepts a valid fadeConfig', () => {
+    const fadeConfig = [
+      { programType: 'movie', periodMins: 5, leadingEdge: false },
+    ];
+    const parsed = StrictWatermarkSchema.parse({
+      ...watermarkBase,
+      fadeConfig,
+    });
+    expect(parsed.fadeConfig?.[0]).toMatchObject({
+      programType: 'movie',
+      leadingEdge: false,
+    });
+  });
+});
+
+describe('channel icon write validation', () => {
+  const icon = { path: 'x', width: 1, duration: 0, position: 'top-left' };
+
+  test.each([
+    ['path', null],
+    ['width', -20],
+    ['position', 'centre'],
+  ])('rejects an invalid %s on write', (key, value) => {
+    expect(
+      StrictChannelIconSchema.safeParse({ ...icon, [key]: value }).success,
+    ).toBe(false);
+  });
+
+  test('still coerces those same values on read', () => {
+    expect(ChannelIconSchema.parse({ ...icon, path: null }).path).toBe('');
+    expect(ChannelIconSchema.parse({ ...icon, width: -20 }).width).toBe(0);
+    expect(
+      ChannelIconSchema.parse({ ...icon, position: 'centre' }).position,
+    ).toBe('bottom-right');
+  });
+
+  /**
+   * The strict schema uses .default() where the lenient one uses .catch(), so
+   * a *missing* field behaves identically and a partial icon is still accepted.
+   */
+  test('a partial icon is still accepted on write', () => {
+    expect(StrictChannelIconSchema.parse({})).toEqual({
+      path: '',
+      width: 0,
+      duration: 0,
+      position: 'bottom-right',
+    });
+  });
+});
+
+describe('SaveableChannelSchema uses the strict variants', () => {
+  const channel = {
+    disableFillerOverlay: false,
+    duration: 60000,
+    groupTitle: 'test',
+    guideMinimumDuration: 30000,
+    icon: { path: '', width: 0, duration: 0, position: 'bottom-right' },
+    id: '00000000-0000-0000-0000-000000000000',
+    name: 'Test',
+    number: 1,
+    offline: { mode: 'pic' },
+    startTime: 0,
+    stealth: false,
+    streamMode: 'hls',
+    transcodeConfigId: '00000000-0000-0000-0000-000000000000',
+    subtitlesEnabled: false,
+  };
+
+  test('accepts a valid channel', () => {
+    expect(SaveableChannelSchema.safeParse(channel).success).toBe(true);
+  });
+
+  test('rejects a channel whose watermark opacity is out of range', () => {
+    const result = SaveableChannelSchema.safeParse({
+      ...channel,
+      watermark: { ...watermarkBase, opacity: 150 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a channel whose icon position is misspelled', () => {
+    const result = SaveableChannelSchema.safeParse({
+      ...channel,
+      icon: { ...channel.icon, position: 'centre' },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/tests/channelWriteContract.test.ts
+++ b/server/tests/channelWriteContract.test.ts
@@ -1,0 +1,133 @@
+import { SaveableChannel } from '@tunarr/types';
+import { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { container } from '../src/container.ts';
+import { ChannelDB } from '../src/db/ChannelDB.ts';
+import { TranscodeConfigDB } from '../src/db/TranscodeConfigDB.ts';
+import { KEYS } from '../src/types/inject.ts';
+import { getAvailablePort } from '../src/util/net.ts';
+import { initTestApp } from './testServer.js';
+
+let app: FastifyInstance;
+let transcodeConfigId: string;
+let channelId: string;
+
+function channelPayload(): Partial<SaveableChannel> {
+  return {
+    name: 'Write Contract Channel',
+    number: 901,
+    duration: 60000,
+    groupTitle: 'test',
+    guideMinimumDuration: 30000,
+    icon: { path: '', width: 0, duration: 0, position: 'bottom-right' },
+    id: '00000000-0000-0000-0000-000000000000',
+    startTime: 0,
+    stealth: false,
+    offline: { mode: 'pic' },
+    streamMode: 'hls',
+    transcodeConfigId,
+    disableFillerOverlay: false,
+    subtitlesEnabled: false,
+  };
+}
+
+beforeAll(async () => {
+  app = await initTestApp(await getAvailablePort());
+  const defaultConfig = await container
+    .get(TranscodeConfigDB)
+    .getDefaultConfig();
+  if (!defaultConfig) {
+    throw new Error('Default transcode config not found after bootstrap');
+  }
+  transcodeConfigId = defaultConfig.uuid;
+
+  const created = await container
+    .get<ChannelDB>(KEYS.ChannelDB)
+    .saveChannel(channelPayload() as SaveableChannel);
+  channelId = created.channel.uuid;
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+async function put(body: Record<string, unknown>) {
+  return await app.inject({
+    method: 'PUT',
+    url: `/api/channels/${channelId}`,
+    payload: body,
+  });
+}
+
+/**
+ * These used to answer 200 and store a different value than the one submitted.
+ * The channel *response* schema stays lenient, so existing rows still load —
+ * only the request body is strict.
+ */
+describe('PUT /channels/:id - values are stored as submitted or rejected', () => {
+  test('accepts a valid channel', async () => {
+    const res = await put(channelPayload());
+    expect(res.statusCode, res.body).toBe(200);
+  });
+
+  test('rejects a watermark opacity outside 0-100', async () => {
+    const res = await put({
+      ...channelPayload(),
+      watermark: {
+        enabled: true,
+        width: 10,
+        verticalMargin: 5,
+        horizontalMargin: 5,
+        opacity: 150,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects an unrecognised fadeConfig programType', async () => {
+    const res = await put({
+      ...channelPayload(),
+      watermark: {
+        enabled: true,
+        width: 10,
+        verticalMargin: 5,
+        horizontalMargin: 5,
+        fadeConfig: [{ programType: 'movies', periodMins: 5 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('rejects a misspelled icon position', async () => {
+    const res = await put({
+      ...channelPayload(),
+      icon: { path: '', width: 0, duration: 0, position: 'centre' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('stores a valid watermark opacity as submitted', async () => {
+    const res = await put({
+      ...channelPayload(),
+      watermark: {
+        enabled: true,
+        width: 10,
+        verticalMargin: 5,
+        horizontalMargin: 5,
+        opacity: 42,
+      },
+    });
+
+    expect(res.statusCode, res.body).toBe(200);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: `/api/channels/${channelId}`,
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json().watermark.opacity).toBe(42);
+  });
+});

--- a/types/src/schemas/channelSchema.ts
+++ b/types/src/schemas/channelSchema.ts
@@ -3,7 +3,11 @@ import type { TupleToUnion } from '../util.js';
 import { ResolutionSchema } from './miscSchemas.js';
 import { ProgramSchema } from './programmingSchema.js';
 import { SubtitlePreference } from './subtitleSchema.js';
-import { ChannelIconSchema, ContentProgramTypeSchema } from './utilSchemas.js';
+import {
+  ChannelIconSchema,
+  ContentProgramTypeSchema,
+  StrictChannelIconSchema,
+} from './utilSchemas.js';
 
 export const WatermarkSchema = z.object({
   url: z.string().optional(),
@@ -34,6 +38,36 @@ export const WatermarkSchema = z.object({
         // If true, the watermark will fade in immediately on channel stream start.
         // If false, the watermark will start not visible and fade in after periodMins.
         leadingEdge: z.boolean().optional().catch(true),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * The watermark as accepted from a client.
+ *
+ * Same split as StrictChannelIconSchema: identical handling of a *missing*
+ * field, validation failure instead of silent substitution for an *invalid*
+ * one. The `.catch()` calls in WatermarkSchema above are kept because that
+ * schema also sits on channel responses, which are serialized from an
+ * unvalidated JSON column.
+ *
+ * What they were hiding:
+ * - `opacity: 150`, `-10`, `50.5` or `"50"` was stored as 100, fully opaque.
+ * - `fadeConfig[].programType: "movies"` (not a ContentProgramType) became
+ *   undefined, which means "no restriction" — so a fade rule the user scoped
+ *   to one program type silently applied to every program on the channel.
+ * - `fadeConfig[].leadingEdge: "false"`, as a form serialiser would send it,
+ *   became true, the opposite of what was asked for.
+ */
+export const StrictWatermarkSchema = WatermarkSchema.extend({
+  opacity: z.number().min(0).max(100).int().optional().default(100),
+  fadeConfig: z
+    .array(
+      z.object({
+        programType: ContentProgramTypeSchema.optional(),
+        periodMins: z.number().positive().min(1),
+        leadingEdge: z.boolean().optional(),
       }),
     )
     .optional(),
@@ -151,14 +185,22 @@ export const ChannelSchema = z.object({
   subtitlePreferences: z.array(SubtitlePreference).nonempty().optional(),
 });
 
+// The write path validates strictly: a bad icon or watermark value is a 400,
+// not a 200 that stored something else. The read path (ChannelSchema, used on
+// channel responses) stays lenient so existing rows still serialize.
 export const SaveableChannelSchema = ChannelSchema.omit({
   fallback: true, // Figure out how to update this
   programCount: true,
   transcoding: true,
   sessions: true,
-}).partial({
-  onDemand: true,
-});
+})
+  .partial({
+    onDemand: true,
+  })
+  .extend({
+    icon: StrictChannelIconSchema,
+    watermark: StrictWatermarkSchema.optional(),
+  });
 
 export const NewChannelSaveRequestSchema = z.object({
   type: z.literal('new'),

--- a/types/src/schemas/utilSchemas.ts
+++ b/types/src/schemas/utilSchemas.ts
@@ -88,18 +88,47 @@ export const ExternalIdSchema = z.discriminatedUnion('type', [
   MultiExternalIdSchema,
 ]);
 
+export const ChannelIconPositionSchema = z.union([
+  z.literal('top-left'),
+  z.literal('top-right'),
+  z.literal('bottom-left'),
+  z.literal('bottom-right'),
+]);
+
+/**
+ * The icon as accepted from a client.
+ *
+ * `.default()` where the lenient schema below has `.catch()`. Both produce the
+ * same value for a *missing* field, so a partial icon is still accepted; the
+ * difference is an *invalid* one. `.catch()` swallows it — `width: -20` was
+ * stored as 0, `position: "centre"` as "bottom-right", `path: null` as "" —
+ * and answered 200, so the client was told its value had been saved when
+ * something else had been. These now fail validation.
+ */
+export const StrictChannelIconSchema = z.object({
+  path: z.string().default(''),
+  width: z.number().nonnegative().default(0),
+  duration: z.number().default(0),
+  position: ChannelIconPositionSchema.default('bottom-right'),
+  useDefaultIconFallback: z.boolean().optional(),
+});
+
+/**
+ * The icon as read back out.
+ *
+ * Deliberately lenient, and the `.catch()` calls here are load-bearing: the
+ * channel `icon` column is raw JSON that drizzle casts but never validates, and
+ * this schema sits on the response of GET /channels, GET /channels/:id,
+ * GET /channels/all/lineups, GET /channels/:id/lineup and GET /guide/channels.
+ * fastify-type-provider-zod validates responses too, so a legacy or malformed
+ * stored icon would become a hard 500 on those routes rather than a coerced
+ * value. Do not tighten this one without a migration.
+ */
 export const ChannelIconSchema = z.object({
   path: z.string().catch(''),
   width: z.number().nonnegative().catch(0),
   duration: z.number().catch(0),
-  position: z
-    .union([
-      z.literal('top-left'),
-      z.literal('top-right'),
-      z.literal('bottom-left'),
-      z.literal('bottom-right'),
-    ])
-    .catch('bottom-right'),
+  position: ChannelIconPositionSchema.catch('bottom-right'),
   useDefaultIconFallback: z.boolean().optional().catch(true),
 });
 


### PR DESCRIPTION
## Problem

`WatermarkSchema` and `ChannelIconSchema` carry `.catch()` on several fields. `PUT /channels/:id` therefore answered **200** while storing something other than what was submitted:

| Submitted | Stored | Consequence |
|---|---|---|
| `watermark.opacity: 150` / `-10` / `50.5` / `"50"` | `100` | Watermark is fully opaque, not the requested opacity |
| `watermark.fadeConfig[].programType: "movies"` | `undefined` | `undefined` means *no restriction*, so a fade rule scoped to one program type silently applied to **every** program on the channel |
| `watermark.fadeConfig[].leadingEdge: "false"` | `true` | The opposite of what was asked for — and `"false"` is what a form serialiser sends |
| `icon.path: null` | `""` | The channel's icon is silently cleared |
| `icon.width: -20` | `0` | |
| `icon.position: "centre"` | `"bottom-right"` | |

All verified directly against the schemas before changing them.

## Why the `.catch()` calls could not just be deleted

This is the part worth reviewing carefully. The plan for this work assumed the `.catch()` was load-bearing because these schemas parse persisted data. **They don't** — nothing in the persistence layer uses them. `channel-lineups/*.json` uses a separate server-local `LineupSchema`, and the `db/schema/base.ts` copies turned out to be nearly decorative (one default value and two type aliases).

But the conclusion still holds, one layer later: **`fastify-type-provider-zod` validates responses too**, calling `safeParse` and throwing `ResponseSerializationError` on failure. The `icon` and `watermark` columns are `text({mode:'json'}).$type<...>()` — a compile-time cast only, so drizzle `JSON.parse`s them with no validation, and the converters pass them through untouched.

So these `.catch()` calls are the *only* sanitizer standing between a legacy or malformed stored blob and a hard **500** on:

- `GET /api/channels`
- `GET /api/channels/:id`
- `GET /api/channels/all/lineups`
- `GET /api/channels/:id/lineup`
- `GET /api/guide/channels`
- `POST /api/troubleshoot`

Tightening them in place would have broken channel loading on exactly the installs with old data.

## Fix

The schemas are split by direction:

- `StrictChannelIconSchema` / `StrictWatermarkSchema` → used by `SaveableChannelSchema`, i.e. the **request body** of `PUT /channels/:id` and `POST /channels`.
- The lenient originals stay on the **response** path, now carrying a comment explaining why they must not be tightened without a migration.

The strict variants use `.default()` in exactly the places the lenient ones use `.catch()`. That is deliberate: **a missing field behaves identically**, so a partial icon or watermark is still accepted and no existing client breaks. Only an *invalid* value changes behaviour — from silent substitution to a 400.

## ⚠️ Behaviour change

A client that was sending an out-of-range opacity, a misspelled position, or a bad `programType` now gets a 400 where it used to get a 200. That is the point of the change, but it is a stricter contract worth calling out.

## Related, not fixed here

`WatermarkSchema.width` is `z.number().positive()` while the DB-side copy allows `nonnegative()`, so a persisted `width: 0` watermark already breaks the channel response today. Pre-existing, out of scope, flagged for a follow-up.

## Test plan

Two new files. The end-to-end rejections were confirmed red by reverting the schema change and re-running: all three returned **200** before.

`server/tests/channelWriteContract.test.ts` (5 tests, through the real route):
- [x] Rejects a watermark opacity outside 0–100. **Was 200.**
- [x] Rejects an unrecognised `fadeConfig.programType`. **Was 200.**
- [x] Rejects a misspelled icon position. **Was 200.**
- [x] Still accepts a valid channel.
- [x] A valid `opacity: 42` round-trips through `PUT` then `GET` unchanged — proving the lenient response path still works.

`server/src/types/channelWriteValidation.test.ts` (20 tests, schema level):
- [x] Each strict schema rejects the values above.
- [x] Each lenient schema **still coerces those same values**, pinning the response-path behaviour that must not regress.
- [x] A partial icon (`{}`) is still accepted by the strict schema and fills its documented defaults.

- [x] Full server suite: 1151 passed, 2 skipped.
- [x] `pnpm turbo typecheck` clean, including `web` — the inferred `SaveableChannel` type changed, so this was the real risk and it is covered.
- [x] `pnpm lint-changed` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)