### PR TITLE
fix: populate scan_kind for interlaced Emby, Jellyfin, and Plex content

### DIFF
--- a/server/src/external/emby/EmbyApiClient.ts
+++ b/server/src/external/emby/EmbyApiClient.ts
@@ -46,6 +46,7 @@ import {
   isNil,
   isNull,
   isNumber,
+  isUndefined,
   mapValues,
   omitBy,
   orderBy,
@@ -876,13 +877,10 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
     let totalCount = Number.MAX_SAFE_INTEGER;
 
     while (page * pageSize < totalCount) {
-      const result = await this.getRawItems(
-        null,
-        libraryId,
-        ['BoxSet'],
-        [],
-        { offset: page * pageSize, limit: pageSize },
-      );
+      const result = await this.getRawItems(null, libraryId, ['BoxSet'], [], {
+        offset: page * pageSize,
+        limit: pageSize,
+      });
 
       if (result.isFailure()) {
         throw result.error;
@@ -1335,6 +1333,11 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
         widthPx: width,
         heightPx: height,
       },
+      scanKind: isUndefined(videoStream?.IsInterlaced)
+        ? 'unknown'
+        : videoStream.IsInterlaced
+          ? 'interlaced'
+          : 'progressive',
     };
   }
 

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -51,6 +51,7 @@ import {
   isNil,
   isNull,
   isNumber,
+  isUndefined,
   mapValues,
   omitBy,
   orderBy,
@@ -1307,6 +1308,11 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
         heightPx: height,
       },
       chapters,
+      scanKind: isUndefined(videoStream?.IsInterlaced)
+        ? 'unknown'
+        : videoStream.IsInterlaced
+          ? 'interlaced'
+          : 'progressive',
     };
   }
 

--- a/server/src/external/plex/PlexApiClient.ts
+++ b/server/src/external/plex/PlexApiClient.ts
@@ -2277,6 +2277,12 @@ export class PlexApiClient extends MediaSourceApiClient<PlexTypes> {
         },
       ],
       chapters,
+      scanKind:
+        videoStream?.scanType === 'interlaced'
+          ? 'interlaced'
+          : videoStream?.scanType === 'progressive'
+            ? 'progressive'
+            : 'unknown',
     } satisfies MediaItem);
   }
 }


### PR DESCRIPTION
Media source clients never mapped the interlaced/progressive info returned by Emby, Jellyfin, and Plex into MediaItem.scanKind, so it was always stored as 'unknown'.

Users will have to rescan libraries to pick up the change. Results for a library before the fix:

```
sqlite> SELECT scan_kind, COUNT(*) FROM program_version GROUP BY scan_kind;
scan_kind    COUNT(*)
-----------  --------
progressive  8       
unknown      4049    
```

Results after scanning a specific show after the fix:

```
sqlite> SELECT scan_kind, COUNT(*) FROM program_version GROUP BY scan_kind;
scan_kind    COUNT(*)
-----------  --------
interlaced   142     
progressive  13      
unknown      3902
```