### PR TITLE
fix(settings): stop a partial feature-flag update turning the others off

### DIFF
--- a/server/src/types/featureFlagsRequest.test.ts
+++ b/server/src/types/featureFlagsRequest.test.ts
@@ -1,0 +1,46 @@
+import { FeatureFlagsSchema } from '@tunarr/types';
+import { UpdateFeatureFlagsRequestSchema } from '@tunarr/types/api';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * UpdateFeatureFlagsRequestSchema is written out field by field instead of
+ * being derived from FeatureFlagsSchema, because `.partial()` leaves each
+ * field's `.default()` in place and so cannot express "omitted". These guard
+ * the hazard that introduces: the two can drift apart.
+ */
+describe('UpdateFeatureFlagsRequestSchema', () => {
+  const flagKeys = Object.keys(FeatureFlagsSchema.shape).sort();
+  const updateKeys = Object.keys(UpdateFeatureFlagsRequestSchema.shape).sort();
+
+  test('covers exactly the flags that exist', () => {
+    expect(updateKeys).toEqual(flagKeys);
+  });
+
+  test('carries no defaults, so an omitted flag stays omitted', () => {
+    // `.partial()` produces `optional` wrapping `default`, which is exactly the
+    // shape that made an omitted flag arrive populated.
+    const withDefaults = Object.entries(
+      UpdateFeatureFlagsRequestSchema.shape,
+    ).filter(([, field]) => {
+      const def = field._zod.def;
+      return (
+        def.type === 'default' ||
+        (def.type === 'optional' &&
+          (def.innerType as typeof field)._zod.def.type === 'default')
+      );
+    });
+
+    expect(withDefaults.map(([key]) => key)).toEqual([]);
+  });
+
+  test.each(flagKeys)('omits %s from the parsed body when not sent', (key) => {
+    const parsed = UpdateFeatureFlagsRequestSchema.parse({});
+    expect(key in parsed).toBe(false);
+  });
+
+  test('passes through only the flags it was given', () => {
+    expect(
+      UpdateFeatureFlagsRequestSchema.parse({ tonemapEnabled: true }),
+    ).toEqual({ tonemapEnabled: true });
+  });
+});

--- a/server/tests/featureFlagsPartialUpdate.test.ts
+++ b/server/tests/featureFlagsPartialUpdate.test.ts
@@ -1,0 +1,95 @@
+import { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { getAvailablePort } from '../src/util/net.ts';
+import { initTestApp } from './testServer.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await initTestApp(await getAvailablePort());
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+async function putFlags(body: Record<string, unknown>) {
+  const res = await app.inject({
+    method: 'PUT',
+    url: '/api/system/feature-flags',
+    payload: body,
+  });
+  expect(res.statusCode, res.body).toBe(200);
+  return res.json();
+}
+
+async function getFlags() {
+  const res = await app.inject({
+    method: 'GET',
+    url: '/api/system/feature-flags',
+  });
+  expect(res.statusCode, res.body).toBe(200);
+  return res.json().flags as Record<string, boolean>;
+}
+
+/**
+ * `UpdateFeatureFlagsRequestSchema` was `FeatureFlagsSchema.partial()`, and
+ * every flag carries `.default(false)`. `.partial()` wraps a default rather
+ * than removing it, so all six flags arrived populated whatever the client
+ * sent, and the handler's `Object.assign(file.featureFlags, req.body)` wrote
+ * all six. Turning one flag on therefore turned every other flag off.
+ */
+describe('PUT /system/feature-flags - partial update', () => {
+  test('turning one flag on does not turn the others off', async () => {
+    await putFlags({
+      proxyArtwork: true,
+      tonemapEnabled: false,
+      webvttSidecarEnabled: true,
+      disableSearchSnapshotInBackup: false,
+      disableVulkan: false,
+      disableVaapiPad: false,
+    });
+
+    expect(await getFlags()).toMatchObject({
+      proxyArtwork: true,
+      webvttSidecarEnabled: true,
+    });
+
+    // Enable one unrelated flag, mentioning nothing else.
+    await putFlags({ tonemapEnabled: true });
+
+    expect(await getFlags()).toMatchObject({
+      tonemapEnabled: true,
+      // These were never mentioned and must survive.
+      proxyArtwork: true,
+      webvttSidecarEnabled: true,
+    });
+  });
+
+  test('an empty body changes nothing', async () => {
+    await putFlags({ proxyArtwork: true, disableVulkan: true });
+    const before = await getFlags();
+
+    await putFlags({});
+
+    expect(await getFlags()).toEqual(before);
+  });
+
+  test('a flag can still be turned off explicitly', async () => {
+    await putFlags({ proxyArtwork: true });
+    expect((await getFlags()).proxyArtwork).toBe(true);
+
+    await putFlags({ proxyArtwork: false });
+    expect((await getFlags()).proxyArtwork).toBe(false);
+  });
+
+  test('rejects a non-boolean flag value', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/system/feature-flags',
+      payload: { proxyArtwork: 'yes' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/types/src/api/index.ts
+++ b/types/src/api/index.ts
@@ -509,7 +509,27 @@ export type GetFeatureFlagsResponse = z.infer<
   typeof GetFeatureFlagsResponseSchema
 >;
 
-export const UpdateFeatureFlagsRequestSchema = FeatureFlagsSchema.partial();
+/**
+ * Declared field by field rather than as `FeatureFlagsSchema.partial()`. Every
+ * flag carries `.default(false)`, and `.partial()` wraps a default rather than
+ * removing it, so all six arrived populated whatever the client sent. The
+ * handler's `Object.assign(file.featureFlags, req.body)` then wrote all six,
+ * which meant turning one flag on turned every other flag off.
+ *
+ * Zod omits an absent optional key from its output entirely, so `Object.assign`
+ * is the correct handler for this shape once the schema is genuinely partial.
+ *
+ * A flag added to FeatureFlagsSchema must be added here too, or it will not be
+ * updatable. `featureFlagsRequest.test.ts` fails if the two drift apart.
+ */
+export const UpdateFeatureFlagsRequestSchema = z.object({
+  proxyArtwork: z.boolean().optional(),
+  tonemapEnabled: z.boolean().optional(),
+  webvttSidecarEnabled: z.boolean().optional(),
+  disableSearchSnapshotInBackup: z.boolean().optional(),
+  disableVulkan: z.boolean().optional(),
+  disableVaapiPad: z.boolean().optional(),
+});
 
 export type UpdateFeatureFlagsRequest = z.infer<
   typeof UpdateFeatureFlagsRequestSchema


### PR DESCRIPTION
Found by the zod contract audit (#2009), not by hand.

## Problem

`UpdateFeatureFlagsRequestSchema` was `FeatureFlagsSchema.partial()`, and every flag carries `.default(false)`. `.partial()` **wraps** a field's default rather than removing it, so all six flags arrive populated whatever the client sent:

```js
UpdateFeatureFlagsRequestSchema.parse({ tonemapEnabled: true })
// => { proxyArtwork: false, tonemapEnabled: true, webvttSidecarEnabled: false,
//      disableSearchSnapshotInBackup: false, disableVulkan: false, disableVaapiPad: false }
```

The handler then does `Object.assign(file.featureFlags, req.body)` over all six. So **enabling one flag through the API silently turns every other flag off.**

`PUT /system/feature-flags` is published as a partial update, so any client following the spec loses state. The Features settings page submits the whole form, which is why the UI never showed it — the same reason the `from`/`to` bug in #1996 went unnoticed for so long.

## Fix

The body is declared field by field, genuinely optional, no defaults.

**The handler does not change.** Zod omits an absent optional key from its output entirely (`'b' in S.parse({a: true})` is `false`), so `Object.assign` is already correct for this shape once the schema is a real partial. Verified before relying on it — if zod had emitted `key: undefined`, `Object.assign` would have written undefined over each flag and this would have needed a handler change too.

## The hazard this introduces

Writing the fields out instead of deriving them means a new flag added to `FeatureFlagsSchema` would silently not be updatable. `server/src/types/featureFlagsRequest.test.ts` closes that: it asserts the two schemas cover exactly the same keys, and that no update field carries a default.

That felt worth a test rather than a clever derived type — the derivation needed a cast to keep the field types, and an explicit list plus a drift test reads better than a cast.

## Test plan

`server/tests/featureFlagsPartialUpdate.test.ts` — through the real route. 2 of 4 confirmed red:

- [x] Turning one flag on leaves the others alone. **Failed before** — `proxyArtwork` flipped to `false` without being mentioned.
- [x] An empty body changes nothing. **Failed before.**
- [x] A flag can still be turned off explicitly (`false` is honoured, not treated as absent).
- [x] A non-boolean flag value is still a 400.

`server/src/types/featureFlagsRequest.test.ts` — 9 tests pinning key coverage and the no-defaults property.

- [x] Full server suite: 1144 passed, 2 skipped.
- [x] `pnpm turbo typecheck` clean.

## Note

Independent of #2009 — no dependency on the audit module, so these can merge in either order. Once both land, the six `UpdateFeatureFlagsRequestSchema.*` entries in that PR's `KNOWN` list should be deleted; its stale-entry test will point this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)