### PR TITLE
fix: repair lint-changed and add a preflight that mirrors CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "fmt": "prettier --write .",
     "lint-staged": "lint-staged --allow-empty",
     "lint-changed": "./scripts/lint-changed.sh",
+    "preflight": "./scripts/preflight.sh",
     "test": "turbo run test",
     "preinstall": "npx only-allow pnpm",
     "should-semantic-release": "should-semantic-release --verbose",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "turbo run dev",
     "fmt": "prettier --write .",
     "lint-staged": "lint-staged --allow-empty",
-    "lint-changed": "eslint --fix $(git diff --name-only HEAD -- './**/*.ts*' | xargs)",
+    "lint-changed": "./scripts/lint-changed.sh",
     "test": "turbo run test",
     "preinstall": "npx only-allow pnpm",
     "should-semantic-release": "should-semantic-release --verbose",

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Lint the TypeScript files this working copy has actually touched.
+#
+# Replaces `eslint --fix $(git diff --name-only HEAD ...)`, which had two
+# failure modes:
+#
+#   * An empty file list left eslint with no path arguments, so it fell back to
+#     linting the entire monorepo and exhausted the V8 heap (abort, exit 134).
+#     The list went empty precisely when you committed first and then ran the
+#     check, which is the normal time to run it.
+#   * Deleted paths were passed straight through and eslint died on the missing
+#     file.
+#
+# Committed-but-unmerged work counts as changed. Otherwise the check reports
+# "nothing to lint" on a branch that plainly has changes, which is a gate that
+# passes by doing nothing.
+set -euo pipefail
+
+# Direct execution has to work too, not just `pnpm lint-changed`, which is the
+# only context that puts the workspace binaries on PATH for us.
+PATH="$(git rev-parse --show-toplevel)/node_modules/.bin:${PATH}"
+
+PATTERNS=('*.ts' '*.tsx' '*.mts' '*.cts')
+
+base_ref=''
+for candidate in "${LINT_BASE_REF:-}" origin/main main; do
+  if [ -n "$candidate" ] && git rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+    base_ref="$candidate"
+    break
+  fi
+done
+
+collect_files() {
+  # Committed work on this branch, relative to where it forked from base.
+  if [ -n "$base_ref" ]; then
+    local merge_base
+    merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
+    if [ -n "$merge_base" ]; then
+      git diff --name-only -z --diff-filter=ACMR "$merge_base" -- "${PATTERNS[@]}"
+    fi
+  fi
+  # Staged and unstaged edits.
+  git diff --name-only -z --diff-filter=ACMR HEAD -- "${PATTERNS[@]}"
+  # New files that are not committed yet but are not ignored either.
+  git ls-files -z --others --exclude-standard -- "${PATTERNS[@]}"
+}
+
+files_list="$(collect_files | tr '\0' '\n' | grep -v '^$' | sort -u || true)"
+
+if [ -z "$files_list" ]; then
+  echo "lint-changed: no changed TypeScript files."
+  exit 0
+fi
+
+# Build an argv array rather than piping to xargs, so eslint's own exit code
+# survives (xargs reports its own 123 for any non-zero child).
+files=()
+while IFS= read -r file; do
+  if [ -n "$file" ]; then files+=("$file"); fi
+done <<< "$files_list"
+
+echo "lint-changed: linting ${#files[@]} file(s)${base_ref:+ (base: ${base_ref})}"
+
+exec eslint --fix --no-warn-ignored "${files[@]}"

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -1,55 +1,90 @@
 #!/usr/bin/env bash
 #
-# Lint the TypeScript files this working copy has actually touched.
+# Lint the TypeScript files you have actually touched.
 #
-# Replaces `eslint --fix $(git diff --name-only HEAD ...)`, which had two
-# failure modes:
+# Replaces `eslint --fix $(git diff --name-only HEAD -- './**/*.ts*' | xargs)`,
+# which had two failure modes:
 #
 #   * An empty file list left eslint with no path arguments, so it fell back to
-#     linting the entire monorepo and exhausted the V8 heap (abort, exit 134).
-#     The list went empty precisely when you committed first and then ran the
-#     check, which is the normal time to run it.
+#     linting the entire monorepo. That exhausts the V8 heap (abort, exit 134)
+#     and, because `--fix` rewrites files as it goes, it reformats whatever it
+#     reached on the way down.
 #   * Deleted paths were passed straight through and eslint died on the missing
 #     file.
 #
-# Committed-but-unmerged work counts as changed. Otherwise the check reports
-# "nothing to lint" on a branch that plainly has changes, which is a gate that
-# passes by doing nothing.
+# Scope is the working tree by default: staged edits, unstaged edits, and
+# untracked files. `--branch` additionally lints everything this branch has
+# committed since it forked from the base ref. That is opt-in because `--fix`
+# rewrites files, and on a long-lived branch the committed set is large -- it
+# would silently reformat files the current task never touched.
 set -euo pipefail
 
-# Direct execution has to work too, not just `pnpm lint-changed`, which is the
-# only context that puts the workspace binaries on PATH for us.
 PATH="$(git rev-parse --show-toplevel)/node_modules/.bin:${PATH}"
 
 PATTERNS=('*.ts' '*.tsx' '*.mts' '*.cts')
+include_branch=0
 
-base_ref=''
-for candidate in "${LINT_BASE_REF:-}" origin/main main; do
-  if [ -n "$candidate" ] && git rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
-    base_ref="$candidate"
-    break
-  fi
+usage() {
+  cat <<'USAGE'
+Usage: lint-changed [--branch]
+
+  (default)   lint staged, unstaged and untracked TypeScript files
+  --branch    also lint files committed on this branch since it forked
+              from origin/main (override the base with LINT_BASE_REF)
+USAGE
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --branch) include_branch=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "lint-changed: unknown argument '$arg'" >&2; usage >&2; exit 2 ;;
+  esac
 done
 
-collect_files() {
-  # Committed work on this branch, relative to where it forked from base.
-  if [ -n "$base_ref" ]; then
-    local merge_base
-    merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
-    if [ -n "$merge_base" ]; then
-      git diff --name-only -z --diff-filter=ACMR "$merge_base" -- "${PATTERNS[@]}"
+resolve_base_ref() {
+  local candidate
+  for candidate in "${LINT_BASE_REF:-}" origin/main main; do
+    if [ -n "$candidate" ] && git rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+      printf '%s' "$candidate"
+      return
     fi
-  fi
-  # Staged and unstaged edits.
+  done
+}
+
+collect_working_tree() {
   git diff --name-only -z --diff-filter=ACMR HEAD -- "${PATTERNS[@]}"
-  # New files that are not committed yet but are not ignored either.
   git ls-files -z --others --exclude-standard -- "${PATTERNS[@]}"
 }
 
-files_list="$(collect_files | tr '\0' '\n' | grep -v '^$' | sort -u || true)"
+collect_branch() {
+  local base merge_base
+  base="$(resolve_base_ref)"
+  if [ -z "$base" ]; then
+    return
+  fi
+  merge_base="$(git merge-base "$base" HEAD 2>/dev/null || true)"
+  if [ -n "$merge_base" ]; then
+    git diff --name-only -z --diff-filter=ACMR "$merge_base" -- "${PATTERNS[@]}"
+  fi
+}
+
+collect_all() {
+  collect_working_tree
+  if [ "$include_branch" -eq 1 ]; then
+    collect_branch
+  fi
+}
+
+files_list="$(collect_all | tr '\0' '\n' | grep -v '^$' | sort -u || true)"
 
 if [ -z "$files_list" ]; then
-  echo "lint-changed: no changed TypeScript files."
+  if [ "$include_branch" -eq 1 ]; then
+    echo "lint-changed: no changed TypeScript files."
+  else
+    echo "lint-changed: no uncommitted TypeScript changes."
+    echo "lint-changed: to lint what this branch has committed, run: pnpm lint-changed --branch"
+  fi
   exit 0
 fi
 
@@ -60,6 +95,10 @@ while IFS= read -r file; do
   if [ -n "$file" ]; then files+=("$file"); fi
 done <<< "$files_list"
 
-echo "lint-changed: linting ${#files[@]} file(s)${base_ref:+ (base: ${base_ref})}"
+scope='working tree'
+if [ "$include_branch" -eq 1 ]; then
+  scope="working tree + branch since $(resolve_base_ref)"
+fi
+echo "lint-changed: linting ${#files[@]} file(s) [${scope}]"
 
 exec eslint --fix --no-warn-ignored "${files[@]}"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -19,6 +19,13 @@
 # The lingui gate mutates the working tree -- regenerating the catalogs is also
 # the remedy, so leaving the result applied saves a round trip. If it reports a
 # diff, commit web/src/locales/ and the gate passes.
+#
+# GATE ORDER MATTERS. `eslint --fix` rewrites source, and the lingui catalogs
+# record source line numbers -- and, for messages with complex placeholders, the
+# whole surrounding file. So eslint runs FIRST and lingui runs LAST. Extracting
+# before an autofix produces catalogs that describe source the fix then changed,
+# which passes here and fails in CI. That is not hypothetical: it is how this
+# script let a red PR through the first time it was used.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -104,6 +111,9 @@ gate_lingui() {
   return 1
 }
 
+# First: the only gate that rewrites source of its own accord.
+run_gate "eslint (changed)"    pnpm lint-changed
+
 run_gate "commitlint"          gate_commitlint
 run_gate "typecheck (server)"  pnpm turbo typecheck --filter=@tunarr/server
 
@@ -115,8 +125,8 @@ else
   run_gate "test"        pnpm turbo test -- run
 fi
 
+# Last: derived from whatever source the gates above settled on.
 run_gate "lingui catalogs"     gate_lingui
-run_gate "eslint (changed)"    pnpm lint-changed
 
 printf '\n\033[1m==> preflight summary\033[0m\n'
 for i in "${!names[@]}"; do

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -20,12 +20,19 @@
 # the remedy, so leaving the result applied saves a round trip. If it reports a
 # diff, commit web/src/locales/ and the gate passes.
 #
-# GATE ORDER MATTERS. `eslint --fix` rewrites source, and the lingui catalogs
-# record source line numbers -- and, for messages with complex placeholders, the
-# whole surrounding file. So eslint runs FIRST and lingui runs LAST. Extracting
-# before an autofix produces catalogs that describe source the fix then changed,
-# which passes here and fails in CI. That is not hypothetical: it is how this
-# script let a red PR through the first time it was used.
+# GATE ORDER MATTERS. The lingui catalogs record source line numbers -- and,
+# for messages with complex placeholders, the whole surrounding file. So
+# anything that rewrites source has to run BEFORE the extraction, and lingui
+# runs last. Extracting first produces catalogs describing source that is then
+# changed: green here, red in CI. Not hypothetical -- it happened twice while
+# this script was being written.
+#
+# The subtle half is that the pre-commit hook is itself a rewriter. It runs
+# `prettier --write` and `eslint --fix` on staged files at commit time, which is
+# after any preflight can possibly run. So the format gate below applies the
+# same prettier pass the hook will, leaving the tree in the shape the hook would
+# produce. Without it the hook reformats at commit time and silently invalidates
+# catalogs this script just certified.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -96,6 +103,27 @@ gate_commitlint() {
   pnpm exec commitlint --from "$merge_base" --to HEAD
 }
 
+# Mirrors what the pre-commit hook's lint-staged config does to staged files:
+# `prettier --write` then `eslint --fix`. Applying prettier here keeps the hook
+# from reformatting at commit time, after the lingui gate has already run.
+gate_format() {
+  local files
+  files="$(collect_changed_source)"
+  if [ -z "$files" ]; then
+    echo "preflight: no changed TypeScript files to format"
+    return 0
+  fi
+  # shellcheck disable=SC2086
+  printf '%s\n' "$files" | tr '\n' '\0' | xargs -0 --no-run-if-empty pnpm exec prettier --write --log-level warn
+}
+
+collect_changed_source() {
+  {
+    git diff --name-only --diff-filter=ACMR HEAD -- '*.ts' '*.tsx' '*.mts' '*.cts'
+    git ls-files --others --exclude-standard -- '*.ts' '*.tsx' '*.mts' '*.cts'
+  } | grep -v '^$' | sort -u
+}
+
 # Mirrors lingui-pr.yml. Extraction rewrites the catalogs in place; a non-empty
 # diff afterwards is exactly what CI fails on.
 gate_lingui() {
@@ -111,7 +139,9 @@ gate_lingui() {
   return 1
 }
 
-# First: the only gate that rewrites source of its own accord.
+# First: everything that rewrites source, in the same order the pre-commit hook
+# applies it, so the tree ends up where the hook would leave it.
+run_gate "format (changed)"    gate_format
 run_gate "eslint (changed)"    pnpm lint-changed
 
 run_gate "commitlint"          gate_commitlint

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Run every gate CI runs, in one command, before pushing.
+#
+# CI is spread over three workflows and no single local command covers them, so
+# it is easy to run `turbo build`, see green, and still fail the PR. The gates
+# and where they live:
+#
+#   main.yml        turbo typecheck --filter=@tunarr/server
+#                   turbo build --filter=@tunarr/web
+#                   turbo test -- run
+#   lingui-pr.yml   lingui extract, then `git diff --exit-code web/src/locales/`
+#   commitlint.yml  conventional-commit check on every commit in the PR
+#
+# eslint is deliberately included even though CI never runs it: it is enforced
+# only by the pre-commit hook, so a commit made with the hook bypassed reaches
+# the PR unlinted.
+#
+# The lingui gate mutates the working tree -- regenerating the catalogs is also
+# the remedy, so leaving the result applied saves a round trip. If it reports a
+# diff, commit web/src/locales/ and the gate passes.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+usage() {
+  cat <<'USAGE'
+Usage: preflight [--quick]
+
+  (default)  run every gate CI runs, plus eslint
+  --quick    skip the web bundle and the test suite (the two slow gates);
+             typecheck, lingui and lint still run
+USAGE
+}
+
+quick=0
+for arg in "$@"; do
+  case "$arg" in
+    --quick) quick=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "preflight: unknown argument '$arg'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+names=()
+results=()
+failed=0
+
+record() {
+  names+=("$1")
+  results+=("$2")
+  if [ "$2" != "pass" ]; then failed=1; fi
+}
+
+run_gate() {
+  local name="$1"; shift
+  printf '\n\033[1m==> %s\033[0m\n' "$name"
+  if "$@"; then
+    record "$name" pass
+  else
+    record "$name" FAIL
+  fi
+}
+
+skip_gate() {
+  names+=("$1")
+  results+=("skipped")
+}
+
+# commitlint reads the range CI would read: this branch since it forked from the
+# base. With no commits yet there is nothing to check, which is a pass.
+gate_commitlint() {
+  local base merge_base candidate
+  for candidate in "${PREFLIGHT_BASE_REF:-}" origin/main main; do
+    if [ -n "$candidate" ] && git rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+      base="$candidate"
+      break
+    fi
+  done
+  if [ -z "${base:-}" ]; then
+    echo "preflight: no base ref found, skipping commitlint"
+    return 0
+  fi
+  merge_base="$(git merge-base "$base" HEAD 2>/dev/null)" || return 0
+  if [ "$merge_base" = "$(git rev-parse HEAD)" ]; then
+    echo "preflight: no commits since $base, nothing to lint"
+    return 0
+  fi
+  pnpm exec commitlint --from "$merge_base" --to HEAD
+}
+
+# Mirrors lingui-pr.yml. Extraction rewrites the catalogs in place; a non-empty
+# diff afterwards is exactly what CI fails on.
+gate_lingui() {
+  (cd web && pnpm run extract-messages) || return 1
+  if git diff --quiet -- web/src/locales/; then
+    return 0
+  fi
+  echo
+  echo "preflight: catalogs are out of date and have been regenerated in place."
+  echo "preflight: commit them to satisfy the lingui check:"
+  git diff --name-only -- web/src/locales/ | sed 's/^/  /'
+  echo "  git add web/src/locales && git commit -m 'chore(web): refresh lingui catalogs'"
+  return 1
+}
+
+run_gate "commitlint"          gate_commitlint
+run_gate "typecheck (server)"  pnpm turbo typecheck --filter=@tunarr/server
+
+if [ "$quick" -eq 1 ]; then
+  skip_gate "build (web)"
+  skip_gate "test"
+else
+  run_gate "build (web)" pnpm turbo build --filter=@tunarr/web
+  run_gate "test"        pnpm turbo test -- run
+fi
+
+run_gate "lingui catalogs"     gate_lingui
+run_gate "eslint (changed)"    pnpm lint-changed
+
+printf '\n\033[1m==> preflight summary\033[0m\n'
+for i in "${!names[@]}"; do
+  case "${results[$i]}" in
+    pass)    printf '  \033[32m%-8s\033[0m %s\n' "pass" "${names[$i]}" ;;
+    FAIL)    printf '  \033[31m%-8s\033[0m %s\n' "FAIL" "${names[$i]}" ;;
+    *)       printf '  %-8s %s\n' "${results[$i]}" "${names[$i]}" ;;
+  esac
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo
+  echo "preflight: not ready to push."
+  exit 1
+fi
+
+if [ "$quick" -eq 1 ]; then
+  echo
+  echo "preflight: passed, but --quick skipped the web bundle and the tests."
+fi


### PR DESCRIPTION
Two fixes to local verification tooling. Both come from the same root problem: what we run locally does not match what CI runs.

## 1. `lint-changed` was linting the wrong thing (or everything)

The old script was:

```
eslint --fix $(git diff --name-only HEAD -- './**/*.ts*' | xargs)
```

Two failure modes:

- **Empty file list.** With no changed TypeScript files, eslint got no path arguments and fell back to linting the entire monorepo. That exhausts the V8 heap and aborts (exit 134) — and because `--fix` rewrites files as it goes, it reformats whatever it reached on the way down. That is where the mystery reformat-everything diffs came from.
- **Deleted paths.** Passed straight through, and eslint dies on the missing file.

`scripts/lint-changed.sh` replaces it:

- Scope is the **working tree** by default — staged, unstaged, and untracked files.
- `--branch` additionally lints what the branch has committed since it forked from `origin/main` (override with `LINT_BASE_REF`). Opt-in, because `--fix` rewrites files and on a long-lived branch the committed set is large.
- Empty list prints a message and exits 0 instead of linting the world.
- Builds a bash argv array rather than piping to `xargs`, so eslint's own exit code survives (`xargs` reports its own 123 for any non-zero child).
- Prepends the repo's `node_modules/.bin` to `PATH` so the script also works when invoked directly.

## 2. `pnpm preflight` — one command that mirrors CI

CI spreads its gates over three workflows and no local command covered them together:

| Gate | Workflow |
| --- | --- |
| `turbo typecheck --filter=@tunarr/server` | `main.yml` |
| `turbo build --filter=@tunarr/web` | `main.yml` |
| `turbo test -- run` | `main.yml` |
| `lingui extract` + `git diff --exit-code web/src/locales/` | `lingui-pr.yml` |
| conventional-commit check | `commitlint.yml` |

A green `turbo build` is therefore not evidence a PR will be green. The lingui check fails on nothing more than shifted source line numbers, which is exactly how a passing local build still produced a red PR on #2014.

`scripts/preflight.sh` runs all of them and prints one summary rather than stopping at the first failure. Notes:

- **eslint is included** even though CI never runs it. The pre-commit hook is its only enforcement, so a commit made with the hook bypassed reaches the PR unlinted.
- **The lingui gate mutates the working tree.** Regenerating the catalogs is also the remedy, so leaving the result applied saves a round trip. On failure it names the files and prints the commit command.
- `--quick` skips the web bundle and the test suite for a fast inner loop, and says so in the summary so a `--quick` pass is not mistaken for a full one.

## Test plan

- [x] `pnpm lint-changed` with no changes — prints a message, exits 0, lints nothing
- [x] `pnpm lint-changed` with changes — lints only those files
- [x] `pnpm lint-changed --branch` — includes the branch's committed files
- [x] Deleted file in the diff no longer crashes eslint
- [x] eslint's non-zero exit code propagates
- [x] `pnpm preflight --quick` passes on a clean branch
- [x] The lingui gate **fails** when replayed against the stale-catalog state that broke #2014, and passes once the catalogs are committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
