### PR TITLE
fix(scheduling): stop an out-of-period slot offset from killing the schedule

### DIFF
--- a/server/src/services/scheduling/TimeSlotService.outOfRange.test.ts
+++ b/server/src/services/scheduling/TimeSlotService.outOfRange.test.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from 'node:crypto';
+import type { TimeSlotSchedule } from '@tunarr/types/api';
+import dayjs from '@/util/dayjs.js';
+import { describe, expect, test } from 'vitest';
+import { createFakeProgramOrm } from '../../testing/fakes/entityCreators.ts';
+import type { SlotSchedulerProgram } from './slotSchedulerUtil.js';
+import { scheduleTimeSlots } from './TimeSlotService.ts';
+
+const ONE_DAY = 86_400_000;
+const TIME_OF_DAY = 21_000_000; // 05:50
+const OUT_OF_RANGE = ONE_DAY + TIME_OF_DAY; // 107_400_000, as reported
+
+const programs: SlotSchedulerProgram[] = Array.from({ length: 8 }, (_, i) => ({
+  ...createFakeProgramOrm({
+    uuid: `mv${i}`,
+    title: `Movie ${i}`,
+    type: 'movie',
+    duration: 90 * 60 * 1000,
+  }),
+  parentFillerLists: [],
+  parentCustomShows: [],
+  parentSmartCollections: [],
+}));
+
+// The settings from the bug report.
+function makeSchedule(startTime: number): TimeSlotSchedule {
+  return {
+    type: 'time',
+    flexPreference: 'distribute',
+    maxDays: 1,
+    padMs: 5 * 60 * 1000,
+    latenessMs: 10 * 60 * 1000,
+    period: 'day',
+    timeZoneOffset: 0,
+    slots: [
+      {
+        id: randomUUID(),
+        startTime,
+        type: 'movie' as const,
+        order: 'next' as const,
+        direction: 'asc' as const,
+      },
+    ],
+  };
+}
+
+describe('time slots with a startTime beyond the period', () => {
+  const midnight = dayjs().startOf('day');
+
+  test('does not throw when generated before the slot offset', async () => {
+    await expect(
+      scheduleTimeSlots(
+        makeSchedule(OUT_OF_RANGE),
+        programs,
+        undefined,
+        0,
+        midnight,
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  test('produces real programming rather than one long flex block', async () => {
+    const result = await scheduleTimeSlots(
+      makeSchedule(OUT_OF_RANGE),
+      programs,
+      undefined,
+      0,
+      midnight.add(7, 'hours'),
+    );
+
+    const longest = Math.max(...result.lineup.map((i) => i.duration));
+    expect(longest).toBeLessThanOrEqual(ONE_DAY);
+    expect(
+      result.lineup.filter((i) => i.type !== 'flex').length,
+    ).toBeGreaterThan(0);
+  });
+
+  test('is equivalent to the same slot expressed within the period', async () => {
+    const seed = [1, 2, 3, 4];
+    const [outOfRange, inRange] = await Promise.all([
+      scheduleTimeSlots(
+        makeSchedule(OUT_OF_RANGE),
+        programs,
+        seed,
+        0,
+        midnight.add(7, 'hours'),
+      ),
+      scheduleTimeSlots(
+        makeSchedule(TIME_OF_DAY),
+        programs,
+        seed,
+        0,
+        midnight.add(7, 'hours'),
+      ),
+    ]);
+
+    expect(outOfRange.lineup.length).toBe(inRange.lineup.length);
+    expect(outOfRange.lineup.map((i) => i.duration)).toEqual(
+      inRange.lineup.map((i) => i.duration),
+    );
+  });
+
+  test('collapses two slots that normalize onto the same offset, keeping the first', async () => {
+    // 05:50 and 29:50 are the same offset once reduced. The editor collapses
+    // such a pair by keeping the first, so the scheduler must agree or what
+    // airs will not match what is on screen.
+    const at = (startTime: number) => ({
+      id: randomUUID(),
+      startTime,
+      type: 'movie' as const,
+      order: 'next' as const,
+      direction: 'asc' as const,
+    });
+    const base = makeSchedule(TIME_OF_DAY);
+    const collided: TimeSlotSchedule = {
+      ...base,
+      slots: [at(TIME_OF_DAY), at(OUT_OF_RANGE)],
+    };
+    const single: TimeSlotSchedule = { ...base, slots: [at(TIME_OF_DAY)] };
+
+    const seed = [9, 8, 7];
+    const start = midnight.add(7, 'hours');
+    const [withCollision, withoutCollision] = await Promise.all([
+      scheduleTimeSlots(collided, programs, seed, 0, start),
+      scheduleTimeSlots(single, programs, seed, 0, start),
+    ]);
+
+    expect(withCollision.lineup.map((i) => i.duration)).toEqual(
+      withoutCollision.lineup.map((i) => i.duration),
+    );
+  });
+});

--- a/server/src/services/scheduling/TimeSlotService.ts
+++ b/server/src/services/scheduling/TimeSlotService.ts
@@ -23,6 +23,7 @@ import {
   nth,
   sortBy,
   sumBy,
+  uniqBy,
 } from 'lodash-es';
 import { createEntropy, MersenneTwister19937, Random } from 'random-js';
 import type { NonEmptyArray } from 'ts-essentials';
@@ -117,15 +118,35 @@ export async function scheduleTimeSlots(
   const periodDuration = dayjs.duration(1, schedule.period);
   const periodMs = dayjs.duration(1, schedule.period).asMilliseconds();
 
+  // A slot's startTime is an offset into the period, but nothing enforces that:
+  // the editor can emit a daily slot that still carries a day multiplier. The
+  // cursor below is already reduced mod the period, so an unreduced slot never
+  // satisfies `slot.startTime <= currOffset` -- the schedule either throws
+  // outright or collapses into a single multi-period flex block. Reduce here so
+  // schedules already stored with such a value keep working.
+  const normalizeStartTime = (startTime: number) =>
+    ((startTime % periodMs) + periodMs) % periodMs;
+
+  // Normalizing can land two slots on the same offset (05:50 and 29:50 both
+  // become 05:50). Equal startTimes give the earlier one a zero-width window
+  // below, so it would air nothing and which of the two died would depend on
+  // array order. Collapse them here instead, keeping the first -- the same rule
+  // the editor uses when converting a weekly schedule to a daily one -- so what
+  // airs matches what the editor shows.
+  const normalizedSlots = uniqBy(
+    map(schedule.slots, (slot) => ({
+      ...slot,
+      startTime: normalizeStartTime(slot.startTime),
+    })),
+    (slot) => slot.startTime,
+  );
+
   const seenLinkGroups = new Set<string>();
   const sortedSlots = map(
-    sortBy(schedule.slots, (slot) => slot.startTime),
+    sortBy(normalizedSlots, (slot) => slot.startTime),
     (slot) =>
       new TimeSlotImpl(
-        {
-          ...slot,
-          startTime: slot.startTime,
-        },
+        slot,
         ('id' in slot ? slotIterators.get(slot.id) : undefined) ??
           createSlotProgramIterator(slot, programMap, random),
         random,


### PR DESCRIPTION
## Problem

A time slot's `startTime` is an offset into the schedule period, but nothing enforces it.
One user reported a daily schedule containing a slot at `107400000` — 29h 50m.

`TimeSlotService` reduces its **cursor** modulo the period but never the **slot**:

```ts
const currOffset = totalOffsetMs % periodMs;   // :183
...
if (slot.startTime <= currOffset && currOffset < endTime)   // :210
```

`currOffset` is bounded to `[0, periodMs)` while `slot.startTime` is not, so such a slot
matches no cursor position at all. That asymmetry is the bug.

Measured with the reporter's settings — 5-minute pad, 10-minute lateness:

| Schedule generated at | Result |
|---|---|
| 00:00 – 05:45 | throws `Could not find a suitable slot` — **70 of 288 five-minute marks, 24% of the day** |
| 05:50 – 23:55 | 1 lineup item: a single 48–72 hour flex block, so the channel plays nothing |

A control slot inside the period never throws at any of the 288 start times and produces
32 items with a longest block of 1.5h.

## Fix

Normalize the offset into the period when building the slot list, so schedules already
stored with such a value start working again instead of needing a manual edit.

Normalizing can land two slots on the same offset, which turned out to matter. Equal
`startTime`s give the earlier slot a zero-width window — its `endTime` is the next slot's
identical `startTime` — so it airs nothing, and which of the two died depended on array
order:

| Slots, in array order | Without collision handling |
|---|---|
| A@05:50, B@29:50 | A silently dropped |
| B@29:50, A@05:50 | B silently dropped |

So collisions collapse explicitly, keeping the first — the rule the editor already applies
in `TimeSlotEditorPage.tsx:241-252` when converting a weekly schedule to a daily one. Had
the server kept the last instead, what airs would not match what the editor shows.

## Test plan

- [x] A slot at `t` and one at `t + period` schedule **identically** — previously 33 items or 1
- [x] No throw when generated before the slot's offset
- [x] Real programming rather than one long flex block
- [x] A collided pair produces the same lineup as the surviving slot alone
- [x] Existing scheduling suite unaffected — 124 tests green

The companion input validation is deliberately a separate PR, since it rejects requests the
API currently accepts and may want its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
