### PR TITLE
fix(api): validate time slot schedules before handing them to the scheduler

### DIFF
--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -19,7 +19,7 @@ import {
   PagedResult,
   RandomSlotScheduleSchema,
   SlotScheduleWithPrograms,
-  TimeSlotScheduleSchema,
+  StrictTimeSlotScheduleSchema,
   TimeSlotScheduleWithPrograms,
   UpdateChannelProgrammingRequestSchema,
 } from '@tunarr/types/api';
@@ -739,7 +739,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
           channelId: z.string(),
         }),
         body: z.object({
-          schedule: TimeSlotScheduleSchema,
+          schedule: StrictTimeSlotScheduleSchema,
         }),
         response: {
           200: TimeSlotScheduleWithPrograms,

--- a/server/src/types/timeSlotScheduleValidation.test.ts
+++ b/server/src/types/timeSlotScheduleValidation.test.ts
@@ -1,0 +1,87 @@
+import {
+  StrictTimeSlotScheduleSchema,
+  TimeSlotScheduleSchema,
+  type TimeSlotSchedule,
+} from '@tunarr/types/api';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, test } from 'vitest';
+
+const slot = (startTime: number) => ({
+  id: randomUUID(),
+  startTime,
+  type: 'movie' as const,
+  order: 'next' as const,
+  direction: 'asc' as const,
+});
+
+const valid: TimeSlotSchedule = {
+  type: 'time',
+  flexPreference: 'distribute',
+  latenessMs: 10 * 60 * 1000,
+  maxDays: 1,
+  padMs: 5 * 60 * 1000,
+  period: 'day',
+  timeZoneOffset: 0,
+  slots: [slot(21_000_000)],
+};
+
+// Each of these makes the scheduler misbehave rather than fail.
+const rejected: [string, TimeSlotSchedule][] = [
+  ['startTime beyond the period', { ...valid, slots: [slot(107_400_000)] }],
+  ['startTime exactly one period', { ...valid, slots: [slot(86_400_000)] }],
+  [
+    'fractional startTime (hangs the scheduler)',
+    { ...valid, slots: [slot(1234.567)] },
+  ],
+  ['negative startTime', { ...valid, slots: [slot(-3_600_000)] }],
+  ['padMs of zero (NaN durations)', { ...valid, padMs: 0 }],
+  ['negative padMs', { ...valid, padMs: -1000 }],
+  ['maxDays of zero', { ...valid, maxDays: 0 }],
+  ['negative maxDays (empty schedule)', { ...valid, maxDays: -1 }],
+  ['negative latenessMs', { ...valid, latenessMs: -1 }],
+  ['no slots at all', { ...valid, slots: [] }],
+];
+
+describe('StrictTimeSlotScheduleSchema', () => {
+  test('accepts a well-formed schedule', () => {
+    expect(StrictTimeSlotScheduleSchema.safeParse(valid).success).toBe(true);
+  });
+
+  test('accepts the last representable offset in the period', () => {
+    const edge = { ...valid, slots: [slot(86_399_999)] };
+    expect(StrictTimeSlotScheduleSchema.safeParse(edge).success).toBe(true);
+  });
+
+  test('accepts a weekly schedule using the wider period', () => {
+    const weekly = {
+      ...valid,
+      period: 'week' as const,
+      slots: [slot(107_400_000)],
+    };
+    expect(StrictTimeSlotScheduleSchema.safeParse(weekly).success).toBe(true);
+  });
+
+  test.each(rejected)('rejects %s', (_label, schedule) => {
+    expect(StrictTimeSlotScheduleSchema.safeParse(schedule).success).toBe(
+      false,
+    );
+  });
+
+  test('rejects a NaN startTime', () => {
+    const nan = { ...valid, slots: [slot(Number.NaN)] };
+    expect(StrictTimeSlotScheduleSchema.safeParse(nan).success).toBe(false);
+    // z.number() already excludes NaN, so this one never reached the scheduler.
+    expect(TimeSlotScheduleSchema.safeParse(nan).success).toBe(false);
+  });
+
+  // These are the states the permissive schema lets through today, and it must
+  // keep letting them through: it also parses lineups already on disk and
+  // serializes channel responses, so tightening it would make a channel holding
+  // one of these values fail to load.
+  test.each(rejected)(
+    'permissive schema still accepts %s',
+    (_label, schedule) => {
+      expect(TimeSlotScheduleSchema.safeParse(schedule).success).toBe(true);
+    },
+  );
+});

--- a/types/src/api/TimeSlots.ts
+++ b/types/src/api/TimeSlots.ts
@@ -166,3 +166,53 @@ export const TimeSlotScheduleSchema = z.object({
 });
 
 export type TimeSlotSchedule = z.infer<typeof TimeSlotScheduleSchema>;
+
+const OneDayMs = 24 * 60 * 60 * 1000;
+const OneWeekMs = 7 * OneDayMs;
+
+/**
+ * Request-body variant of {@link TimeSlotScheduleSchema}.
+ *
+ * The permissive schema above also parses lineups already on disk and is used
+ * to serialize channel responses, so it cannot be tightened: a channel holding
+ * a value written by an older build would stop loading entirely. Validate
+ * incoming schedules with this instead.
+ *
+ * Every bound here corresponds to a state the scheduler mishandles rather than
+ * rejects: a fractional `startTime` spins it in a loop that no timeout can
+ * interrupt, `padMs` of zero yields a lineup of NaN durations, a non-positive
+ * `maxDays` returns an empty schedule, and a `startTime` at or beyond the
+ * period matches no cursor position, so the schedule either throws or collapses
+ * into one flex block.
+ */
+export const StrictTimeSlotScheduleSchema = TimeSlotScheduleSchema.extend({
+  latenessMs: z.number().int().nonnegative(),
+  maxDays: z.number().int().positive(),
+  padMs: z.number().int().positive(),
+  slots: z.array(TimeSlotSchema).min(1),
+}).superRefine((schedule, ctx) => {
+  const periodMs = schedule.period === 'week' ? OneWeekMs : OneDayMs;
+
+  schedule.slots.forEach((slot, index) => {
+    if (!Number.isInteger(slot.startTime)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['slots', index, 'startTime'],
+        message: `startTime must be a whole number of milliseconds, got ${slot.startTime}`,
+      });
+      return;
+    }
+
+    if (slot.startTime < 0 || slot.startTime >= periodMs) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['slots', index, 'startTime'],
+        message: `startTime must be an offset within the ${schedule.period} period (0 to ${periodMs - 1} ms), got ${slot.startTime}`,
+      });
+    }
+  });
+});
+
+export type StrictTimeSlotSchedule = z.infer<
+  typeof StrictTimeSlotScheduleSchema
+>;


### PR DESCRIPTION
## Problem

Every numeric field on `TimeSlotScheduleSchema` is a bare `z.number()`, and `slots` has no
minimum length. Several inputs therefore reach the scheduler, which mishandles rather than
rejects them. Each row below was reproduced:

| Input | Scheduler behaviour |
|---|---|
| `startTime: 1234.567` | **infinite loop — the worker thread hangs permanently** |
| `padMs: 0` | reports success, returns a lineup whose durations are all `NaN` |
| `maxDays: -1` | reports success, returns **zero** lineup items |
| `maxDays: 0` | returns 16 items where 32 are expected |
| `slots: []` | throws `Could not find a suitable slot` — the same message an out-of-period offset produces, so the log can't tell them apart |

The first is the serious one. The scheduling loop is **synchronous** despite the enclosing
`async`, so it blocks the event loop outright: vitest's own 15-second test timeout never
fired and the process had to be killed at 60 seconds. The worker pool's `timeoutPromise`
rejects the caller's promise after 60s while the thread keeps burning a core forever, so N
such requests permanently exhaust an N-worker pool.

## Fix

Add `StrictTimeSlotScheduleSchema` and use it for the request body at `channelsApi.ts:743`.

**`TimeSlotScheduleSchema` itself is deliberately left permissive.** It feeds
`LineupScheduleSchema` inside `CondensedChannelProgrammingSchema`, which is both persisted
and used to serialize channel responses — so tightening it would make a channel already
holding one of these values fail response serialization and stop loading entirely, which is
worse than the bug. This is the same split already used for `StrictChannelIconSchema` and
`ChannelIconSchema`.

Bounds: `startTime` a whole number within the period (via `superRefine`, since the valid
range depends on `period`), `padMs` and `maxDays` positive, `latenessMs` non-negative, at
least one slot.

## Note for review

This **rejects requests the API currently accepts**. That should only affect payloads that
already produce a broken schedule, but it is a behaviour change at the boundary and is the
reason this is split from the scheduler fix in #2012, which stands on its own.

## Test plan

- [x] Accepts a well-formed schedule, the last representable offset in the period, and a weekly schedule using the wider period
- [x] Rejects all ten malformed cases above
- [x] **The permissive schema still accepts every rejected case** — asserted, so the distinction can't be erased later and existing channels keep loading
- [x] `NaN` was already excluded by `z.number()`; recorded as such rather than claimed as a fix
- [x] 24 tests, typecheck 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
