### PR TITLE
fix(web): stop the slot editor producing offsets outside the schedule period

### DIFF
--- a/web/src/components/slot_scheduler/AddTimeSlotButton.tsx
+++ b/web/src/components/slot_scheduler/AddTimeSlotButton.tsx
@@ -12,12 +12,14 @@ import type {
 import { Trans } from '@lingui/react/macro';
 import AddIcon from '@mui/icons-material/Add';
 import { Button } from '@mui/material';
-import dayjs from 'dayjs';
-import { groupBy, isEmpty, maxBy, sortBy } from 'lodash-es';
+import { groupBy, isEmpty, sortBy } from 'lodash-es';
 import { useCallback, useMemo } from 'react';
 import type { Dictionary } from 'ts-essentials';
 import { v4 } from 'uuid';
-import { OneDayMillis } from '../../helpers/constants.ts';
+import {
+  nextSlotStartTime,
+  slotsForDayColumn,
+} from '../../helpers/slotSchedulerUtil.ts';
 
 export const AddTimeSlotButton = ({
   onAdd,
@@ -30,16 +32,10 @@ export const AddTimeSlotButton = ({
   } = useTimeSlotFormContext();
   const currentPeriod = watch('period');
 
-  const relevantSlots = useMemo(() => {
-    return slots.filter((slot) => {
-      if (currentPeriod !== 'week') {
-        return true;
-      }
-      const start = OneDayMillis * dayOffset;
-      const end = start + OneDayMillis;
-      return slot.startTime >= start && slot.startTime < end;
-    });
-  }, [currentPeriod, dayOffset, slots]);
+  const relevantSlots = useMemo(
+    () => slotsForDayColumn(slots, currentPeriod, dayOffset),
+    [currentPeriod, dayOffset, slots],
+  );
 
   const optionsByType = useMemo(() => {
     return groupBy(programOptions, (opt) => opt.type) as Dictionary<
@@ -49,15 +45,14 @@ export const AddTimeSlotButton = ({
   }, [programOptions]);
 
   const addSlot = useCallback(() => {
-    const maxSlot = maxBy(relevantSlots, (p) => p.startTime);
-    const newStartTime = maxSlot
-      ? dayjs.duration(maxSlot.startTime).add(1, 'hour')
-      : currentPeriod === 'week'
-        ? dayjs.duration(OneDayMillis * dayOffset)
-        : dayjs.duration(0);
+    const newStartTime = nextSlotStartTime(
+      relevantSlots.map((slot) => slot.startTime),
+      currentPeriod,
+      dayOffset,
+    );
 
     const baseSlot = {
-      startTime: +newStartTime,
+      startTime: newStartTime,
       direction: 'asc' as const,
       order: 'next' as const,
     } as const;

--- a/web/src/components/slot_scheduler/EditTimeSlotDialogContent.tsx
+++ b/web/src/components/slot_scheduler/EditTimeSlotDialogContent.tsx
@@ -2,7 +2,11 @@ import type {
   CustomShowProgramOption,
   FillerProgramOption,
 } from '@/helpers/slotSchedulerUtil';
-import { OneDayMillis } from '@/helpers/slotSchedulerUtil';
+import {
+  slotDayOfWeek,
+  withSlotDayOfWeek,
+  withSlotTimeOfDay,
+} from '@/helpers/slotSchedulerUtil';
 import type { TimeSlotViewModel } from '@/model/TimeSlotModels.ts';
 import { Trans, useLingui } from '@lingui/react/macro';
 import {
@@ -144,9 +148,7 @@ export const EditTimeSlotDialogContent = ({
 
   const updateSlotDay = useCallback(
     (newDayOfWeek: number, originalOnChange: (...args: unknown[]) => void) => {
-      const startTimeOfDay = getValues('startTime') % OneDayMillis;
-      const newStartTime = startTimeOfDay + newDayOfWeek * OneDayMillis;
-      originalOnChange(newStartTime);
+      originalOnChange(withSlotDayOfWeek(getValues('startTime'), newDayOfWeek));
     },
     [getValues],
   );
@@ -157,11 +159,13 @@ export const EditTimeSlotDialogContent = ({
       originalOnChange: (...args: unknown[]) => void,
     ) => {
       if (!fieldValue) return;
-      const h = fieldValue.hour();
-      const m = fieldValue.minute();
-      const multiplier = Math.floor(getValues('startTime') / OneDayMillis);
-      const millis = dayjs.duration({ hours: h, minutes: m }).asMilliseconds();
-      originalOnChange(millis + multiplier * OneDayMillis);
+      originalOnChange(
+        withSlotTimeOfDay(
+          getValues('startTime'),
+          fieldValue.hour(),
+          fieldValue.minute(),
+        ),
+      );
     },
     [getValues],
   );
@@ -337,7 +341,7 @@ export const EditTimeSlotDialogContent = ({
                           <Select
                             {...field}
                             fullWidth
-                            value={Math.floor(field.value / OneDayMillis)}
+                            value={slotDayOfWeek(field.value)}
                             label={t`Day`}
                             onChange={(e) =>
                               updateSlotDay(

--- a/web/src/components/slot_scheduler/EditTimeSlotDialogContent.tsx
+++ b/web/src/components/slot_scheduler/EditTimeSlotDialogContent.tsx
@@ -164,10 +164,11 @@ export const EditTimeSlotDialogContent = ({
           getValues('startTime'),
           fieldValue.hour(),
           fieldValue.minute(),
+          currentPeriod,
         ),
       );
     },
-    [getValues],
+    [getValues, currentPeriod],
   );
 
   const slotType = formMethods.watch('type');

--- a/web/src/helpers/slotSchedulerUtil.test.ts
+++ b/web/src/helpers/slotSchedulerUtil.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+import {
+  nextSlotStartTime,
+  OneDayMillis,
+  slotDayOfWeek,
+  slotPeriodMillis,
+  slotsForDayColumn,
+  withSlotDayOfWeek,
+  withSlotTimeOfDay,
+} from './slotSchedulerUtil';
+
+const HOUR = 60 * 60 * 1000;
+const at = (startTime: number) => ({ startTime });
+
+describe('slotPeriodMillis', () => {
+  test('a day is 24 hours, a week is seven of them', () => {
+    expect(slotPeriodMillis('day')).toBe(OneDayMillis);
+    expect(slotPeriodMillis('week')).toBe(7 * OneDayMillis);
+  });
+});
+
+describe('slotsForDayColumn', () => {
+  test('a daily schedule has one column, so every slot is relevant', () => {
+    const slots = [at(0), at(5 * HOUR), at(23 * HOUR)];
+    expect(slotsForDayColumn(slots, 'day', 0)).toEqual(slots);
+  });
+
+  test('a weekly schedule keeps only the slots inside the requested day', () => {
+    const slots = [at(0), at(OneDayMillis + HOUR), at(2 * OneDayMillis)];
+    expect(slotsForDayColumn(slots, 'week', 1)).toEqual([
+      at(OneDayMillis + HOUR),
+    ]);
+  });
+
+  test('a weekly day with no slots yields nothing', () => {
+    expect(slotsForDayColumn([at(0)], 'week', 3)).toEqual([]);
+  });
+});
+
+describe('slotDayOfWeek', () => {
+  test('reads the day a weekly offset encodes', () => {
+    expect(slotDayOfWeek(0)).toBe(0);
+    expect(slotDayOfWeek(23 * HOUR)).toBe(0);
+    expect(slotDayOfWeek(OneDayMillis)).toBe(1);
+    expect(slotDayOfWeek(3 * OneDayMillis + 5 * HOUR)).toBe(3);
+  });
+});
+
+describe('withSlotDayOfWeek', () => {
+  test('moves a slot between days and keeps its time', () => {
+    const wednesdayAt6 = 3 * OneDayMillis + 6 * HOUR;
+    expect(withSlotDayOfWeek(wednesdayAt6, 5)).toBe(
+      5 * OneDayMillis + 6 * HOUR,
+    );
+  });
+
+  test('day zero strips the day entirely', () => {
+    expect(withSlotDayOfWeek(4 * OneDayMillis + 2 * HOUR, 0)).toBe(2 * HOUR);
+  });
+});
+
+describe('withSlotTimeOfDay', () => {
+  test('sets the time of day on a same-day slot', () => {
+    expect(withSlotTimeOfDay(0, 5, 50)).toBe(5 * HOUR + 50 * 60 * 1000);
+  });
+
+  test('keeps the day a weekly offset encodes', () => {
+    const tuesday = 2 * OneDayMillis;
+    expect(withSlotTimeOfDay(tuesday, 9, 0)).toBe(2 * OneDayMillis + 9 * HOUR);
+  });
+});
+
+describe('nextSlotStartTime', () => {
+  test('an empty daily schedule starts at midnight', () => {
+    expect(nextSlotStartTime([], 'day', 0)).toBe(0);
+  });
+
+  test('an empty weekly column starts at the top of its day', () => {
+    expect(nextSlotStartTime([], 'week', 4)).toBe(4 * OneDayMillis);
+  });
+
+  test('otherwise it is an hour after the latest slot', () => {
+    expect(nextSlotStartTime([0, 2 * HOUR, HOUR], 'day', 0)).toBe(3 * HOUR);
+  });
+});

--- a/web/src/helpers/slotSchedulerUtil.test.ts
+++ b/web/src/helpers/slotSchedulerUtil.test.ts
@@ -61,12 +61,14 @@ describe('withSlotDayOfWeek', () => {
 
 describe('withSlotTimeOfDay', () => {
   test('sets the time of day on a same-day slot', () => {
-    expect(withSlotTimeOfDay(0, 5, 50)).toBe(5 * HOUR + 50 * 60 * 1000);
+    expect(withSlotTimeOfDay(0, 5, 50, 'day')).toBe(5 * HOUR + 50 * 60 * 1000);
   });
 
   test('keeps the day a weekly offset encodes', () => {
     const tuesday = 2 * OneDayMillis;
-    expect(withSlotTimeOfDay(tuesday, 9, 0)).toBe(2 * OneDayMillis + 9 * HOUR);
+    expect(withSlotTimeOfDay(tuesday, 9, 0, 'week')).toBe(
+      2 * OneDayMillis + 9 * HOUR,
+    );
   });
 });
 
@@ -81,5 +83,37 @@ describe('nextSlotStartTime', () => {
 
   test('otherwise it is an hour after the latest slot', () => {
     expect(nextSlotStartTime([0, 2 * HOUR, HOUR], 'day', 0)).toBe(3 * HOUR);
+  });
+});
+
+// The two defects that produced a daily slot at 29h50m in the field.
+describe('offsets stay inside the schedule period', () => {
+  test('adding past the end of a day wraps instead of running on', () => {
+    expect(nextSlotStartTime([23 * HOUR], 'day', 0)).toBe(0);
+  });
+
+  test('repeatedly adding to a daily schedule never leaves the day', () => {
+    const starts: number[] = [];
+    for (let i = 0; i < 30; i++) {
+      starts.push(nextSlotStartTime(starts, 'day', 0));
+    }
+    expect(Math.max(...starts)).toBeLessThan(OneDayMillis);
+  });
+
+  test('adding past the end of a week wraps too', () => {
+    expect(nextSlotStartTime([7 * OneDayMillis - HOUR], 'week', 6)).toBe(0);
+  });
+
+  test('a daily schedule has no day component to preserve', () => {
+    // 24h with the time set to 05:50 is how 107400000 was produced.
+    expect(withSlotTimeOfDay(OneDayMillis, 5, 50, 'day')).toBe(
+      5 * HOUR + 50 * 60 * 1000,
+    );
+  });
+
+  test('a weekly schedule still keeps its day', () => {
+    expect(withSlotTimeOfDay(2 * OneDayMillis, 9, 0, 'week')).toBe(
+      2 * OneDayMillis + 9 * HOUR,
+    );
   });
 });

--- a/web/src/helpers/slotSchedulerUtil.ts
+++ b/web/src/helpers/slotSchedulerUtil.ts
@@ -152,6 +152,74 @@ export const slotOptionIsScheduled = (
 export const OneDayMillis = dayjs.duration(1, 'day').asMilliseconds();
 export const OneWeekMillis = dayjs.duration(1, 'week').asMilliseconds();
 
+const OneHourMillis = dayjs.duration(1, 'hour').asMilliseconds();
+
+export type SlotPeriod = 'day' | 'week';
+
+/** Milliseconds spanned by one repetition of a schedule. */
+export function slotPeriodMillis(period: SlotPeriod): number {
+  return period === 'week' ? OneWeekMillis : OneDayMillis;
+}
+
+/**
+ * The slots an "add slot" control should consider. A weekly schedule shows one
+ * column per day and only the slots in that column are relevant; a daily
+ * schedule has a single column, so every slot is.
+ */
+export function slotsForDayColumn<T extends { startTime: number }>(
+  slots: readonly T[],
+  period: SlotPeriod,
+  dayOffset: number,
+): readonly T[] {
+  if (period !== 'week') {
+    return slots;
+  }
+  const start = OneDayMillis * dayOffset;
+  const end = start + OneDayMillis;
+  return slots.filter(
+    (slot) => slot.startTime >= start && slot.startTime < end,
+  );
+}
+
+/**
+ * Offset for a newly added slot: an hour after the latest one already present,
+ * or the start of the column when there are none.
+ */
+export function nextSlotStartTime(
+  existingStartTimes: readonly number[],
+  period: SlotPeriod,
+  dayOffset: number,
+): number {
+  if (existingStartTimes.length > 0) {
+    return Math.max(...existingStartTimes) + OneHourMillis;
+  }
+  return period === 'week' ? OneDayMillis * dayOffset : 0;
+}
+
+/** The day index a weekly slot offset encodes. */
+export function slotDayOfWeek(startTime: number): number {
+  return Math.floor(startTime / OneDayMillis);
+}
+
+/** Move a slot to another day of the week, keeping its time of day. */
+export function withSlotDayOfWeek(
+  startTime: number,
+  dayOfWeek: number,
+): number {
+  return (startTime % OneDayMillis) + dayOfWeek * OneDayMillis;
+}
+
+/** Set a slot's time of day, keeping the day a weekly offset encodes. */
+export function withSlotTimeOfDay(
+  startTime: number,
+  hours: number,
+  minutes: number,
+): number {
+  const dayOfWeek = slotDayOfWeek(startTime);
+  const timeOfDay = dayjs.duration({ hours, minutes }).asMilliseconds();
+  return timeOfDay + dayOfWeek * OneDayMillis;
+}
+
 type SlotTypeWithOrdering = StrictExclude<
   BaseSlot['type'],
   'redirect' | 'flex'

--- a/web/src/helpers/slotSchedulerUtil.ts
+++ b/web/src/helpers/slotSchedulerUtil.ts
@@ -191,7 +191,14 @@ export function nextSlotStartTime(
   dayOffset: number,
 ): number {
   if (existingStartTimes.length > 0) {
-    return Math.max(...existingStartTimes) + OneHourMillis;
+    // Wrap rather than run past the end of the period. Building an hourly day
+    // takes 24 additions, and the 25th used to land on exactly 24h -- an offset
+    // the scheduler cannot match, which either throws or collapses the channel
+    // into a single flex block.
+    return (
+      (Math.max(...existingStartTimes) + OneHourMillis) %
+      slotPeriodMillis(period)
+    );
   }
   return period === 'week' ? OneDayMillis * dayOffset : 0;
 }
@@ -209,13 +216,21 @@ export function withSlotDayOfWeek(
   return (startTime % OneDayMillis) + dayOfWeek * OneDayMillis;
 }
 
-/** Set a slot's time of day, keeping the day a weekly offset encodes. */
+/**
+ * Set a slot's time of day, keeping the day a weekly offset encodes.
+ *
+ * Only a weekly schedule has a day to keep. Carrying one over in a daily
+ * schedule is how a slot ends up at an offset outside its own period, and the
+ * editor hides the day control in that mode, so nothing on screen would show
+ * what happened.
+ */
 export function withSlotTimeOfDay(
   startTime: number,
   hours: number,
   minutes: number,
+  period: SlotPeriod,
 ): number {
-  const dayOfWeek = slotDayOfWeek(startTime);
+  const dayOfWeek = period === 'week' ? slotDayOfWeek(startTime) : 0;
   const timeOfDay = dayjs.duration({ hours, minutes }).asMilliseconds();
   return timeOfDay + dayOfWeek * OneDayMillis;
 }

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -415,7 +415,7 @@ msgid "Add Show"
 msgstr "Add Show"
 
 #: src/components/slot_scheduler/AddRandomSlotButton.tsx:142
-#: src/components/slot_scheduler/AddTimeSlotButton.tsx:136
+#: src/components/slot_scheduler/AddTimeSlotButton.tsx:131
 msgid "Add Slot"
 msgstr "Add Slot"
 
@@ -792,7 +792,7 @@ msgstr "Calculating Slots..."
 #: src/components/settings/media_source/PlexServerEditDialog.tsx:353
 #: src/components/settings/UnsavedNavigationAlert.tsx:67
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:576
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:408
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:413
 #: src/components/slot_scheduler/RandomSlotsWeightAdjustDialog.tsx:156
 #: src/components/slot_scheduler/SlotLinkingControl.tsx:313
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
@@ -963,7 +963,7 @@ msgstr "Component"
 msgid "Condition"
 msgstr "Condition"
 
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:323
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:328
 msgid "Config"
 msgstr "Config"
 
@@ -1168,8 +1168,8 @@ msgid "Data Directory:"
 msgstr "Data Directory:"
 
 #: src/components/channel_config/ChannelProgrammingConfig.tsx:180
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:332
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:341
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:337
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:346
 msgid "Day"
 msgstr "Day"
 
@@ -1844,7 +1844,7 @@ msgid "Fill with Flex"
 msgstr "Fill with Flex"
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:401
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:319
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:46
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:293
 #: src/components/slot_scheduler/TimeSlotTable.tsx:299
@@ -2491,7 +2491,7 @@ msgid "Message"
 msgstr "Message"
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:402
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:329
 msgid "Mid-Roll"
 msgstr "Mid-Roll"
 
@@ -2984,7 +2984,7 @@ msgstr "Program Playback Troubleshooter"
 #: src/components/custom-shows/EditCustomShowForm.tsx:420
 #: src/components/filler/EditFillerListForm.tsx:152
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:400
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:317
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:322
 #: src/hooks/useRouteName.ts:79
 msgid "Programming"
 msgstr "Programming"
@@ -3334,7 +3334,7 @@ msgstr "Sample rate cannot be changed when copying input audio"
 #: src/components/programming_controls/AdjustWeightsModal.tsx:36
 #: src/components/settings/general/GeneralSettingsForm.tsx:496
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:583
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:415
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:420
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:311
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:196
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:121
@@ -3666,7 +3666,7 @@ msgid "Start"
 msgstr "Start"
 
 #: src/components/programming_controls/AddRestrictHoursModal.tsx:112
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:373
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:378
 #: src/components/slot_scheduler/TimeSlotTable.tsx:261
 msgid "Start Time"
 msgstr "Start Time"

--- a/web/src/locales/es/messages.po
+++ b/web/src/locales/es/messages.po
@@ -415,7 +415,7 @@ msgid "Add Show"
 msgstr ""
 
 #: src/components/slot_scheduler/AddRandomSlotButton.tsx:142
-#: src/components/slot_scheduler/AddTimeSlotButton.tsx:136
+#: src/components/slot_scheduler/AddTimeSlotButton.tsx:131
 msgid "Add Slot"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 #: src/components/settings/media_source/PlexServerEditDialog.tsx:353
 #: src/components/settings/UnsavedNavigationAlert.tsx:67
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:576
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:408
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:413
 #: src/components/slot_scheduler/RandomSlotsWeightAdjustDialog.tsx:156
 #: src/components/slot_scheduler/SlotLinkingControl.tsx:313
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
@@ -963,7 +963,7 @@ msgstr ""
 msgid "Condition"
 msgstr ""
 
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:323
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:328
 msgid "Config"
 msgstr ""
 
@@ -1168,8 +1168,8 @@ msgid "Data Directory:"
 msgstr ""
 
 #: src/components/channel_config/ChannelProgrammingConfig.tsx:180
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:332
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:341
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:337
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:346
 msgid "Day"
 msgstr ""
 
@@ -1844,7 +1844,7 @@ msgid "Fill with Flex"
 msgstr ""
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:401
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:319
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:46
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:293
 #: src/components/slot_scheduler/TimeSlotTable.tsx:299
@@ -2491,7 +2491,7 @@ msgid "Message"
 msgstr ""
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:402
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:329
 msgid "Mid-Roll"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 #: src/components/custom-shows/EditCustomShowForm.tsx:420
 #: src/components/filler/EditFillerListForm.tsx:152
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:400
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:317
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:322
 #: src/hooks/useRouteName.ts:79
 msgid "Programming"
 msgstr ""
@@ -3332,7 +3332,7 @@ msgstr ""
 #: src/components/programming_controls/AdjustWeightsModal.tsx:36
 #: src/components/settings/general/GeneralSettingsForm.tsx:496
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:583
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:415
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:420
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:311
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:196
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:121
@@ -3664,7 +3664,7 @@ msgid "Start"
 msgstr ""
 
 #: src/components/programming_controls/AddRestrictHoursModal.tsx:112
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:373
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:378
 #: src/components/slot_scheduler/TimeSlotTable.tsx:261
 msgid "Start Time"
 msgstr ""

--- a/web/src/locales/pseudo-LOCALE/messages.po
+++ b/web/src/locales/pseudo-LOCALE/messages.po
@@ -415,7 +415,7 @@ msgid "Add Show"
 msgstr ""
 
 #: src/components/slot_scheduler/AddRandomSlotButton.tsx:142
-#: src/components/slot_scheduler/AddTimeSlotButton.tsx:136
+#: src/components/slot_scheduler/AddTimeSlotButton.tsx:131
 msgid "Add Slot"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 #: src/components/settings/media_source/PlexServerEditDialog.tsx:353
 #: src/components/settings/UnsavedNavigationAlert.tsx:67
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:576
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:408
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:413
 #: src/components/slot_scheduler/RandomSlotsWeightAdjustDialog.tsx:156
 #: src/components/slot_scheduler/SlotLinkingControl.tsx:313
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
@@ -963,7 +963,7 @@ msgstr ""
 msgid "Condition"
 msgstr ""
 
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:323
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:328
 msgid "Config"
 msgstr ""
 
@@ -1168,8 +1168,8 @@ msgid "Data Directory:"
 msgstr ""
 
 #: src/components/channel_config/ChannelProgrammingConfig.tsx:180
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:332
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:341
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:337
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:346
 msgid "Day"
 msgstr ""
 
@@ -1844,7 +1844,7 @@ msgid "Fill with Flex"
 msgstr ""
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:401
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:319
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:46
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:293
 #: src/components/slot_scheduler/TimeSlotTable.tsx:299
@@ -2491,7 +2491,7 @@ msgid "Message"
 msgstr ""
 
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:402
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:324
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:329
 msgid "Mid-Roll"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 #: src/components/custom-shows/EditCustomShowForm.tsx:420
 #: src/components/filler/EditFillerListForm.tsx:152
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:400
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:317
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:322
 #: src/hooks/useRouteName.ts:79
 msgid "Programming"
 msgstr ""
@@ -3332,7 +3332,7 @@ msgstr ""
 #: src/components/programming_controls/AdjustWeightsModal.tsx:36
 #: src/components/settings/general/GeneralSettingsForm.tsx:496
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:583
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:415
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:420
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:311
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:196
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:121
@@ -3664,7 +3664,7 @@ msgid "Start"
 msgstr ""
 
 #: src/components/programming_controls/AddRestrictHoursModal.tsx:112
-#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:373
+#: src/components/slot_scheduler/EditTimeSlotDialogContent.tsx:378
 #: src/components/slot_scheduler/TimeSlotTable.tsx:261
 msgid "Start Time"
 msgstr ""


### PR DESCRIPTION
## Problem

This is the client-side half of #2012 — how a daily slot ends up at an offset outside its
own period. Two controls combine, using only ordinary interactions.

**1. “Add slot” has no wraparound.** `AddTimeSlotButton.tsx` placed each new slot an hour
after the latest one, and in a daily schedule the day-column filter matches *every* slot
(`if (currentPeriod !== 'week') return true`), so it walked the global maximum upward
without limit. Building an hourly day takes 24 additions; **the 25th landed on exactly 24h**.
That is the ordinary way to build an hourly schedule, not an exotic sequence.

**2. The time picker preserved the day multiplier.** `EditTimeSlotDialogContent.tsx`:

```ts
const multiplier = Math.floor(getValues('startTime') / OneDayMillis);
originalOnChange(millis + multiplier * OneDayMillis);
```

Applied unconditionally, though only a weekly schedule has a day to preserve. Setting that
24h slot to 5:50 AM yields `21000000 + 86400000` = **107400000** — exactly the reported value.

**And it was invisible.** The Day dropdown renders only when `currentPeriod === 'week'`, so
in a daily schedule the slot displayed as an ordinary “5:50 AM” with nothing indicating the
extra day and no way to clear it.

## Two commits

**`refactor` — lift the arithmetic out of the components.** Both expressions lived inside
component closures and couldn't be tested without mounting the component and driving a form,
so neither was. They move to `slotSchedulerUtil`, which already owns the period constants, as
plain functions — following the shape already used in `hooks/programming_controls`, where
five of the eleven existing web tests live. No behaviour change; 12 tests cover the
arithmetic that was already correct, so the extraction is demonstrably faithful before
anything is changed on top of it. It also collapses a small duplication: the two components
had been importing `OneDayMillis` from different modules.

**`fix` — the actual change.** `nextSlotStartTime` wraps into the period; `withSlotTimeOfDay`
takes the day from the offset only when the schedule is weekly.

Written red first, and the failures named the bug outright:

```
expected 86400000 to be +0                     ← 23:00 + 1h ran past midnight
expected 104400000 to be less than 86400000    ← 29h after 30 additions
expected 107400000 to be 21000000              ← the reported value, verbatim
```

## One deliberate consequence

Wrapping means that if a day already holds a slot at every hour, the next addition produces a
**duplicate** offset. Chosen over clamping because a duplicate is visible in the editor and
the user can change it, where the old value was neither visible nor correctable. It is also
consistent with how the editor and #2012 both collapse collisions, keeping the first.

## Test plan

- [x] 12 tests pinning the extracted arithmetic before any change
- [x] 5 tests for the fix, red before green
- [x] Repeated additions never leave the period, in daily and weekly
- [x] A 24h offset set to 05:50 gives `21000000`, not `107400000`
- [x] A weekly schedule still keeps its day
- [x] Web suite 93 green, typecheck 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
