### PR TITLE
fix(web): stop the slot warning reporting a bogus average program length

### DIFF
--- a/web/src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx
+++ b/web/src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx
@@ -25,10 +25,10 @@ import {
 import { seq } from '@tunarr/shared/util';
 import type { BaseSlot } from '@tunarr/types/api';
 import dayjs from 'dayjs';
-import { map, round, sum, uniqBy, values } from 'lodash-es';
+import { map, uniqBy, values } from 'lodash-es';
+import { averageProgramDurationMs } from '@/helpers/slots.ts';
 import type { ListChildComponentProps } from 'react-window';
 import { FixedSizeList } from 'react-window';
-import { getEpisodeShowId } from '../../helpers/programUtil.ts';
 
 type Props = {
   slot: BaseSlot & SlotTableWarnings;
@@ -82,49 +82,7 @@ export const SlotProgrammingTooLongWarningDetails = ({
     );
   };
 
-  let averageLength = dayjs.duration(0);
-
-  switch (slot.type) {
-    case 'movie': {
-      const durations = seq.collect(values(programLookup), (program) => {
-        if (program.type === 'content' && program.program.type === 'movie') {
-          return program.duration;
-        }
-        return;
-      });
-      if (durations.length === 0) {
-        averageLength = dayjs.duration(
-          round(sum(durations) / durations.length),
-        );
-      }
-      break;
-    }
-    case 'show': {
-      const showId = slot.showId;
-      const durations = seq.collect(values(programLookup), (program) => {
-        if (
-          program.type === 'content' &&
-          program.program.type === 'episode' &&
-          getEpisodeShowId(program.program) === showId
-        ) {
-          return program.duration;
-        }
-        return;
-      });
-      if (durations.length > 0) {
-        averageLength = dayjs.duration(
-          round(sum(durations) / durations.length),
-        );
-      }
-      break;
-    }
-    case 'custom-show':
-    case 'filler':
-    case 'flex':
-    case 'redirect':
-    default:
-      break;
-  }
+  const averageLengthMs = averageProgramDurationMs(slot, values(programLookup));
 
   return (
     <Accordion
@@ -140,7 +98,9 @@ export const SlotProgrammingTooLongWarningDetails = ({
             sx={{ mr: 1, color: (theme) => theme.palette.warning.main }}
           />
         )}
-        <Typography><Trans>Programs Too Long</Trans></Typography>
+        <Typography>
+          <Trans>Programs Too Long</Trans>
+        </Typography>
       </AccordionSummary>
       <AccordionDetails>
         <Stack>
@@ -158,22 +118,42 @@ export const SlotProgrammingTooLongWarningDetails = ({
           <div>
             <p>
               <Trans>
-              {warning.programs.length} of {slot.programCount}{' '}
-              {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of
-              this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}
-              ). Average program length: {averageLength.humanize()}
+                {warning.programs.length} of {slot.programCount}{' '}
+                {plural(slot.programCount, {
+                  one: 'program',
+                  other: 'programs',
+                })}{' '}
+                exceed the length of this slot (
+                {betterHumanize(dayjs.duration(slot.durationMs ?? 0))}).
               </Trans>
+              {averageLengthMs !== undefined && (
+                <>
+                  {' '}
+                  <Trans>
+                    Average program length:{' '}
+                    {betterHumanize(dayjs.duration(averageLengthMs))}
+                  </Trans>
+                </>
+              )}
               <br />
-              <Trans>This could cause the following slot's programs to go unscheduled.
-              Possible solutions include:</Trans>
+              <Trans>
+                This could cause the following slot's programs to go
+                unscheduled. Possible solutions include:
+              </Trans>
             </p>
             <ul>
               {}
               {slotType === 'time' && (
-                <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li>
+                <li>
+                  <Trans>Increasing "Max Lateness" for the schedule.</Trans>
+                </li>
               )}
-              <li><Trans>Increasing the slot duration.</Trans></li>
-              <li><Trans>Removing overrun programs from the channel.</Trans></li>
+              <li>
+                <Trans>Increasing the slot duration.</Trans>
+              </li>
+              <li>
+                <Trans>Removing overrun programs from the channel.</Trans>
+              </li>
             </ul>
           </div>
           <Box sx={{ width: '100%', height: 400 }}>

--- a/web/src/helpers/slots.test.ts
+++ b/web/src/helpers/slots.test.ts
@@ -1,0 +1,113 @@
+import type { BaseSlot } from '@tunarr/types/api';
+import { describe, expect, test } from 'vitest';
+import {
+  makeContentProgram,
+  makeEpisode,
+  makeMovie,
+  makeShowGrouping,
+} from '../test/programFixtures.ts';
+import { averageProgramDurationMs } from './slots.ts';
+
+const OneMinute = 60_000;
+
+const movieSlot: BaseSlot = {
+  type: 'movie',
+  id: 'slot-movie',
+  order: 'shuffle',
+  direction: 'asc',
+};
+
+const showSlot = (showId: string): BaseSlot => ({
+  type: 'show',
+  id: `slot-show-${showId}`,
+  showId,
+  order: 'next',
+  direction: 'asc',
+  seasonFilter: [],
+  seasonExcludeFilter: [],
+});
+
+const flexSlot: BaseSlot = { type: 'flex' };
+
+const movieProgram = (durationMs: number, uuid: string) =>
+  makeContentProgram(makeMovie({ uuid }), durationMs);
+
+const episodeProgram = (durationMs: number, uuid: string, showId: string) =>
+  makeContentProgram(
+    makeEpisode({ uuid, show: makeShowGrouping(showId) }),
+    durationMs,
+  );
+
+describe('averageProgramDurationMs', () => {
+  describe('movie slots', () => {
+    test('averages the movies in the pool', () => {
+      const programs = [
+        movieProgram(90 * OneMinute, 'a'),
+        movieProgram(110 * OneMinute, 'b'),
+      ];
+
+      expect(averageProgramDurationMs(movieSlot, programs)).toBe(
+        100 * OneMinute,
+      );
+    });
+
+    test('ignores episodes when averaging a movie slot', () => {
+      const programs = [
+        movieProgram(90 * OneMinute, 'a'),
+        episodeProgram(20 * OneMinute, 'b', 'show-1'),
+      ];
+
+      expect(averageProgramDurationMs(movieSlot, programs)).toBe(
+        90 * OneMinute,
+      );
+    });
+
+    test('returns undefined rather than NaN when there are no movies', () => {
+      expect(averageProgramDurationMs(movieSlot, [])).toBeUndefined();
+      expect(
+        averageProgramDurationMs(movieSlot, [
+          episodeProgram(20 * OneMinute, 'b', 'show-1'),
+        ]),
+      ).toBeUndefined();
+    });
+
+    test('rounds to a whole millisecond', () => {
+      const programs = [
+        movieProgram(1000, 'a'),
+        movieProgram(1001, 'b'),
+        movieProgram(1001, 'c'),
+      ];
+
+      expect(averageProgramDurationMs(movieSlot, programs)).toBe(1001);
+    });
+  });
+
+  describe('show slots', () => {
+    test('averages only the episodes of the slots own show', () => {
+      const programs = [
+        episodeProgram(20 * OneMinute, 'a', 'show-1'),
+        episodeProgram(40 * OneMinute, 'b', 'show-1'),
+        episodeProgram(90 * OneMinute, 'c', 'show-2'),
+        movieProgram(120 * OneMinute, 'd'),
+      ];
+
+      expect(averageProgramDurationMs(showSlot('show-1'), programs)).toBe(
+        30 * OneMinute,
+      );
+    });
+
+    test('returns undefined when the show has no episodes in the pool', () => {
+      expect(
+        averageProgramDurationMs(showSlot('show-3'), [
+          episodeProgram(20 * OneMinute, 'a', 'show-1'),
+        ]),
+      ).toBeUndefined();
+    });
+  });
+
+  test('returns undefined for a slot type with no fixed pool', () => {
+    expect(
+      averageProgramDurationMs(flexSlot, [movieProgram(90 * OneMinute, 'a')]),
+    ).toBeUndefined();
+  });
+});

--- a/web/src/helpers/slots.ts
+++ b/web/src/helpers/slots.ts
@@ -1,9 +1,13 @@
-import { prettifySnakeCaseString } from '@tunarr/shared/util';
+import { prettifySnakeCaseString, seq } from '@tunarr/shared/util';
 import { blue, green, orange, pink, purple } from '@mui/material/colors';
+import type { BaseSlot } from '@tunarr/types/api';
+import type { ContentProgram } from '@tunarr/types';
+import { round, sum } from 'lodash-es';
 import type {
   RandomSlotTableRowType,
   TimeSlotTableRowType,
 } from '../model/CommonSlotModels.ts';
+import { getEpisodeShowId } from './programUtil.ts';
 
 const iterationGroupColors = [
   blue[700],
@@ -35,4 +39,39 @@ export function formatSlotOrder(
     case 'smart-collection':
       return prettifySnakeCaseString(row.order);
   }
+}
+
+/**
+ * Mean duration, in milliseconds, of the programs a slot of this type would
+ * actually draw from.
+ *
+ * Returns undefined rather than 0 when there is nothing to average -- an empty
+ * pool, or a slot type with no fixed pool at all. The two are different answers
+ * and the caller has to render them differently: `dayjs.duration(0).humanize()`
+ * is "a few seconds", which reads as a real measurement rather than a missing
+ * one.
+ */
+export function averageProgramDurationMs(
+  slot: BaseSlot,
+  programs: ContentProgram[],
+): number | undefined {
+  const durations = seq.collect(programs, ({ program, duration }) => {
+    switch (slot.type) {
+      case 'movie':
+        return program.type === 'movie' ? duration : undefined;
+      case 'show':
+        return program.type === 'episode' &&
+          getEpisodeShowId(program) === slot.showId
+          ? duration
+          : undefined;
+      default:
+        return undefined;
+    }
+  });
+
+  if (durations.length === 0) {
+    return undefined;
+  }
+
+  return round(sum(durations) / durations.length);
 }

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr "{0, plural, one {Path} other {Paths}}"
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:162
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0, plural, one {program} other {programs}}"
 msgstr "{0, plural, one {program} other {programs}}"
 
@@ -110,12 +110,15 @@ msgstr "{0} Info"
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, round, sum, uniqBy, values } from 'lodash-es'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; import { getEpisodeShowId } from '../../helpers/programUtil.ts'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; let averageLength = dayjs.duration(0); switch (slot.type) { case 'movie': { const durations = seq.collect(values(programLookup), (program) => { if (program.type === 'content' && program.program.type === 'movie') { return program.duration; } return; }); if (durations.length === 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'show': { const showId = slot.showId; const durations = seq.collect(values(programLookup), (program) => { if ( program.type === 'content' && program.program.type === 'episode' && getEpisodeShowId(program.program) === showId ) { return program.duration; } return; }); if (durations.length > 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'custom-show': case 'filler': case 'flex': case 'redirect': default: break; } return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))} ). Average program length: {averageLength.humanize()} </Trans> <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#. placeholder {4}: averageLength.humanize()
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+msgid "{0} of {1} {2} exceed the length of this slot ({3})."
+msgstr "{0} of {1} {2} exceed the length of this slot ({3})."
+
 #: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:160
-msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
-msgstr "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#~ msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#~ msgstr "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
 
 #. placeholder {0}: program.title
 #: src/components/programs/MediaDetailCard.tsx:171
@@ -657,6 +660,11 @@ msgstr "Auto-Update Guide"
 #: src/components/programming_controls/AdjustWeightsModal.tsx:29
 msgid "Automatic"
 msgstr "Automatic"
+
+#. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+msgid "Average program length: {0}"
+msgstr "Average program length: {0}"
 
 #: src/pages/welcome/WelcomePage.tsx:231
 msgid "Back"
@@ -2128,11 +2136,11 @@ msgstr "Image URL"
 msgid "Include Seasons"
 msgstr "Include Seasons"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:173
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr "Increasing \"Max Lateness\" for the schedule."
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:175
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
 msgid "Increasing the slot duration."
 msgstr "Increasing the slot duration."
 
@@ -3024,7 +3032,7 @@ msgstr ""
 "Programs shorter than this value will be treated the same as Flex time. Meaning that the TV Guide will try to meld them with the previous program or display the block of programs as the \"place holder program\" if they make a large continuous group. Use 0 to disable this feature or use a large value to make the channel report only the placeholder program and not the real programming.\n"
 "{0}"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:143
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
 msgid "Programs Too Long"
 msgstr "Programs Too Long"
 
@@ -3145,7 +3153,7 @@ msgstr "Remove"
 msgid "Remove {count} {0}"
 msgstr "Remove {count} {0}"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
 msgid "Remove All"
 msgstr "Remove All"
 
@@ -3189,7 +3197,7 @@ msgstr "Removes any specials from the schedule. Specials are episodes with seaso
 msgid "Removes repeated programs."
 msgstr "Removes repeated programs."
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:176
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "Removing overrun programs from the channel."
 msgstr "Removing overrun programs from the channel."
 
@@ -3896,7 +3904,7 @@ msgstr "This channel is set up to use <0>{0}Slots</0> for programming. Any manua
 msgid "This channel number has already been used"
 msgstr "This channel number has already been used"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:167
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr "{0, plural, one {Path} other {Paths}}"
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:122
 msgid "{0, plural, one {program} other {programs}}"
 msgstr "{0, plural, one {program} other {programs}}"
 
@@ -110,9 +110,9 @@ msgstr "{0} Info"
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography> <Trans>Programs Too Long</Trans> </Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs', })}{' '} exceed the length of this slot ( {betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans> Average program length:{' '} {betterHumanize(dayjs.duration(averageLengthMs))} </Trans> </> )} <br /> <Trans> This could cause the following slot's programs to go unscheduled. Possible solutions include: </Trans> </p> <ul> {} {slotType === 'time' && ( <li> <Trans>Increasing "Max Lateness" for the schedule.</Trans> </li> )} <li> <Trans>Increasing the slot duration.</Trans> </li> <li> <Trans>Removing overrun programs from the channel.</Trans> </li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0} of {1} {2} exceed the length of this slot ({3})."
 msgstr "{0} of {1} {2} exceed the length of this slot ({3})."
 
@@ -662,7 +662,7 @@ msgid "Automatic"
 msgstr "Automatic"
 
 #. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:132
 msgid "Average program length: {0}"
 msgstr "Average program length: {0}"
 
@@ -2136,11 +2136,11 @@ msgstr "Image URL"
 msgid "Include Seasons"
 msgstr "Include Seasons"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:148
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr "Increasing \"Max Lateness\" for the schedule."
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:152
 msgid "Increasing the slot duration."
 msgstr "Increasing the slot duration."
 
@@ -3032,7 +3032,7 @@ msgstr ""
 "Programs shorter than this value will be treated the same as Flex time. Meaning that the TV Guide will try to meld them with the previous program or display the block of programs as the \"place holder program\" if they make a large continuous group. Use 0 to disable this feature or use a large value to make the channel report only the placeholder program and not the real programming.\n"
 "{0}"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:102
 msgid "Programs Too Long"
 msgstr "Programs Too Long"
 
@@ -3153,7 +3153,7 @@ msgstr "Remove"
 msgid "Remove {count} {0}"
 msgstr "Remove {count} {0}"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:115
 msgid "Remove All"
 msgstr "Remove All"
 
@@ -3197,7 +3197,7 @@ msgstr "Removes any specials from the schedule. Specials are episodes with seaso
 msgid "Removes repeated programs."
 msgstr "Removes repeated programs."
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
 msgid "Removing overrun programs from the channel."
 msgstr "Removing overrun programs from the channel."
 
@@ -3904,7 +3904,7 @@ msgstr "This channel is set up to use <0>{0}Slots</0> for programming. Any manua
 msgid "This channel number has already been used"
 msgstr "This channel number has already been used"
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 

--- a/web/src/locales/es/messages.po
+++ b/web/src/locales/es/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr ""
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:122
 msgid "{0, plural, one {program} other {programs}}"
 msgstr ""
 
@@ -110,9 +110,9 @@ msgstr ""
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography> <Trans>Programs Too Long</Trans> </Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs', })}{' '} exceed the length of this slot ( {betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans> Average program length:{' '} {betterHumanize(dayjs.duration(averageLengthMs))} </Trans> </> )} <br /> <Trans> This could cause the following slot's programs to go unscheduled. Possible solutions include: </Trans> </p> <ul> {} {slotType === 'time' && ( <li> <Trans>Increasing "Max Lateness" for the schedule.</Trans> </li> )} <li> <Trans>Increasing the slot duration.</Trans> </li> <li> <Trans>Removing overrun programs from the channel.</Trans> </li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0} of {1} {2} exceed the length of this slot ({3})."
 msgstr ""
 
@@ -662,7 +662,7 @@ msgid "Automatic"
 msgstr ""
 
 #. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:132
 msgid "Average program length: {0}"
 msgstr ""
 
@@ -2136,11 +2136,11 @@ msgstr ""
 msgid "Include Seasons"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:148
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:152
 msgid "Increasing the slot duration."
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:102
 msgid "Programs Too Long"
 msgstr ""
 
@@ -3151,7 +3151,7 @@ msgstr ""
 msgid "Remove {count} {0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:115
 msgid "Remove All"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "Removes repeated programs."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
 msgid "Removing overrun programs from the channel."
 msgstr ""
 
@@ -3902,7 +3902,7 @@ msgstr ""
 msgid "This channel number has already been used"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr ""
 

--- a/web/src/locales/es/messages.po
+++ b/web/src/locales/es/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr ""
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:162
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0, plural, one {program} other {programs}}"
 msgstr ""
 
@@ -110,12 +110,15 @@ msgstr ""
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, round, sum, uniqBy, values } from 'lodash-es'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; import { getEpisodeShowId } from '../../helpers/programUtil.ts'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; let averageLength = dayjs.duration(0); switch (slot.type) { case 'movie': { const durations = seq.collect(values(programLookup), (program) => { if (program.type === 'content' && program.program.type === 'movie') { return program.duration; } return; }); if (durations.length === 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'show': { const showId = slot.showId; const durations = seq.collect(values(programLookup), (program) => { if ( program.type === 'content' && program.program.type === 'episode' && getEpisodeShowId(program.program) === showId ) { return program.duration; } return; }); if (durations.length > 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'custom-show': case 'filler': case 'flex': case 'redirect': default: break; } return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))} ). Average program length: {averageLength.humanize()} </Trans> <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#. placeholder {4}: averageLength.humanize()
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:160
-msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+msgid "{0} of {1} {2} exceed the length of this slot ({3})."
 msgstr ""
+
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:160
+#~ msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#~ msgstr ""
 
 #. placeholder {0}: program.title
 #: src/components/programs/MediaDetailCard.tsx:171
@@ -656,6 +659,11 @@ msgstr ""
 
 #: src/components/programming_controls/AdjustWeightsModal.tsx:29
 msgid "Automatic"
+msgstr ""
+
+#. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+msgid "Average program length: {0}"
 msgstr ""
 
 #: src/pages/welcome/WelcomePage.tsx:231
@@ -2128,11 +2136,11 @@ msgstr ""
 msgid "Include Seasons"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:173
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:175
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
 msgid "Increasing the slot duration."
 msgstr ""
 
@@ -3022,7 +3030,7 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:143
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
 msgid "Programs Too Long"
 msgstr ""
 
@@ -3143,7 +3151,7 @@ msgstr ""
 msgid "Remove {count} {0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
 msgid "Remove All"
 msgstr ""
 
@@ -3187,7 +3195,7 @@ msgstr ""
 msgid "Removes repeated programs."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:176
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "Removing overrun programs from the channel."
 msgstr ""
 
@@ -3894,7 +3902,7 @@ msgstr ""
 msgid "This channel number has already been used"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:167
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr ""
 

--- a/web/src/locales/pseudo-LOCALE/messages.po
+++ b/web/src/locales/pseudo-LOCALE/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr ""
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:122
 msgid "{0, plural, one {program} other {programs}}"
 msgstr ""
 
@@ -110,9 +110,9 @@ msgstr ""
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography> <Trans>Programs Too Long</Trans> </Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs', })}{' '} exceed the length of this slot ( {betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans> Average program length:{' '} {betterHumanize(dayjs.duration(averageLengthMs))} </Trans> </> )} <br /> <Trans> This could cause the following slot's programs to go unscheduled. Possible solutions include: </Trans> </p> <ul> {} {slotType === 'time' && ( <li> <Trans>Increasing "Max Lateness" for the schedule.</Trans> </li> )} <li> <Trans>Increasing the slot duration.</Trans> </li> <li> <Trans>Removing overrun programs from the channel.</Trans> </li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0} of {1} {2} exceed the length of this slot ({3})."
 msgstr ""
 
@@ -662,7 +662,7 @@ msgid "Automatic"
 msgstr ""
 
 #. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:132
 msgid "Average program length: {0}"
 msgstr ""
 
@@ -2136,11 +2136,11 @@ msgstr ""
 msgid "Include Seasons"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:148
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:152
 msgid "Increasing the slot duration."
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:102
 msgid "Programs Too Long"
 msgstr ""
 
@@ -3151,7 +3151,7 @@ msgstr ""
 msgid "Remove {count} {0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:115
 msgid "Remove All"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "Removes repeated programs."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
 msgid "Removing overrun programs from the channel."
 msgstr ""
 
@@ -3902,7 +3902,7 @@ msgstr ""
 msgid "This channel number has already been used"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr ""
 

--- a/web/src/locales/pseudo-LOCALE/messages.po
+++ b/web/src/locales/pseudo-LOCALE/messages.po
@@ -94,7 +94,7 @@ msgid "{0, plural, one {Path} other {Paths}}"
 msgstr ""
 
 #. placeholder {0}: slot.programCount
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:162
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:120
 msgid "{0, plural, one {program} other {programs}}"
 msgstr ""
 
@@ -110,12 +110,15 @@ msgstr ""
 
 #. placeholder {0}: warning.programs.length
 #. placeholder {1}: slot.programCount
-#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, round, sum, uniqBy, values } from 'lodash-es'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; import { getEpisodeShowId } from '../../helpers/programUtil.ts'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; let averageLength = dayjs.duration(0); switch (slot.type) { case 'movie': { const durations = seq.collect(values(programLookup), (program) => { if (program.type === 'content' && program.program.type === 'movie') { return program.duration; } return; }); if (durations.length === 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'show': { const showId = slot.showId; const durations = seq.collect(values(programLookup), (program) => { if ( program.type === 'content' && program.program.type === 'episode' && getEpisodeShowId(program.program) === showId ) { return program.duration; } return; }); if (durations.length > 0) { averageLength = dayjs.duration( round(sum(durations) / durations.length), ); } break; } case 'custom-show': case 'filler': case 'flex': case 'redirect': default: break; } return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))} ). Average program length: {averageLength.humanize()} </Trans> <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
+#. placeholder {2}: import { betterHumanize } from '@/helpers/dayjs.ts'; import { alternateColors } from '@/helpers/util.ts'; import { plural } from '@lingui/core/macro'; import { Trans } from '@lingui/react/macro'; import { useProgramTitleFormatter } from '@/hooks/useProgramTitleFormatter.ts'; import type { ProgramTooLongWarning, SlotTableWarnings, } from '@/model/CommonSlotModels'; import { removeChannelProgramsById } from '@/store/entityEditor/util.ts'; import { useStoreProgramLookup } from '@/store/selectors.ts'; import { Delete, Error, ExpandMore, WarningAmber } from '@mui/icons-material'; import { Accordion, AccordionDetails, AccordionSummary, Box, Button, IconButton, ListItem, ListItemText, Stack, Typography, } from '@mui/material'; import { seq } from '@tunarr/shared/util'; import type { BaseSlot } from '@tunarr/types/api'; import dayjs from 'dayjs'; import { map, uniqBy, values } from 'lodash-es'; import { averageProgramDurationMs } from '@/helpers/slots.ts'; import type { ListChildComponentProps } from 'react-window'; import { FixedSizeList } from 'react-window'; type Props = { slot: BaseSlot & SlotTableWarnings; slotType: 'time' | 'random'; warning: ProgramTooLongWarning; }; export const SlotProgrammingTooLongWarningDetails = ({ slot, warning, slotType, }: Props) => { const formatter = useProgramTitleFormatter(); const programLookup = useStoreProgramLookup(); const longPrograms = seq.collect( uniqBy(warning.programs, (p) => p.id), ({ id }) => { return programLookup[id]; }, ); const renderLongProgramRow = (props: ListChildComponentProps) => { const program = longPrograms[props.index]; if (!program.id) { return null; } const programId = program.id; return ( <ListItem style={props.style} sx={{ backgroundColor: (theme) => alternateColors(props.index, theme.palette.mode), }} key={programId} component="div" > <ListItemText primary={formatter(program)} /> <IconButton onClick={() => removeChannelProgramsById(programId)} edge="end" aria-label="delete" size="small" > <Delete fontSize="small" /> </IconButton> </ListItem> ); }; const averageLengthMs = averageProgramDurationMs(slot, values(programLookup)); return ( <Accordion defaultExpanded={slot.warnings.length === 1} key={warning.type} elevation={5} > <AccordionSummary expandIcon={<ExpandMore />}> {warning.programs.length === slot.programCount ? ( <Error sx={{ mr: 1, color: (theme) => theme.palette.error.main }} /> ) : ( <WarningAmber sx={{ mr: 1, color: (theme) => theme.palette.warning.main }} /> )} <Typography><Trans>Programs Too Long</Trans></Typography> </AccordionSummary> <AccordionDetails> <Stack> <Stack direction="row"> <Button onClick={() => removeChannelProgramsById( new Set(map(warning.programs, (p) => p.id)), ) } > <Trans>Remove All</Trans> </Button> </Stack> <div> <p> <Trans> {warning.programs.length} of {slot.programCount}{' '} {plural(slot.programCount, { one: 'program', other: 'programs' })} exceed the length of this slot ({betterHumanize(dayjs.duration(slot.durationMs ?? 0))}). </Trans> {averageLengthMs !== undefined && ( <> {' '} <Trans>Average program length: {betterHumanize(dayjs.duration(averageLengthMs))}</Trans> </> )} <br /> <Trans>This could cause the following slot's programs to go unscheduled. Possible solutions include:</Trans> </p> <ul> {} {slotType === 'time' && ( <li><Trans>Increasing "Max Lateness" for the schedule.</Trans></li> )} <li><Trans>Increasing the slot duration.</Trans></li> <li><Trans>Removing overrun programs from the channel.</Trans></li> </ul> </div> <Box sx={{ width: '100%', height: 400 }}> <FixedSizeList height={400} width={'100%'} itemSize={46} itemCount={longPrograms.length} overscanCount={5} > {renderLongProgramRow} </FixedSizeList> </Box> </Stack> </AccordionDetails> </Accordion> ); }; 
 #. placeholder {3}: betterHumanize(dayjs.duration(slot.durationMs ?? 0))
-#. placeholder {4}: averageLength.humanize()
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:160
-msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:118
+msgid "{0} of {1} {2} exceed the length of this slot ({3})."
 msgstr ""
+
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:160
+#~ msgid "{0} of {1} {2} exceed the length of this slot ({3}). Average program length: {4}"
+#~ msgstr ""
 
 #. placeholder {0}: program.title
 #: src/components/programs/MediaDetailCard.tsx:171
@@ -656,6 +659,11 @@ msgstr ""
 
 #: src/components/programming_controls/AdjustWeightsModal.tsx:29
 msgid "Automatic"
+msgstr ""
+
+#. placeholder {0}: betterHumanize(dayjs.duration(averageLengthMs))
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:126
+msgid "Average program length: {0}"
 msgstr ""
 
 #: src/pages/welcome/WelcomePage.tsx:231
@@ -2128,11 +2136,11 @@ msgstr ""
 msgid "Include Seasons"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:173
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:136
 msgid "Increasing \"Max Lateness\" for the schedule."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:175
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:138
 msgid "Increasing the slot duration."
 msgstr ""
 
@@ -3022,7 +3030,7 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:143
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:101
 msgid "Programs Too Long"
 msgstr ""
 
@@ -3143,7 +3151,7 @@ msgstr ""
 msgid "Remove {count} {0}"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:155
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:113
 msgid "Remove All"
 msgstr ""
 
@@ -3187,7 +3195,7 @@ msgstr ""
 msgid "Removes repeated programs."
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:176
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:139
 msgid "Removing overrun programs from the channel."
 msgstr ""
 
@@ -3894,7 +3902,7 @@ msgstr ""
 msgid "This channel number has already been used"
 msgstr ""
 
-#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:167
+#: src/components/slot_scheduler/SlotProgrammingTooLongWarningDetails.tsx:130
 msgid "This could cause the following slot's programs to go unscheduled. Possible solutions include:"
 msgstr ""
 

--- a/web/src/test/programFixtures.ts
+++ b/web/src/test/programFixtures.ts
@@ -1,0 +1,85 @@
+import type { ContentProgram } from '@tunarr/types';
+
+type TerminalProgram = ContentProgram['program'];
+type Movie = Extract<TerminalProgram, { type: 'movie' }>;
+type Episode = Extract<TerminalProgram, { type: 'episode' }>;
+
+/**
+ * Fixtures for the program shapes the editors actually receive.
+ *
+ * These are built without casts on purpose. Four of the existing web test files
+ * assert against hand-written program literals that no longer match
+ * `ContentProgram` -- extra fields, missing `program` -- and nothing caught it,
+ * because `tsconfig.build.json` excludes `*.test.ts` from the typecheck CI
+ * runs. A cast-free factory is the only version of this that stays honest when
+ * the schema moves.
+ */
+const terminalDefaults = {
+  uuid: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+  sourceType: 'local',
+  identifiers: [],
+  title: 'Untitled',
+  sortTitle: 'Untitled',
+  tags: [],
+  originalTitle: null,
+  year: null,
+  releaseDate: null,
+  releaseDateString: null,
+  artwork: [],
+  state: 'ok',
+  summary: null,
+  mediaSourceId: 'source-1',
+  libraryId: 'library-1',
+  canonicalId: 'canonical-1',
+  externalId: 'external-1',
+  duration: 0,
+} as const satisfies Omit<Movie, 'type' | 'plot' | 'tagline' | 'rating'>;
+
+export function makeMovie(overrides: Partial<Movie> = {}): Movie {
+  return {
+    ...terminalDefaults,
+    type: 'movie',
+    plot: null,
+    tagline: null,
+    rating: null,
+    ...overrides,
+  };
+}
+
+type ShowGrouping = NonNullable<Episode['show']>;
+
+export function makeShowGrouping(
+  uuid: string,
+  overrides: Partial<ShowGrouping> = {},
+): ShowGrouping {
+  return {
+    ...terminalDefaults,
+    uuid,
+    type: 'show',
+    plot: null,
+    tagline: null,
+    rating: null,
+    genres: [],
+    actors: [],
+    studios: [],
+    ...overrides,
+  };
+}
+
+export function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    ...terminalDefaults,
+    type: 'episode',
+    episodeNumber: 1,
+    ...overrides,
+  };
+}
+
+/** Wraps a terminal program in the lineup envelope the editors store. */
+export function makeContentProgram(
+  program: TerminalProgram,
+  durationMs: number,
+  id = `program-${program.uuid}`,
+): ContentProgram {
+  return { type: 'content', id, duration: durationMs, program };
+}


### PR DESCRIPTION
First item from the frontend audit plan (FE1).

## The bug

`SlotProgrammingTooLongWarningDetails` computes the average length of the programs a slot draws from, so the user can compare it against the slot duration and decide how to fix the "Programs Too Long" warning.

The **movie** branch guarded on `durations.length === 0`. The **show** branch immediately below it correctly guards on `> 0`. Inverted, so a movie slot took the wrong path every time:

| Pool | Old result |
| --- | --- |
| No movies | `sum([]) / 0` → `NaN` |
| Movies present | branch skipped, average stays `0` |

Neither is ever correct, and — this is the part that matters — neither looks wrong on screen:

```
dayjs.duration(NaN).humanize()  ->  "a month"
dayjs.duration(0).humanize()    ->  "a few seconds"
```

So the dialog answers "Average program length" with confident nonsense rather than showing an error. Same shape as the rest of this sweep: it does not fail, it substitutes a plausible value.

Slot types with no fixed pool (`flex`, `redirect`, `filler`, `custom-show`) also fell through to `0` and claimed an average of "a few seconds". They now omit the sentence.

## What changed

Three commits:

1. **`test(web)`** — extract the calculation into `averageProgramDurationMs` in `helpers/slots.ts`, with 7 tests. It returns `undefined` rather than `0` when there is nothing to average, because "there is no average" and "the average is zero" are different answers the caller must render differently.
2. **`fix(web)`** — the component calls the helper and omits the sentence when the average is unknown. Formatting moves from `.humanize()` to `betterHumanize`, so the two durations in the same sentence are comparable; `.humanize()` renders a 45-minute average as "an hour" next to a precisely-formatted slot duration.
3. **`chore(web)`** — lingui catalogs.

## A note on the fixtures

`web/src/test/programFixtures.ts` builds `ContentProgram` values **without casts**. That was deliberate and it is worth flagging separately:

`web/tsconfig.build.json` excludes `./src/**/*.test.ts`, and CI typechecks web only through that config (`turbo build --filter=@tunarr/web` runs `tsgo -p tsconfig.build.json`). So **web test files are never typechecked.** Running `tsgo -p tsconfig.json` today reports **14 errors across 4 of the 11 web test files** — fixtures carrying `persisted`, `uniqueId`, `title`, `subtype` fields that `ContentProgram` no longer has, and one missing `program` entirely. Those tests still pass, against a program shape the app never produces.

I have not fixed that here — it is a separate change. Filing it as the next Phase 0 item.

## Test plan

- [x] 7 new tests pass against the fixed helper
- [x] 6 of the 7 fail when the original inverted-guard logic is restored, including `expected NaN to be undefined`
- [x] `tsgo -p tsconfig.json` clean for every file this PR adds or touches
- [x] Full preflight green: commitlint, server typecheck, web build, all tests, lingui, eslint

🤖 Generated with [Claude Code](https://claude.com/claude-code)