### PR TITLE
fix(web): typecheck web test files, and repair the four that had rotted

### DIFF
--- a/web/src/hooks/programming_controls/useAddBreaks.test.ts
+++ b/web/src/hooks/programming_controls/useAddBreaks.test.ts
@@ -1,7 +1,12 @@
-import type { ChannelProgram, ContentProgram, FlexProgram } from '@tunarr/types';
+import type {
+  ChannelProgram,
+  ContentProgram,
+  FlexProgram,
+} from '@tunarr/types';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { makeContentProgram, makeMovie } from '../../test/programFixtures.ts';
 import { addBreaks, type AddBreaksConfig } from './useAddBreaks';
 
 dayjs.extend(duration);
@@ -9,27 +14,26 @@ dayjs.extend(duration);
 // Mock the random helper
 vi.mock('../../helpers/random.ts', () => ({
   random: {
-    integer: vi.fn((min: number, max: number) => min), // Always return min for deterministic tests
+    integer: vi.fn((min: number) => min), // Always return min for deterministic tests
   },
 }));
 
 const createContentProgram = (
   durationMs: number,
   title = 'Test',
-): ContentProgram => ({
-  type: 'content',
-  id: `id-${title}-${durationMs}`,
-  persisted: true,
-  subtype: 'movie',
-  title,
-  duration: durationMs,
-  externalIds: [],
-});
+): ContentProgram =>
+  makeContentProgram(
+    makeMovie({ title }),
+    durationMs,
+    `id-${title}-${durationMs}`,
+  );
+
+const programTitle = (program: ChannelProgram) =>
+  program.type === 'content' ? program.program.title : undefined;
 
 const createFlexProgram = (durationMs: number): FlexProgram => ({
   type: 'flex',
   duration: durationMs,
-  persisted: false,
 });
 
 const createConfig = (
@@ -168,8 +172,8 @@ describe('addBreaks', () => {
 
     // Flex should be inserted before 'Second'
     expect(result).toHaveLength(3);
-    expect((result[0] as ContentProgram).title).toBe('First');
+    expect(programTitle(result[0])).toBe('First');
     expect(result[1].type).toBe('flex');
-    expect((result[2] as ContentProgram).title).toBe('Second');
+    expect(programTitle(result[2])).toBe('Second');
   });
 });

--- a/web/src/hooks/programming_controls/useAlphaSort.test.ts
+++ b/web/src/hooks/programming_controls/useAlphaSort.test.ts
@@ -1,5 +1,6 @@
 import type { ChannelProgram, ContentProgram } from '@tunarr/types';
 import { describe, expect, test } from 'vitest';
+import { makeMovie } from '../../test/programFixtures.ts';
 import { sortPrograms } from './useAlphaSort';
 
 const createContentProgram = (
@@ -8,24 +9,22 @@ const createContentProgram = (
 ): ContentProgram => ({
   type: 'content',
   id: `id-${title}`,
-  uniqueId: `id-${title}`,
-  persisted: true,
   duration: 3600000,
-  program: { type: 'movie', title } as ContentProgram['program'],
+  program: makeMovie({ title }),
   ...overrides,
 });
 
 const createFlexProgram = (): ChannelProgram => ({
   type: 'flex',
   duration: 60000,
-  persisted: false,
 });
 
 const createRedirectProgram = (channel: string): ChannelProgram => ({
   type: 'redirect',
   channel,
+  channelNumber: 1,
+  channelName: 'Channel One',
   duration: 3600000,
-  persisted: false,
 });
 
 describe('sortPrograms', () => {

--- a/web/src/hooks/programming_controls/useReleaseDateSort.test.ts
+++ b/web/src/hooks/programming_controls/useReleaseDateSort.test.ts
@@ -1,8 +1,13 @@
 import { v4 } from 'uuid';
 import { describe, expect, test } from 'vitest';
 import { sortProgramsByReleaseDate } from './useReleaseDateSort';
-import { ChannelProgram } from '@tunarr/types';
+import type { ChannelProgram } from '@tunarr/types';
 import { map } from 'lodash-es';
+import {
+  makeContentProgram,
+  makeEpisode,
+  makeSeasonGrouping,
+} from '../../test/programFixtures.ts';
 
 describe('useReleaseDateSort', () => {
   test('use season and episode index as fallback to release date', () => {
@@ -10,47 +15,27 @@ describe('useReleaseDateSort', () => {
       two = v4(),
       three = v4();
 
-    const before = [
-      {
-        type: 'content',
-        id: one,
-        persisted: false,
-        duration: 0,
-        uniqueId: one,
-        program: {
-          type: 'episode',
+    const episode = (
+      id: string,
+      episodeNumber: number,
+      seasonIndex: number,
+    ): ChannelProgram =>
+      makeContentProgram(
+        makeEpisode({
+          uuid: id,
+          episodeNumber,
           releaseDate: 0,
-          episodeNumber: 7,
-          season: { index: 3 },
-        },
-      },
-      {
-        type: 'content',
-        id: two,
-        persisted: false,
-        duration: 0,
-        uniqueId: two,
-        program: {
-          type: 'episode',
-          releaseDate: 0,
-          episodeNumber: 1,
-          season: { index: 2 },
-        },
-      },
-      {
-        type: 'content',
-        id: three,
-        persisted: false,
-        duration: 0,
-        uniqueId: three,
-        program: {
-          type: 'episode',
-          releaseDate: 0,
-          episodeNumber: 2,
-          season: { index: 3 },
-        },
-      },
-    ] as ChannelProgram[];
+          season: makeSeasonGrouping(seasonIndex),
+        }),
+        0,
+        id,
+      );
+
+    const before: ChannelProgram[] = [
+      episode(one, 7, 3),
+      episode(two, 1, 2),
+      episode(three, 2, 3),
+    ];
 
     const sortedPrograms = sortProgramsByReleaseDate(before, 'asc');
 

--- a/web/src/hooks/programming_controls/useRemoveDuplicates.test.ts
+++ b/web/src/hooks/programming_controls/useRemoveDuplicates.test.ts
@@ -5,6 +5,7 @@ import type {
   RedirectProgram,
 } from '@tunarr/types';
 import { describe, expect, test } from 'vitest';
+import { makeMovie } from '../../test/programFixtures.ts';
 import type { UIChannelProgram } from '../../types/index';
 import { removeDuplicatePrograms } from './useRemoveDuplicates';
 
@@ -14,9 +15,8 @@ const createContentProgram = (
 ): UIChannelProgram<ContentProgram> => ({
   type: 'content',
   id,
-  uniqueId: id,
   duration: 3600000,
-  program: { type: 'movie', identifiers: [] } as ContentProgram['program'],
+  program: makeMovie(),
   uiIndex: 0,
   originalIndex: 0,
   ...overrides,
@@ -34,6 +34,8 @@ const createRedirectProgram = (
 ): UIChannelProgram<RedirectProgram> => ({
   type: 'redirect',
   channel,
+  channelNumber: 1,
+  channelName: 'Channel One',
   duration: 3600000,
   uiIndex: 0,
   originalIndex: 0,
@@ -46,6 +48,7 @@ const createCustomProgram = (
   type: 'custom',
   customShowId,
   id,
+  index: 0,
   duration: 3600000,
   uiIndex: 0,
   originalIndex: 0,
@@ -92,12 +95,10 @@ describe('removeDuplicatePrograms', () => {
     ): UIChannelProgram<ContentProgram> => ({
       type: 'content',
       id: internalId,
-      uniqueId: internalId,
       duration: 3600000,
-      program: {
-        type: 'movie',
+      program: makeMovie({
         identifiers: [{ type: 'plex', sourceId: 'server-1', id: externalId }],
-      } as ContentProgram['program'],
+      }),
       uiIndex: 0,
       originalIndex: 0,
     });

--- a/web/src/test/programFixtures.ts
+++ b/web/src/test/programFixtures.ts
@@ -66,6 +66,24 @@ export function makeShowGrouping(
   };
 }
 
+type SeasonGrouping = NonNullable<Episode['season']>;
+
+export function makeSeasonGrouping(
+  index: number,
+  overrides: Partial<SeasonGrouping> = {},
+): SeasonGrouping {
+  return {
+    ...terminalDefaults,
+    uuid: `season-${index}`,
+    type: 'season',
+    index,
+    plot: null,
+    tagline: null,
+    studios: [],
+    ...overrides,
+  };
+}
+
 export function makeEpisode(overrides: Partial<Episode> = {}): Episode {
   return {
     ...terminalDefaults,

--- a/web/tsconfig.build.json
+++ b/web/tsconfig.build.json
@@ -11,8 +11,6 @@
         "vitest.config.ts",
         "./build/**/*",
         "./dist/**/*",
-        "./src/**/*.test.ts",
-        "./src/**/*.test.tsx",
         "./src/**/*.ignore.ts"
     ]
 }


### PR DESCRIPTION
Phase 0 of the frontend audit. **Stacked on #2016** — base is that branch so the diff is clean; retarget to `main` once #2016 merges.

## The gap

`web/tsconfig.build.json` excludes `./src/**/*.test.ts` and `./src/**/*.test.tsx`. That is the **only** config CI typechecks web through — `main.yml` runs `turbo build --filter=@tunarr/web`, and web's `build` script is `tsgo -p tsconfig.build.json --noEmit`.

So no web test file has ever been typechecked. Running `tsgo -p tsconfig.json` (which does include them) reports **14 errors across 4 of the 11 web test files**.

## What had rotted

Every error is a fixture asserting against a `ContentProgram` shape the app no longer produces:

| Field used | Reality |
| --- | --- |
| `persisted` | not on `ContentProgram` |
| `uniqueId` | not on `ContentProgram` |
| `subtype` | not on `ContentProgram` |
| `title` (top level) | lives at `program.title` |

`useAddBreaks.test.ts` is the clearest case: its fixture has **no `program` field at all**, and its assertions then read a `title` the fixture itself invented. The tests pass — against a shape nothing in the app can produce.

These are 4 of the 5 pure-function tests that the audit plan calls "the pattern that already works". They are worth trusting, so they should be checked.

## The fix

Drop the two exclude lines. **No CI workflow change needed** — `build` for web is already a typecheck, and vite bundling is a separate `bundle` script unaffected by the include set.

Then repair the four files by building programs through the cast-free fixture factory added in #2016, which is what keeps them honest when the schema next moves. `useRemoveDuplicates` additionally needed `channelNumber`/`channelName` on its redirect fixture and `index` on its custom-show fixture — fields the function under test never reads, but the type requires.

**No assertions were weakened.** All 83 tests still pass.

## Test plan

- [x] `tsgo -p tsconfig.build.json --noEmit` — 14 errors before, 0 after
- [x] `vitest --run` — 83 passed across 12 files, unchanged
- [x] `turbo build --filter=@tunarr/web` passes (the command CI runs)
- [x] Full preflight green: eslint, commitlint, server typecheck, web build, tests, lingui

🤖 Generated with [Claude Code](https://claude.com/claude-code)