### PR TITLE
fix(web): repair eleven cache invalidations that matched no query

### DIFF
--- a/web/src/components/channels/ChannelNowPlayingCard.tsx
+++ b/web/src/components/channels/ChannelNowPlayingCard.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
+import { getApiChannelsByIdNowPlayingQueryKey } from '@/generated/@tanstack/react-query.gen.ts';
 import type { MediaArtwork } from '@tunarr/types';
 import * as globalDayjs from 'dayjs';
 import { capitalize, isNil } from 'lodash-es';
@@ -55,7 +56,9 @@ export const ChannelNowPlayingCard = ({ channelId }: Props) => {
   useTimeout(() => {
     queryClient
       .invalidateQueries({
-        queryKey: ['channels', channelId, 'now_playing'],
+        queryKey: getApiChannelsByIdNowPlayingQueryKey({
+          path: { id: channelId },
+        }),
       })
       .catch(console.error);
   }, firstProgram.stop + 5_000);

--- a/web/src/components/guide/TvGuide.tsx
+++ b/web/src/components/guide/TvGuide.tsx
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
+import { invalidateTaggedQueries } from '@/helpers/queryUtil.ts';
 import { seq } from '@tunarr/shared/util';
 import type { Channel } from '@tunarr/types';
 import { type ChannelLineup, type TvGuideProgram } from '@tunarr/types';
@@ -100,10 +101,10 @@ export function TvGuide({ channelId, start, end, showStealth = true }: Props) {
       if (ev.type === 'xmltv') {
         queryClient
           .invalidateQueries({
-            // Gnarly
-            predicate: (query) =>
-              query.queryKey?.[0] === 'channels' &&
-              query.queryKey?.[2] === 'guide',
+            // The guide renders from the channel lineup endpoints, which carry
+            // the 'Channels' tag -- not the 'Guide' tag, which belongs to the
+            // separate /api/guide/channels endpoints this page never calls.
+            predicate: invalidateTaggedQueries('Channels'),
           })
           .catch(console.error);
       }

--- a/web/src/helpers/queryUtil.test.ts
+++ b/web/src/helpers/queryUtil.test.ts
@@ -1,0 +1,198 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, test } from 'vitest';
+import {
+  getApiChannelsAllLineupsQueryKey,
+  getApiChannelsByIdLineupQueryKey,
+  getApiChannelsByIdNowPlayingQueryKey,
+  getApiChannelsByIdProgrammingQueryKey,
+  getApiProgramGroupingsByIdQueryKey,
+  getApiProgramsByIdQueryKey,
+  getApiSystemDebugEnvQueryKey,
+  getApiXmltvSettingsQueryKey,
+  getChannelsQueryKey,
+} from '../generated/@tanstack/react-query.gen.ts';
+import { invalidateTaggedQueries } from './queryUtil.ts';
+
+/**
+ * Generated hey-api query keys are a single-element array whose element is an
+ * object: `[{ _id, baseURL, tags }]`. A hand-written string key such as
+ * `['Channels']` therefore diverges at element 0 and prefix-matches nothing --
+ * `'Channels'` is the *tag*, not a key segment.
+ *
+ * These tests drive a real QueryClient rather than reimplementing the matcher,
+ * so they stay true if TanStack changes how matching works.
+ */
+const seed = (client: QueryClient, key: readonly unknown[]) => {
+  client.setQueryData(key, { seeded: true });
+  const query = client.getQueryCache().find({ queryKey: key });
+  if (!query) {
+    throw new Error('failed to seed query into the cache');
+  }
+  return query;
+};
+
+describe('generated query keys', () => {
+  test('a bare tag string does not match the query it names', async () => {
+    const client = new QueryClient();
+    const query = seed(client, getChannelsQueryKey());
+
+    await client.invalidateQueries({ queryKey: ['Channels'] });
+
+    expect(query.state.isInvalidated).toBe(false);
+  });
+
+  test('invalidateTaggedQueries matches it', async () => {
+    const client = new QueryClient();
+    const query = seed(client, getChannelsQueryKey());
+
+    await client.invalidateQueries({
+      predicate: invalidateTaggedQueries('Channels'),
+    });
+
+    expect(query.state.isInvalidated).toBe(true);
+  });
+
+  test('the generated key factory matches it exactly', async () => {
+    const client = new QueryClient();
+    const query = seed(client, getChannelsQueryKey());
+
+    await client.invalidateQueries({ queryKey: getChannelsQueryKey() });
+
+    expect(query.state.isInvalidated).toBe(true);
+  });
+});
+
+describe('invalidateTaggedQueries', () => {
+  test('does not match a query carrying a different tag', async () => {
+    const client = new QueryClient();
+    const channels = seed(client, getChannelsQueryKey());
+    const settings = seed(client, getApiXmltvSettingsQueryKey());
+
+    await client.invalidateQueries({
+      predicate: invalidateTaggedQueries('Settings'),
+    });
+
+    expect(settings.state.isInvalidated).toBe(true);
+    expect(channels.state.isInvalidated).toBe(false);
+  });
+
+  test('matches when any one of several tags matches', async () => {
+    const client = new QueryClient();
+    const query = seed(client, getChannelsQueryKey());
+
+    await client.invalidateQueries({
+      predicate: invalidateTaggedQueries(['Guide', 'Channels']),
+    });
+
+    expect(query.state.isInvalidated).toBe(true);
+  });
+
+  test('matches nothing when given no tags', async () => {
+    const client = new QueryClient();
+    const query = seed(client, getChannelsQueryKey());
+
+    await client.invalidateQueries({ predicate: invalidateTaggedQueries([]) });
+
+    expect(query.state.isInvalidated).toBe(false);
+  });
+
+  test('ignores hand-written string keys, which carry no tags', async () => {
+    const client = new QueryClient();
+    const query = seed(client, ['channels', 'abc', 'now_playing']);
+
+    await client.invalidateQueries({
+      predicate: invalidateTaggedQueries('Channels'),
+    });
+
+    expect(query.state.isInvalidated).toBe(false);
+  });
+});
+
+/**
+ * Pins each invalidation site to the query it exists to refresh.
+ *
+ * Every one of these was dead before: a hand-written string key, or a
+ * hand-rolled predicate, aimed at a generated key it could never match. The
+ * risk in fixing them by tag is picking a tag that is equally wrong -- the TV
+ * Guide case nearly went out invalidating the 'Guide' tag, which belongs to
+ * endpoints that page never calls. This table is the check.
+ */
+describe('invalidation sites reach their targets', () => {
+  const cases: {
+    site: string;
+    tag: string;
+    targets: readonly (readonly unknown[])[];
+  }[] = [
+    {
+      site: 'useCreateChannel / ChannelsPage delete + stream events',
+      tag: 'Channels',
+      targets: [getChannelsQueryKey()],
+    },
+    {
+      site: 'TvGuide on xmltv regeneration',
+      tag: 'Channels',
+      targets: [
+        getApiChannelsByIdLineupQueryKey({ path: { id: 'c1' } }),
+        getApiChannelsAllLineupsQueryKey(),
+      ],
+    },
+    {
+      site: 'useUpdateLineup after saving programming',
+      tag: 'Channels',
+      targets: [getApiChannelsByIdProgrammingQueryKey({ path: { id: 'c1' } })],
+    },
+    {
+      site: 'XmlTvSettingsPage after save',
+      tag: 'Settings',
+      targets: [getApiXmltvSettingsQueryKey()],
+    },
+    {
+      site: 'SystemDebugPage on server lifecycle events',
+      tag: 'System',
+      targets: [getApiSystemDebugEnvQueryKey()],
+    },
+    {
+      site: 'useScanNow after a rescan',
+      tag: 'Programs',
+      targets: [
+        getApiProgramsByIdQueryKey({ path: { id: 'p1' } }),
+        getApiProgramGroupingsByIdQueryKey({ path: { id: 'p1' } }),
+      ],
+    },
+  ];
+
+  test.each(cases)(
+    '$site invalidates via the $tag tag',
+    async ({ tag, targets }) => {
+      const client = new QueryClient();
+      const queries = targets.map((key) => seed(client, key));
+
+      await client.invalidateQueries({
+        predicate: invalidateTaggedQueries(tag),
+      });
+
+      for (const query of queries) {
+        expect(query.state.isInvalidated).toBe(true);
+      }
+    },
+  );
+
+  test('ChannelNowPlayingCard invalidates exactly its own query', async () => {
+    const client = new QueryClient();
+    const mine = seed(
+      client,
+      getApiChannelsByIdNowPlayingQueryKey({ path: { id: 'c1' } }),
+    );
+    const other = seed(
+      client,
+      getApiChannelsByIdNowPlayingQueryKey({ path: { id: 'c2' } }),
+    );
+
+    await client.invalidateQueries({
+      queryKey: getApiChannelsByIdNowPlayingQueryKey({ path: { id: 'c1' } }),
+    });
+
+    expect(mine.state.isInvalidated).toBe(true);
+    expect(other.state.isInvalidated).toBe(false);
+  });
+});

--- a/web/src/hooks/useCreateChannel.ts
+++ b/web/src/hooks/useCreateChannel.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { invalidateTaggedQueries } from '../helpers/queryUtil.ts';
 import { createChannelV2Mutation } from '../generated/@tanstack/react-query.gen.ts';
 
 export const useCreateChannel = (
@@ -10,8 +11,7 @@ export const useCreateChannel = (
     ...createChannelV2Mutation(),
     onSuccess: async (...args) => {
       await queryClient.invalidateQueries({
-        exact: false,
-        queryKey: ['Channels'],
+        predicate: invalidateTaggedQueries('Channels'),
       });
 
       if (opts?.onSuccess) {

--- a/web/src/hooks/useScanNow.ts
+++ b/web/src/hooks/useScanNow.ts
@@ -1,35 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isEqual } from 'lodash-es';
 import { useCallback } from 'react';
-import {
-  getApiProgramGroupingsByIdQueryKey,
-  getApiProgramsByIdOptions,
-  postApiProgramsByIdScanMutation,
-} from '../generated/@tanstack/react-query.gen.ts';
+import { invalidateTaggedQueries } from '../helpers/queryUtil.ts';
+import { postApiProgramsByIdScanMutation } from '../generated/@tanstack/react-query.gen.ts';
 
 export const useScanNow = () => {
   const queryClient = useQueryClient();
-  const clearQueryCache = useCallback(
-    (programId: string) => {
-      return queryClient.invalidateQueries({
-        predicate: (key) => {
-          return (
-            isEqual(
-              key,
-              getApiProgramGroupingsByIdQueryKey({ path: { id: programId } }),
-            ) ||
-            isEqual(key, getApiProgramsByIdOptions({ path: { id: programId } }))
-          );
-        },
-      });
-    },
-    [queryClient],
-  );
+  // A scan rewrites metadata for the program and, for a grouping, its
+  // children -- so the whole Programs category is stale, not one entry.
+  const clearQueryCache = useCallback(() => {
+    return queryClient.invalidateQueries({
+      predicate: invalidateTaggedQueries('Programs'),
+    });
+  }, [queryClient]);
 
   const scanMut = useMutation({
     ...postApiProgramsByIdScanMutation(),
-    onSuccess: (_, { path: { id } }) => {
-      return clearQueryCache(id);
+    onSuccess: () => {
+      return clearQueryCache();
     },
   });
 

--- a/web/src/hooks/useUpdateLineup.ts
+++ b/web/src/hooks/useUpdateLineup.ts
@@ -1,5 +1,6 @@
 import { resetCurrentLineup } from '@/store/channelEditor/actions';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { invalidateTaggedQueries } from '../helpers/queryUtil.ts';
 import { postApiChannelsByIdProgrammingMutation } from '../generated/@tanstack/react-query.gen.ts';
 
 export const useUpdateLineup = (
@@ -9,18 +10,12 @@ export const useUpdateLineup = (
   return useMutation({
     ...postApiChannelsByIdProgrammingMutation(),
     onSuccess: async (...args) => {
-      const [
-        response,
-        {
-          path: { id: channelId },
-        },
-      ] = args;
+      const [response] = args;
 
       resetCurrentLineup(response);
 
       await queryClient.invalidateQueries({
-        queryKey: ['channels', channelId],
-        exact: false,
+        predicate: invalidateTaggedQueries('Channels'),
       });
 
       if (opts?.onSuccess) {

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -45,7 +45,7 @@ msgstr "{0, plural, one {# item} other {# items}}"
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:492
+#: src/pages/channels/ChannelsPage.tsx:493
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr "{0, plural, one {# program} other {# programs}}"
 
@@ -66,8 +66,8 @@ msgid "{0, plural, one {# Selected Item} other {# Selected Items}}"
 msgstr "{0, plural, one {# Selected Item} other {# Selected Items}}"
 
 #. placeholder {0}: sessions.length
-#: src/pages/channels/ChannelsPage.tsx:293
-#: src/pages/channels/ChannelsPage.tsx:423
+#: src/pages/channels/ChannelsPage.tsx:294
+#: src/pages/channels/ChannelsPage.tsx:424
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr "{0, plural, one {# session} other {# sessions}}"
 
@@ -206,17 +206,17 @@ msgstr "{len, plural, one {There is # warning. Click for details.} other {There 
 msgid "{minutes, plural, one {# minute} other {# minutes}}"
 msgstr "{minutes, plural, one {# minute} other {# minutes}}"
 
-#: src/components/guide/TvGuide.tsx:337
+#: src/components/guide/TvGuide.tsx:338
 msgid "{remainingTime} left"
 msgstr "{remainingTime} left"
 
-#: src/pages/channels/ChannelsPage.tsx:296
-#: src/pages/channels/ChannelsPage.tsx:426
+#: src/pages/channels/ChannelsPage.tsx:297
+#: src/pages/channels/ChannelsPage.tsx:427
 msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr "{totalConnections, plural, one {# connection} other {# connections}}"
 
-#: src/pages/channels/ChannelsPage.tsx:295
-#: src/pages/channels/ChannelsPage.tsx:425
+#: src/pages/channels/ChannelsPage.tsx:296
+#: src/pages/channels/ChannelsPage.tsx:426
 msgid "{totalConnections} total"
 msgstr "{totalConnections} total"
 
@@ -232,7 +232,7 @@ msgstr "* Restart required"
 msgid "# of Programs"
 msgstr "# of Programs"
 
-#: src/pages/channels/ChannelsPage.tsx:342
+#: src/pages/channels/ChannelsPage.tsx:343
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -265,7 +265,7 @@ msgid "<0>Pad Slot:</0> Align slot start times to the specified pad time.<1/><2>
 msgstr "<0>Pad Slot:</0> Align slot start times to the specified pad time.<1/><2>Pad Episode:</2> Align episode start times (within a slot) to the specified pad time. <3>NOTE:</3> Depending on slot length and the chosen pad time, this could potentially create a lot of flex."
 
 #. placeholder {0}: new URL( '/api/xmltv.xml', isEmpty(backendUri) ? document.location.href : backendUri, ).href
-#: src/pages/settings/XmlTvSettingsPage.tsx:96
+#: src/pages/settings/XmlTvSettingsPage.tsx:97
 msgid "<0>You can edit this location in your settings.json within your Tunarr data directory<1/><2>NOTE:</2> When manually adding the XMLTV location to a client like Plex, do not use this file directly. Instead, use the generated XMLTV from the Tunarr API endpoint: {0}</0>"
 msgstr "<0>You can edit this location in your settings.json within your Tunarr data directory<1/><2>NOTE:</2> When manually adding the XMLTV location to a client like Plex, do not use this file directly. Instead, use the generated XMLTV from the Tunarr API endpoint: {0}</0>"
 
@@ -542,7 +542,7 @@ msgid "Amount"
 msgstr "Amount"
 
 #. placeholder {0}: error.message
-#: src/components/guide/TvGuide.tsx:579
+#: src/components/guide/TvGuide.tsx:580
 msgid "An error occurred: {0}"
 msgstr "An error occurred: {0}"
 
@@ -798,7 +798,7 @@ msgstr "Calculating Slots..."
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:189
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:114
-#: src/pages/channels/ChannelsPage.tsx:200
+#: src/pages/channels/ChannelsPage.tsx:201
 #: src/pages/library/CustomShowsPage.tsx:105
 #: src/pages/library/FillerListsPage.tsx:115
 msgid "Cancel"
@@ -885,7 +885,7 @@ msgstr "Channel Transcode Config"
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:566
+#: src/pages/channels/ChannelsPage.tsx:567
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr "Channels"
@@ -898,8 +898,8 @@ msgstr "Channels configured to use the HLS Direct stream mode will output in the
 msgid "Channels M3U Link:"
 msgstr "Channels M3U Link:"
 
-#: src/pages/system/SystemDebugPage.tsx:117
-#: src/pages/system/SystemDebugPage.tsx:147
+#: src/pages/system/SystemDebugPage.tsx:119
+#: src/pages/system/SystemDebugPage.tsx:149
 msgid "Check"
 msgstr "Check"
 
@@ -1057,9 +1057,9 @@ msgstr "Copied Channel ID!"
 msgid "Copied to clipboard!"
 msgstr "Copied to clipboard!"
 
-#: src/pages/system/SystemDebugPage.tsx:109
-#: src/pages/system/SystemDebugPage.tsx:139
-#: src/pages/system/SystemDebugPage.tsx:170
+#: src/pages/system/SystemDebugPage.tsx:111
+#: src/pages/system/SystemDebugPage.tsx:141
+#: src/pages/system/SystemDebugPage.tsx:172
 msgid "Copy"
 msgstr "Copy"
 
@@ -1104,7 +1104,7 @@ msgstr "Create Rerun Block"
 msgid "Creates a new collection"
 msgstr "Creates a new collection"
 
-#: src/components/guide/TvGuide.tsx:207
+#: src/components/guide/TvGuide.tsx:208
 msgid "Custom Program"
 msgstr "Custom Program"
 
@@ -1200,7 +1200,7 @@ msgstr "Default Config"
 #: src/components/DeleteConfirmationDialog.tsx:59
 #: src/components/settings/ffmpeg/TranscodeConfigsTable.tsx:75
 #: src/components/smart_collections/SmartCollectionsTable.tsx:124
-#: src/pages/channels/ChannelsPage.tsx:206
+#: src/pages/channels/ChannelsPage.tsx:207
 #: src/pages/library/CustomShowsPage.tsx:113
 #: src/pages/library/CustomShowsPage.tsx:132
 #: src/pages/library/FillerListsPage.tsx:123
@@ -1214,7 +1214,7 @@ msgid "Delete \"{0}\""
 msgstr "Delete \"{0}\""
 
 #: src/components/channels/ChannelOptionsMenu.tsx:225
-#: src/pages/channels/ChannelsPage.tsx:185
+#: src/pages/channels/ChannelsPage.tsx:186
 msgid "Delete Channel"
 msgstr "Delete Channel"
 
@@ -1255,7 +1255,7 @@ msgid "Delete Transcoding Config \"{0}\"?"
 msgstr "Delete Transcoding Config \"{0}\"?"
 
 #: src/components/channels/ChannelDeleteDialog.tsx:72
-#: src/pages/channels/ChannelsPage.tsx:189
+#: src/pages/channels/ChannelsPage.tsx:190
 msgid "Deleting a Channel will remove all programming from the channel. This action cannot be undone."
 msgstr "Deleting a Channel will remove all programming from the channel. This action cannot be undone."
 
@@ -1287,7 +1287,7 @@ msgstr "Descending"
 msgid "Description"
 msgstr "Description"
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:223
+#: src/components/channels/ChannelNowPlayingCard.tsx:226
 msgid "Details"
 msgstr "Details"
 
@@ -1389,7 +1389,7 @@ msgstr "Duplicates"
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:346
+#: src/pages/channels/ChannelsPage.tsx:347
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr "Duration"
@@ -1435,7 +1435,7 @@ msgstr "Edit Channel"
 msgid "Edit Channel Redirect"
 msgstr "Edit Channel Redirect"
 
-#: src/pages/channels/ChannelsPage.tsx:236
+#: src/pages/channels/ChannelsPage.tsx:237
 msgid "Edit Channel Settings"
 msgstr "Edit Channel Settings"
 
@@ -1602,8 +1602,8 @@ msgstr "Enter your Jellyfin password to generate a new access token.<0/><1>NOTE:
 msgid "EPG"
 msgstr "EPG"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:122
-#: src/pages/settings/XmlTvSettingsPage.tsx:125
+#: src/pages/settings/XmlTvSettingsPage.tsx:123
+#: src/pages/settings/XmlTvSettingsPage.tsx:126
 msgid "EPG (Hours)"
 msgstr "EPG (Hours)"
 
@@ -2063,7 +2063,7 @@ msgstr "How frequently libraries should be scanned (starting from midnight)."
 msgid "How long each commercial break lasts"
 msgstr "How long each commercial break lasts"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:138
 msgid "How often the XMLTV file is regenerated"
 msgstr "How often the XMLTV file is regenerated"
 
@@ -2079,11 +2079,11 @@ msgstr "HW Accel"
 msgid "HW Acceleration"
 msgstr "HW Acceleration"
 
-#: src/pages/channels/ChannelsPage.tsx:314
+#: src/pages/channels/ChannelsPage.tsx:315
 msgid "Icon"
 msgstr "Icon"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:165
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 
@@ -2580,7 +2580,7 @@ msgstr "Must use a valid URL, or empty."
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:337
+#: src/pages/channels/ChannelsPage.tsx:338
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr "never"
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:573
+#: src/pages/channels/ChannelsPage.tsx:574
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2655,8 +2655,8 @@ msgstr "Next run"
 msgid "Next Scheduled Execution"
 msgstr "Next Scheduled Execution"
 
-#: src/pages/channels/ChannelsPage.tsx:272
-#: src/pages/channels/ChannelsPage.tsx:403
+#: src/pages/channels/ChannelsPage.tsx:273
+#: src/pages/channels/ChannelsPage.tsx:404
 msgid "No active sessions"
 msgstr "No active sessions"
 
@@ -2672,11 +2672,11 @@ msgstr "No Media Sources detected."
 msgid "No programming added yet"
 msgstr "No programming added yet"
 
-#: src/components/guide/TvGuide.tsx:377
+#: src/components/guide/TvGuide.tsx:378
 msgid "No Programming scheduled"
 msgstr "No Programming scheduled"
 
-#: src/components/guide/TvGuide.tsx:354
+#: src/components/guide/TvGuide.tsx:355
 msgid "No programming scheduled for this time period"
 msgstr "No programming scheduled for this time period"
 
@@ -2721,15 +2721,15 @@ msgstr "Not a valid URL"
 msgid "Not found!"
 msgstr "Not found!"
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:208
+#: src/components/channels/ChannelNowPlayingCard.tsx:211
 msgid "Now Playing:"
 msgstr "Now Playing:"
 
-#: src/pages/channels/ChannelsPage.tsx:331
+#: src/pages/channels/ChannelsPage.tsx:332
 msgid "Number"
 msgstr "Number"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:127
 msgid "Number of hours to include in the XMLTV file"
 msgstr "Number of hours to include in the XMLTV file"
 
@@ -2738,7 +2738,7 @@ msgstr "Number of hours to include in the XMLTV file"
 msgid "Number of Replications"
 msgstr "Number of Replications"
 
-#: src/pages/system/SystemDebugPage.tsx:102
+#: src/pages/system/SystemDebugPage.tsx:104
 msgid "Nvidia Capabilities"
 msgstr "Nvidia Capabilities"
 
@@ -2750,7 +2750,7 @@ msgstr "On-Demand"
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 
-#: src/pages/channels/ChannelsPage.tsx:365
+#: src/pages/channels/ChannelsPage.tsx:366
 msgid "On-Demand?"
 msgstr "On-Demand?"
 
@@ -2808,7 +2808,7 @@ msgid "Other Videos"
 msgstr "Other Videos"
 
 #: src/components/settings/general/BackupForm.tsx:76
-#: src/pages/settings/XmlTvSettingsPage.tsx:90
+#: src/pages/settings/XmlTvSettingsPage.tsx:91
 msgid "Output Path"
 msgstr "Output Path"
 
@@ -3090,7 +3090,7 @@ msgid "Redirect to \"{0}\""
 msgstr "Redirect to \"{0}\""
 
 #. placeholder {0}: p.channel
-#: src/components/guide/TvGuide.tsx:208
+#: src/components/guide/TvGuide.tsx:209
 msgid "Redirect to Channel {0}"
 msgstr "Redirect to Channel {0}"
 
@@ -3111,8 +3111,8 @@ msgstr "Refresh Page"
 msgid "Refresh Preview"
 msgstr "Refresh Preview"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:133
-#: src/pages/settings/XmlTvSettingsPage.tsx:136
+#: src/pages/settings/XmlTvSettingsPage.tsx:134
+#: src/pages/settings/XmlTvSettingsPage.tsx:137
 msgid "Refresh Timer (Hours)"
 msgstr "Refresh Timer (Hours)"
 
@@ -3229,7 +3229,7 @@ msgstr "Reset"
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:208
+#: src/pages/settings/XmlTvSettingsPage.tsx:209
 msgid "Reset Changes"
 msgstr "Reset Changes"
 
@@ -3262,7 +3262,7 @@ msgid "Restore default logo"
 msgstr "Restore default logo"
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:190
+#: src/pages/settings/XmlTvSettingsPage.tsx:191
 msgid "Restore Default Settings"
 msgstr "Restore Default Settings"
 
@@ -3344,7 +3344,7 @@ msgstr "Sample rate cannot be changed when copying input audio"
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:218
+#: src/pages/settings/XmlTvSettingsPage.tsx:219
 msgid "Save"
 msgstr "Save"
 
@@ -3499,7 +3499,7 @@ msgstr "Settings"
 #: src/components/settings/general/GeneralSettingsForm.tsx:216
 #: src/pages/settings/FfmpegSettingsPage.tsx:131
 #: src/pages/settings/HdhrSettingsPage.tsx:59
-#: src/pages/settings/XmlTvSettingsPage.tsx:57
+#: src/pages/settings/XmlTvSettingsPage.tsx:58
 msgid "Settings Saved!"
 msgstr "Settings Saved!"
 
@@ -3671,7 +3671,7 @@ msgstr "Start"
 msgid "Start Time"
 msgstr "Start Time"
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:215
+#: src/components/channels/ChannelNowPlayingCard.tsx:218
 msgid "Started {startedAgo} - {remainingTime}remaining"
 msgstr "Started {startedAgo} - {remainingTime}remaining"
 
@@ -3684,7 +3684,7 @@ msgstr "Status"
 msgid "Stealth Mode"
 msgstr "Stealth Mode"
 
-#: src/pages/channels/ChannelsPage.tsx:354
+#: src/pages/channels/ChannelsPage.tsx:355
 msgid "Stealth?"
 msgstr "Stealth?"
 
@@ -3775,7 +3775,7 @@ msgstr "Synced with external playlist"
 msgid "System"
 msgstr "System"
 
-#: src/pages/system/SystemDebugPage.tsx:162
+#: src/pages/system/SystemDebugPage.tsx:164
 msgid "System Environment"
 msgstr "System Environment"
 
@@ -4035,7 +4035,7 @@ msgstr "Total Runtime"
 msgid "Tracks"
 msgstr "Tracks"
 
-#: src/pages/channels/ChannelsPage.tsx:373
+#: src/pages/channels/ChannelsPage.tsx:374
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr "Transcode Config"
@@ -4142,7 +4142,7 @@ msgstr "URL"
 msgid "Use channel default"
 msgstr "Use channel default"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:162
+#: src/pages/settings/XmlTvSettingsPage.tsx:163
 msgid "Use Show Poster"
 msgstr "Use Show Poster"
 
@@ -4163,7 +4163,7 @@ msgstr "Usually slots need to add flex time to ensure that the next slot starts 
 msgid "VA-API Device"
 msgstr "VA-API Device"
 
-#: src/pages/system/SystemDebugPage.tsx:132
+#: src/pages/system/SystemDebugPage.tsx:134
 msgid "VAAPI Capabilities"
 msgstr "VAAPI Capabilities"
 
@@ -4229,7 +4229,7 @@ msgstr "View Full Details"
 
 #. placeholder {0}: capitalize(firstProgram.program.sourceType)
 #. placeholder {0}: capitalize(program.sourceType)
-#: src/components/channels/ChannelNowPlayingCard.tsx:241
+#: src/components/channels/ChannelNowPlayingCard.tsx:244
 #: src/components/ProgramMetadataDialogContent.tsx:144
 msgid "View in {0}"
 msgstr "View in {0}"

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -45,7 +45,7 @@ msgstr "{0, plural, one {# item} other {# items}}"
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:493
+#: src/pages/channels/ChannelsPage.tsx:513
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr "{0, plural, one {# program} other {# programs}}"
 
@@ -67,7 +67,7 @@ msgstr "{0, plural, one {# Selected Item} other {# Selected Items}}"
 
 #. placeholder {0}: sessions.length
 #: src/pages/channels/ChannelsPage.tsx:294
-#: src/pages/channels/ChannelsPage.tsx:424
+#: src/pages/channels/ChannelsPage.tsx:434
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr "{0, plural, one {# session} other {# sessions}}"
 
@@ -210,13 +210,13 @@ msgstr "{minutes, plural, one {# minute} other {# minutes}}"
 msgid "{remainingTime} left"
 msgstr "{remainingTime} left"
 
-#: src/pages/channels/ChannelsPage.tsx:297
-#: src/pages/channels/ChannelsPage.tsx:427
+#: src/pages/channels/ChannelsPage.tsx:303
+#: src/pages/channels/ChannelsPage.tsx:443
 msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr "{totalConnections, plural, one {# connection} other {# connections}}"
 
-#: src/pages/channels/ChannelsPage.tsx:296
-#: src/pages/channels/ChannelsPage.tsx:426
+#: src/pages/channels/ChannelsPage.tsx:301
+#: src/pages/channels/ChannelsPage.tsx:441
 msgid "{totalConnections} total"
 msgstr "{totalConnections} total"
 
@@ -232,7 +232,7 @@ msgstr "* Restart required"
 msgid "# of Programs"
 msgstr "# of Programs"
 
-#: src/pages/channels/ChannelsPage.tsx:343
+#: src/pages/channels/ChannelsPage.tsx:353
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -885,7 +885,7 @@ msgstr "Channel Transcode Config"
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:567
+#: src/pages/channels/ChannelsPage.tsx:592
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr "Channels"
@@ -1389,7 +1389,7 @@ msgstr "Duplicates"
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:347
+#: src/pages/channels/ChannelsPage.tsx:357
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr "Duration"
@@ -1602,8 +1602,8 @@ msgstr "Enter your Jellyfin password to generate a new access token.<0/><1>NOTE:
 msgid "EPG"
 msgstr "EPG"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:123
 #: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:129
 msgid "EPG (Hours)"
 msgstr "EPG (Hours)"
 
@@ -2063,7 +2063,7 @@ msgstr "How frequently libraries should be scanned (starting from midnight)."
 msgid "How long each commercial break lasts"
 msgstr "How long each commercial break lasts"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:138
+#: src/pages/settings/XmlTvSettingsPage.tsx:141
 msgid "How often the XMLTV file is regenerated"
 msgstr "How often the XMLTV file is regenerated"
 
@@ -2079,11 +2079,11 @@ msgstr "HW Accel"
 msgid "HW Acceleration"
 msgstr "HW Acceleration"
 
-#: src/pages/channels/ChannelsPage.tsx:315
+#: src/pages/channels/ChannelsPage.tsx:325
 msgid "Icon"
 msgstr "Icon"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:166
+#: src/pages/settings/XmlTvSettingsPage.tsx:169
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 
@@ -2580,7 +2580,7 @@ msgstr "Must use a valid URL, or empty."
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:338
+#: src/pages/channels/ChannelsPage.tsx:348
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr "never"
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:574
+#: src/pages/channels/ChannelsPage.tsx:599
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2656,7 +2656,7 @@ msgid "Next Scheduled Execution"
 msgstr "Next Scheduled Execution"
 
 #: src/pages/channels/ChannelsPage.tsx:273
-#: src/pages/channels/ChannelsPage.tsx:404
+#: src/pages/channels/ChannelsPage.tsx:414
 msgid "No active sessions"
 msgstr "No active sessions"
 
@@ -2725,11 +2725,11 @@ msgstr "Not found!"
 msgid "Now Playing:"
 msgstr "Now Playing:"
 
-#: src/pages/channels/ChannelsPage.tsx:332
+#: src/pages/channels/ChannelsPage.tsx:342
 msgid "Number"
 msgstr "Number"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:127
+#: src/pages/settings/XmlTvSettingsPage.tsx:130
 msgid "Number of hours to include in the XMLTV file"
 msgstr "Number of hours to include in the XMLTV file"
 
@@ -2750,7 +2750,7 @@ msgstr "On-Demand"
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 
-#: src/pages/channels/ChannelsPage.tsx:366
+#: src/pages/channels/ChannelsPage.tsx:376
 msgid "On-Demand?"
 msgstr "On-Demand?"
 
@@ -3111,8 +3111,8 @@ msgstr "Refresh Page"
 msgid "Refresh Preview"
 msgstr "Refresh Preview"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:134
 #: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:140
 msgid "Refresh Timer (Hours)"
 msgstr "Refresh Timer (Hours)"
 
@@ -3229,7 +3229,7 @@ msgstr "Reset"
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:209
+#: src/pages/settings/XmlTvSettingsPage.tsx:212
 msgid "Reset Changes"
 msgstr "Reset Changes"
 
@@ -3262,7 +3262,7 @@ msgid "Restore default logo"
 msgstr "Restore default logo"
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:191
+#: src/pages/settings/XmlTvSettingsPage.tsx:194
 msgid "Restore Default Settings"
 msgstr "Restore Default Settings"
 
@@ -3344,7 +3344,7 @@ msgstr "Sample rate cannot be changed when copying input audio"
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:219
+#: src/pages/settings/XmlTvSettingsPage.tsx:222
 msgid "Save"
 msgstr "Save"
 
@@ -3684,7 +3684,7 @@ msgstr "Status"
 msgid "Stealth Mode"
 msgstr "Stealth Mode"
 
-#: src/pages/channels/ChannelsPage.tsx:355
+#: src/pages/channels/ChannelsPage.tsx:365
 msgid "Stealth?"
 msgstr "Stealth?"
 
@@ -4035,7 +4035,7 @@ msgstr "Total Runtime"
 msgid "Tracks"
 msgstr "Tracks"
 
-#: src/pages/channels/ChannelsPage.tsx:374
+#: src/pages/channels/ChannelsPage.tsx:384
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr "Transcode Config"
@@ -4142,7 +4142,7 @@ msgstr "URL"
 msgid "Use channel default"
 msgstr "Use channel default"
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:163
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "Use Show Poster"
 msgstr "Use Show Poster"
 

--- a/web/src/locales/es/messages.po
+++ b/web/src/locales/es/messages.po
@@ -45,7 +45,7 @@ msgstr ""
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:492
+#: src/pages/channels/ChannelsPage.tsx:493
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr ""
 
@@ -66,8 +66,8 @@ msgid "{0, plural, one {# Selected Item} other {# Selected Items}}"
 msgstr ""
 
 #. placeholder {0}: sessions.length
-#: src/pages/channels/ChannelsPage.tsx:293
-#: src/pages/channels/ChannelsPage.tsx:423
+#: src/pages/channels/ChannelsPage.tsx:294
+#: src/pages/channels/ChannelsPage.tsx:424
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
@@ -206,17 +206,17 @@ msgstr ""
 msgid "{minutes, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:337
+#: src/components/guide/TvGuide.tsx:338
 msgid "{remainingTime} left"
+msgstr ""
+
+#: src/pages/channels/ChannelsPage.tsx:297
+#: src/pages/channels/ChannelsPage.tsx:427
+msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr ""
 
 #: src/pages/channels/ChannelsPage.tsx:296
 #: src/pages/channels/ChannelsPage.tsx:426
-msgid "{totalConnections, plural, one {# connection} other {# connections}}"
-msgstr ""
-
-#: src/pages/channels/ChannelsPage.tsx:295
-#: src/pages/channels/ChannelsPage.tsx:425
 msgid "{totalConnections} total"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "# of Programs"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:342
+#: src/pages/channels/ChannelsPage.tsx:343
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -265,7 +265,7 @@ msgid "<0>Pad Slot:</0> Align slot start times to the specified pad time.<1/><2>
 msgstr ""
 
 #. placeholder {0}: new URL( '/api/xmltv.xml', isEmpty(backendUri) ? document.location.href : backendUri, ).href
-#: src/pages/settings/XmlTvSettingsPage.tsx:96
+#: src/pages/settings/XmlTvSettingsPage.tsx:97
 msgid "<0>You can edit this location in your settings.json within your Tunarr data directory<1/><2>NOTE:</2> When manually adding the XMLTV location to a client like Plex, do not use this file directly. Instead, use the generated XMLTV from the Tunarr API endpoint: {0}</0>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgid "Amount"
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/components/guide/TvGuide.tsx:579
+#: src/components/guide/TvGuide.tsx:580
 msgid "An error occurred: {0}"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:189
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:114
-#: src/pages/channels/ChannelsPage.tsx:200
+#: src/pages/channels/ChannelsPage.tsx:201
 #: src/pages/library/CustomShowsPage.tsx:105
 #: src/pages/library/FillerListsPage.tsx:115
 msgid "Cancel"
@@ -885,7 +885,7 @@ msgstr ""
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:566
+#: src/pages/channels/ChannelsPage.tsx:567
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr ""
@@ -898,8 +898,8 @@ msgstr ""
 msgid "Channels M3U Link:"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:117
-#: src/pages/system/SystemDebugPage.tsx:147
+#: src/pages/system/SystemDebugPage.tsx:119
+#: src/pages/system/SystemDebugPage.tsx:149
 msgid "Check"
 msgstr ""
 
@@ -1057,9 +1057,9 @@ msgstr ""
 msgid "Copied to clipboard!"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:109
-#: src/pages/system/SystemDebugPage.tsx:139
-#: src/pages/system/SystemDebugPage.tsx:170
+#: src/pages/system/SystemDebugPage.tsx:111
+#: src/pages/system/SystemDebugPage.tsx:141
+#: src/pages/system/SystemDebugPage.tsx:172
 msgid "Copy"
 msgstr ""
 
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Creates a new collection"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:207
+#: src/components/guide/TvGuide.tsx:208
 msgid "Custom Program"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr ""
 #: src/components/DeleteConfirmationDialog.tsx:59
 #: src/components/settings/ffmpeg/TranscodeConfigsTable.tsx:75
 #: src/components/smart_collections/SmartCollectionsTable.tsx:124
-#: src/pages/channels/ChannelsPage.tsx:206
+#: src/pages/channels/ChannelsPage.tsx:207
 #: src/pages/library/CustomShowsPage.tsx:113
 #: src/pages/library/CustomShowsPage.tsx:132
 #: src/pages/library/FillerListsPage.tsx:123
@@ -1214,7 +1214,7 @@ msgid "Delete \"{0}\""
 msgstr ""
 
 #: src/components/channels/ChannelOptionsMenu.tsx:225
-#: src/pages/channels/ChannelsPage.tsx:185
+#: src/pages/channels/ChannelsPage.tsx:186
 msgid "Delete Channel"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgid "Delete Transcoding Config \"{0}\"?"
 msgstr ""
 
 #: src/components/channels/ChannelDeleteDialog.tsx:72
-#: src/pages/channels/ChannelsPage.tsx:189
+#: src/pages/channels/ChannelsPage.tsx:190
 msgid "Deleting a Channel will remove all programming from the channel. This action cannot be undone."
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:223
+#: src/components/channels/ChannelNowPlayingCard.tsx:226
 msgid "Details"
 msgstr ""
 
@@ -1389,7 +1389,7 @@ msgstr ""
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:346
+#: src/pages/channels/ChannelsPage.tsx:347
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr ""
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Edit Channel Redirect"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:236
+#: src/pages/channels/ChannelsPage.tsx:237
 msgid "Edit Channel Settings"
 msgstr ""
 
@@ -1602,8 +1602,8 @@ msgstr ""
 msgid "EPG"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:122
-#: src/pages/settings/XmlTvSettingsPage.tsx:125
+#: src/pages/settings/XmlTvSettingsPage.tsx:123
+#: src/pages/settings/XmlTvSettingsPage.tsx:126
 msgid "EPG (Hours)"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "How long each commercial break lasts"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:138
 msgid "How often the XMLTV file is regenerated"
 msgstr ""
 
@@ -2079,11 +2079,11 @@ msgstr ""
 msgid "HW Acceleration"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:314
+#: src/pages/channels/ChannelsPage.tsx:315
 msgid "Icon"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:165
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:337
+#: src/pages/channels/ChannelsPage.tsx:338
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr ""
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:573
+#: src/pages/channels/ChannelsPage.tsx:574
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2655,8 +2655,8 @@ msgstr ""
 msgid "Next Scheduled Execution"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:272
-#: src/pages/channels/ChannelsPage.tsx:403
+#: src/pages/channels/ChannelsPage.tsx:273
+#: src/pages/channels/ChannelsPage.tsx:404
 msgid "No active sessions"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "No programming added yet"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:377
+#: src/components/guide/TvGuide.tsx:378
 msgid "No Programming scheduled"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:354
+#: src/components/guide/TvGuide.tsx:355
 msgid "No programming scheduled for this time period"
 msgstr ""
 
@@ -2721,15 +2721,15 @@ msgstr ""
 msgid "Not found!"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:208
+#: src/components/channels/ChannelNowPlayingCard.tsx:211
 msgid "Now Playing:"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:331
+#: src/pages/channels/ChannelsPage.tsx:332
 msgid "Number"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:127
 msgid "Number of hours to include in the XMLTV file"
 msgstr ""
 
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Number of Replications"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:102
+#: src/pages/system/SystemDebugPage.tsx:104
 msgid "Nvidia Capabilities"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:365
+#: src/pages/channels/ChannelsPage.tsx:366
 msgid "On-Demand?"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgid "Other Videos"
 msgstr ""
 
 #: src/components/settings/general/BackupForm.tsx:76
-#: src/pages/settings/XmlTvSettingsPage.tsx:90
+#: src/pages/settings/XmlTvSettingsPage.tsx:91
 msgid "Output Path"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgid "Redirect to \"{0}\""
 msgstr ""
 
 #. placeholder {0}: p.channel
-#: src/components/guide/TvGuide.tsx:208
+#: src/components/guide/TvGuide.tsx:209
 msgid "Redirect to Channel {0}"
 msgstr ""
 
@@ -3109,8 +3109,8 @@ msgstr ""
 msgid "Refresh Preview"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:133
-#: src/pages/settings/XmlTvSettingsPage.tsx:136
+#: src/pages/settings/XmlTvSettingsPage.tsx:134
+#: src/pages/settings/XmlTvSettingsPage.tsx:137
 msgid "Refresh Timer (Hours)"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:208
+#: src/pages/settings/XmlTvSettingsPage.tsx:209
 msgid "Reset Changes"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgid "Restore default logo"
 msgstr ""
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:190
+#: src/pages/settings/XmlTvSettingsPage.tsx:191
 msgid "Restore Default Settings"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:218
+#: src/pages/settings/XmlTvSettingsPage.tsx:219
 msgid "Save"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 #: src/components/settings/general/GeneralSettingsForm.tsx:216
 #: src/pages/settings/FfmpegSettingsPage.tsx:131
 #: src/pages/settings/HdhrSettingsPage.tsx:59
-#: src/pages/settings/XmlTvSettingsPage.tsx:57
+#: src/pages/settings/XmlTvSettingsPage.tsx:58
 msgid "Settings Saved!"
 msgstr ""
 
@@ -3669,7 +3669,7 @@ msgstr ""
 msgid "Start Time"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:215
+#: src/components/channels/ChannelNowPlayingCard.tsx:218
 msgid "Started {startedAgo} - {remainingTime}remaining"
 msgstr ""
 
@@ -3682,7 +3682,7 @@ msgstr ""
 msgid "Stealth Mode"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:354
+#: src/pages/channels/ChannelsPage.tsx:355
 msgid "Stealth?"
 msgstr ""
 
@@ -3773,7 +3773,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:162
+#: src/pages/system/SystemDebugPage.tsx:164
 msgid "System Environment"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "Tracks"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:373
+#: src/pages/channels/ChannelsPage.tsx:374
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr ""
@@ -4140,7 +4140,7 @@ msgstr ""
 msgid "Use channel default"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:162
+#: src/pages/settings/XmlTvSettingsPage.tsx:163
 msgid "Use Show Poster"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "VA-API Device"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:132
+#: src/pages/system/SystemDebugPage.tsx:134
 msgid "VAAPI Capabilities"
 msgstr ""
 
@@ -4227,7 +4227,7 @@ msgstr ""
 
 #. placeholder {0}: capitalize(firstProgram.program.sourceType)
 #. placeholder {0}: capitalize(program.sourceType)
-#: src/components/channels/ChannelNowPlayingCard.tsx:241
+#: src/components/channels/ChannelNowPlayingCard.tsx:244
 #: src/components/ProgramMetadataDialogContent.tsx:144
 msgid "View in {0}"
 msgstr ""

--- a/web/src/locales/es/messages.po
+++ b/web/src/locales/es/messages.po
@@ -45,7 +45,7 @@ msgstr ""
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:493
+#: src/pages/channels/ChannelsPage.tsx:513
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr ""
 
@@ -67,7 +67,7 @@ msgstr ""
 
 #. placeholder {0}: sessions.length
 #: src/pages/channels/ChannelsPage.tsx:294
-#: src/pages/channels/ChannelsPage.tsx:424
+#: src/pages/channels/ChannelsPage.tsx:434
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
@@ -210,13 +210,13 @@ msgstr ""
 msgid "{remainingTime} left"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:297
-#: src/pages/channels/ChannelsPage.tsx:427
+#: src/pages/channels/ChannelsPage.tsx:303
+#: src/pages/channels/ChannelsPage.tsx:443
 msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:296
-#: src/pages/channels/ChannelsPage.tsx:426
+#: src/pages/channels/ChannelsPage.tsx:301
+#: src/pages/channels/ChannelsPage.tsx:441
 msgid "{totalConnections} total"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "# of Programs"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:343
+#: src/pages/channels/ChannelsPage.tsx:353
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -885,7 +885,7 @@ msgstr ""
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:567
+#: src/pages/channels/ChannelsPage.tsx:592
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr ""
@@ -1389,7 +1389,7 @@ msgstr ""
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:347
+#: src/pages/channels/ChannelsPage.tsx:357
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr ""
@@ -1602,8 +1602,8 @@ msgstr ""
 msgid "EPG"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:123
 #: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:129
 msgid "EPG (Hours)"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "How long each commercial break lasts"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:138
+#: src/pages/settings/XmlTvSettingsPage.tsx:141
 msgid "How often the XMLTV file is regenerated"
 msgstr ""
 
@@ -2079,11 +2079,11 @@ msgstr ""
 msgid "HW Acceleration"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:315
+#: src/pages/channels/ChannelsPage.tsx:325
 msgid "Icon"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:166
+#: src/pages/settings/XmlTvSettingsPage.tsx:169
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:338
+#: src/pages/channels/ChannelsPage.tsx:348
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr ""
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:574
+#: src/pages/channels/ChannelsPage.tsx:599
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2656,7 +2656,7 @@ msgid "Next Scheduled Execution"
 msgstr ""
 
 #: src/pages/channels/ChannelsPage.tsx:273
-#: src/pages/channels/ChannelsPage.tsx:404
+#: src/pages/channels/ChannelsPage.tsx:414
 msgid "No active sessions"
 msgstr ""
 
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Now Playing:"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:332
+#: src/pages/channels/ChannelsPage.tsx:342
 msgid "Number"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:127
+#: src/pages/settings/XmlTvSettingsPage.tsx:130
 msgid "Number of hours to include in the XMLTV file"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:366
+#: src/pages/channels/ChannelsPage.tsx:376
 msgid "On-Demand?"
 msgstr ""
 
@@ -3109,8 +3109,8 @@ msgstr ""
 msgid "Refresh Preview"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:134
 #: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:140
 msgid "Refresh Timer (Hours)"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:209
+#: src/pages/settings/XmlTvSettingsPage.tsx:212
 msgid "Reset Changes"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgid "Restore default logo"
 msgstr ""
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:191
+#: src/pages/settings/XmlTvSettingsPage.tsx:194
 msgid "Restore Default Settings"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:219
+#: src/pages/settings/XmlTvSettingsPage.tsx:222
 msgid "Save"
 msgstr ""
 
@@ -3682,7 +3682,7 @@ msgstr ""
 msgid "Stealth Mode"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:355
+#: src/pages/channels/ChannelsPage.tsx:365
 msgid "Stealth?"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "Tracks"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:374
+#: src/pages/channels/ChannelsPage.tsx:384
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr ""
@@ -4140,7 +4140,7 @@ msgstr ""
 msgid "Use channel default"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:163
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "Use Show Poster"
 msgstr ""
 

--- a/web/src/locales/pseudo-LOCALE/messages.po
+++ b/web/src/locales/pseudo-LOCALE/messages.po
@@ -45,7 +45,7 @@ msgstr ""
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:492
+#: src/pages/channels/ChannelsPage.tsx:493
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr ""
 
@@ -66,8 +66,8 @@ msgid "{0, plural, one {# Selected Item} other {# Selected Items}}"
 msgstr ""
 
 #. placeholder {0}: sessions.length
-#: src/pages/channels/ChannelsPage.tsx:293
-#: src/pages/channels/ChannelsPage.tsx:423
+#: src/pages/channels/ChannelsPage.tsx:294
+#: src/pages/channels/ChannelsPage.tsx:424
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
@@ -206,17 +206,17 @@ msgstr ""
 msgid "{minutes, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:337
+#: src/components/guide/TvGuide.tsx:338
 msgid "{remainingTime} left"
+msgstr ""
+
+#: src/pages/channels/ChannelsPage.tsx:297
+#: src/pages/channels/ChannelsPage.tsx:427
+msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr ""
 
 #: src/pages/channels/ChannelsPage.tsx:296
 #: src/pages/channels/ChannelsPage.tsx:426
-msgid "{totalConnections, plural, one {# connection} other {# connections}}"
-msgstr ""
-
-#: src/pages/channels/ChannelsPage.tsx:295
-#: src/pages/channels/ChannelsPage.tsx:425
 msgid "{totalConnections} total"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "# of Programs"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:342
+#: src/pages/channels/ChannelsPage.tsx:343
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -265,7 +265,7 @@ msgid "<0>Pad Slot:</0> Align slot start times to the specified pad time.<1/><2>
 msgstr ""
 
 #. placeholder {0}: new URL( '/api/xmltv.xml', isEmpty(backendUri) ? document.location.href : backendUri, ).href
-#: src/pages/settings/XmlTvSettingsPage.tsx:96
+#: src/pages/settings/XmlTvSettingsPage.tsx:97
 msgid "<0>You can edit this location in your settings.json within your Tunarr data directory<1/><2>NOTE:</2> When manually adding the XMLTV location to a client like Plex, do not use this file directly. Instead, use the generated XMLTV from the Tunarr API endpoint: {0}</0>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgid "Amount"
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/components/guide/TvGuide.tsx:579
+#: src/components/guide/TvGuide.tsx:580
 msgid "An error occurred: {0}"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 #: src/components/slot_scheduler/SlotSchedulerCyclicShuffleDialog.tsx:301
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:189
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:114
-#: src/pages/channels/ChannelsPage.tsx:200
+#: src/pages/channels/ChannelsPage.tsx:201
 #: src/pages/library/CustomShowsPage.tsx:105
 #: src/pages/library/FillerListsPage.tsx:115
 msgid "Cancel"
@@ -885,7 +885,7 @@ msgstr ""
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:566
+#: src/pages/channels/ChannelsPage.tsx:567
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr ""
@@ -898,8 +898,8 @@ msgstr ""
 msgid "Channels M3U Link:"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:117
-#: src/pages/system/SystemDebugPage.tsx:147
+#: src/pages/system/SystemDebugPage.tsx:119
+#: src/pages/system/SystemDebugPage.tsx:149
 msgid "Check"
 msgstr ""
 
@@ -1057,9 +1057,9 @@ msgstr ""
 msgid "Copied to clipboard!"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:109
-#: src/pages/system/SystemDebugPage.tsx:139
-#: src/pages/system/SystemDebugPage.tsx:170
+#: src/pages/system/SystemDebugPage.tsx:111
+#: src/pages/system/SystemDebugPage.tsx:141
+#: src/pages/system/SystemDebugPage.tsx:172
 msgid "Copy"
 msgstr ""
 
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Creates a new collection"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:207
+#: src/components/guide/TvGuide.tsx:208
 msgid "Custom Program"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr ""
 #: src/components/DeleteConfirmationDialog.tsx:59
 #: src/components/settings/ffmpeg/TranscodeConfigsTable.tsx:75
 #: src/components/smart_collections/SmartCollectionsTable.tsx:124
-#: src/pages/channels/ChannelsPage.tsx:206
+#: src/pages/channels/ChannelsPage.tsx:207
 #: src/pages/library/CustomShowsPage.tsx:113
 #: src/pages/library/CustomShowsPage.tsx:132
 #: src/pages/library/FillerListsPage.tsx:123
@@ -1214,7 +1214,7 @@ msgid "Delete \"{0}\""
 msgstr ""
 
 #: src/components/channels/ChannelOptionsMenu.tsx:225
-#: src/pages/channels/ChannelsPage.tsx:185
+#: src/pages/channels/ChannelsPage.tsx:186
 msgid "Delete Channel"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgid "Delete Transcoding Config \"{0}\"?"
 msgstr ""
 
 #: src/components/channels/ChannelDeleteDialog.tsx:72
-#: src/pages/channels/ChannelsPage.tsx:189
+#: src/pages/channels/ChannelsPage.tsx:190
 msgid "Deleting a Channel will remove all programming from the channel. This action cannot be undone."
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:223
+#: src/components/channels/ChannelNowPlayingCard.tsx:226
 msgid "Details"
 msgstr ""
 
@@ -1389,7 +1389,7 @@ msgstr ""
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:346
+#: src/pages/channels/ChannelsPage.tsx:347
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr ""
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Edit Channel Redirect"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:236
+#: src/pages/channels/ChannelsPage.tsx:237
 msgid "Edit Channel Settings"
 msgstr ""
 
@@ -1602,8 +1602,8 @@ msgstr ""
 msgid "EPG"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:122
-#: src/pages/settings/XmlTvSettingsPage.tsx:125
+#: src/pages/settings/XmlTvSettingsPage.tsx:123
+#: src/pages/settings/XmlTvSettingsPage.tsx:126
 msgid "EPG (Hours)"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "How long each commercial break lasts"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:138
 msgid "How often the XMLTV file is regenerated"
 msgstr ""
 
@@ -2079,11 +2079,11 @@ msgstr ""
 msgid "HW Acceleration"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:314
+#: src/pages/channels/ChannelsPage.tsx:315
 msgid "Icon"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:165
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:337
+#: src/pages/channels/ChannelsPage.tsx:338
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr ""
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:573
+#: src/pages/channels/ChannelsPage.tsx:574
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2655,8 +2655,8 @@ msgstr ""
 msgid "Next Scheduled Execution"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:272
-#: src/pages/channels/ChannelsPage.tsx:403
+#: src/pages/channels/ChannelsPage.tsx:273
+#: src/pages/channels/ChannelsPage.tsx:404
 msgid "No active sessions"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "No programming added yet"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:377
+#: src/components/guide/TvGuide.tsx:378
 msgid "No Programming scheduled"
 msgstr ""
 
-#: src/components/guide/TvGuide.tsx:354
+#: src/components/guide/TvGuide.tsx:355
 msgid "No programming scheduled for this time period"
 msgstr ""
 
@@ -2721,15 +2721,15 @@ msgstr ""
 msgid "Not found!"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:208
+#: src/components/channels/ChannelNowPlayingCard.tsx:211
 msgid "Now Playing:"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:331
+#: src/pages/channels/ChannelsPage.tsx:332
 msgid "Number"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:127
 msgid "Number of hours to include in the XMLTV file"
 msgstr ""
 
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Number of Replications"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:102
+#: src/pages/system/SystemDebugPage.tsx:104
 msgid "Nvidia Capabilities"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:365
+#: src/pages/channels/ChannelsPage.tsx:366
 msgid "On-Demand?"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgid "Other Videos"
 msgstr ""
 
 #: src/components/settings/general/BackupForm.tsx:76
-#: src/pages/settings/XmlTvSettingsPage.tsx:90
+#: src/pages/settings/XmlTvSettingsPage.tsx:91
 msgid "Output Path"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgid "Redirect to \"{0}\""
 msgstr ""
 
 #. placeholder {0}: p.channel
-#: src/components/guide/TvGuide.tsx:208
+#: src/components/guide/TvGuide.tsx:209
 msgid "Redirect to Channel {0}"
 msgstr ""
 
@@ -3109,8 +3109,8 @@ msgstr ""
 msgid "Refresh Preview"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:133
-#: src/pages/settings/XmlTvSettingsPage.tsx:136
+#: src/pages/settings/XmlTvSettingsPage.tsx:134
+#: src/pages/settings/XmlTvSettingsPage.tsx:137
 msgid "Refresh Timer (Hours)"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:208
+#: src/pages/settings/XmlTvSettingsPage.tsx:209
 msgid "Reset Changes"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgid "Restore default logo"
 msgstr ""
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:190
+#: src/pages/settings/XmlTvSettingsPage.tsx:191
 msgid "Restore Default Settings"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:218
+#: src/pages/settings/XmlTvSettingsPage.tsx:219
 msgid "Save"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 #: src/components/settings/general/GeneralSettingsForm.tsx:216
 #: src/pages/settings/FfmpegSettingsPage.tsx:131
 #: src/pages/settings/HdhrSettingsPage.tsx:59
-#: src/pages/settings/XmlTvSettingsPage.tsx:57
+#: src/pages/settings/XmlTvSettingsPage.tsx:58
 msgid "Settings Saved!"
 msgstr ""
 
@@ -3669,7 +3669,7 @@ msgstr ""
 msgid "Start Time"
 msgstr ""
 
-#: src/components/channels/ChannelNowPlayingCard.tsx:215
+#: src/components/channels/ChannelNowPlayingCard.tsx:218
 msgid "Started {startedAgo} - {remainingTime}remaining"
 msgstr ""
 
@@ -3682,7 +3682,7 @@ msgstr ""
 msgid "Stealth Mode"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:354
+#: src/pages/channels/ChannelsPage.tsx:355
 msgid "Stealth?"
 msgstr ""
 
@@ -3773,7 +3773,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:162
+#: src/pages/system/SystemDebugPage.tsx:164
 msgid "System Environment"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "Tracks"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:373
+#: src/pages/channels/ChannelsPage.tsx:374
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr ""
@@ -4140,7 +4140,7 @@ msgstr ""
 msgid "Use channel default"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:162
+#: src/pages/settings/XmlTvSettingsPage.tsx:163
 msgid "Use Show Poster"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "VA-API Device"
 msgstr ""
 
-#: src/pages/system/SystemDebugPage.tsx:132
+#: src/pages/system/SystemDebugPage.tsx:134
 msgid "VAAPI Capabilities"
 msgstr ""
 
@@ -4227,7 +4227,7 @@ msgstr ""
 
 #. placeholder {0}: capitalize(firstProgram.program.sourceType)
 #. placeholder {0}: capitalize(program.sourceType)
-#: src/components/channels/ChannelNowPlayingCard.tsx:241
+#: src/components/channels/ChannelNowPlayingCard.tsx:244
 #: src/components/ProgramMetadataDialogContent.tsx:144
 msgid "View in {0}"
 msgstr ""

--- a/web/src/locales/pseudo-LOCALE/messages.po
+++ b/web/src/locales/pseudo-LOCALE/messages.po
@@ -45,7 +45,7 @@ msgstr ""
 #. placeholder {0}: value?.programCount ?? 0
 #: src/components/channel_config/ChannelLineupList.tsx:525
 #: src/components/slot_scheduler/FillerListSlotProgrammingForm.tsx:47
-#: src/pages/channels/ChannelsPage.tsx:493
+#: src/pages/channels/ChannelsPage.tsx:513
 msgid "{0, plural, one {# program} other {# programs}}"
 msgstr ""
 
@@ -67,7 +67,7 @@ msgstr ""
 
 #. placeholder {0}: sessions.length
 #: src/pages/channels/ChannelsPage.tsx:294
-#: src/pages/channels/ChannelsPage.tsx:424
+#: src/pages/channels/ChannelsPage.tsx:434
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
@@ -210,13 +210,13 @@ msgstr ""
 msgid "{remainingTime} left"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:297
-#: src/pages/channels/ChannelsPage.tsx:427
+#: src/pages/channels/ChannelsPage.tsx:303
+#: src/pages/channels/ChannelsPage.tsx:443
 msgid "{totalConnections, plural, one {# connection} other {# connections}}"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:296
-#: src/pages/channels/ChannelsPage.tsx:426
+#: src/pages/channels/ChannelsPage.tsx:301
+#: src/pages/channels/ChannelsPage.tsx:441
 msgid "{totalConnections} total"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "# of Programs"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:343
+#: src/pages/channels/ChannelsPage.tsx:353
 #: src/pages/library/CustomShowsPage.tsx:160
 #: src/pages/library/FillerListsPage.tsx:166
 msgid "# Programs"
@@ -885,7 +885,7 @@ msgstr ""
 #: src/App.tsx:95
 #: src/hooks/useNavItems.tsx:63
 #: src/hooks/useRouteName.ts:38
-#: src/pages/channels/ChannelsPage.tsx:567
+#: src/pages/channels/ChannelsPage.tsx:592
 #: src/pages/system/TroubleshootPage.tsx:636
 msgid "Channels"
 msgstr ""
@@ -1389,7 +1389,7 @@ msgstr ""
 #: src/components/programming_controls/BalanceProgrammingModal.tsx:62
 #: src/components/slot_scheduler/EditRandomSlotDialogContent.tsx:466
 #: src/components/slot_scheduler/RandomSlotTable.tsx:233
-#: src/pages/channels/ChannelsPage.tsx:347
+#: src/pages/channels/ChannelsPage.tsx:357
 #: src/pages/system/TroubleshootPage.tsx:521
 msgid "Duration"
 msgstr ""
@@ -1602,8 +1602,8 @@ msgstr ""
 msgid "EPG"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:123
 #: src/pages/settings/XmlTvSettingsPage.tsx:126
+#: src/pages/settings/XmlTvSettingsPage.tsx:129
 msgid "EPG (Hours)"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "How long each commercial break lasts"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:138
+#: src/pages/settings/XmlTvSettingsPage.tsx:141
 msgid "How often the XMLTV file is regenerated"
 msgstr ""
 
@@ -2079,11 +2079,11 @@ msgstr ""
 msgid "HW Acceleration"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:315
+#: src/pages/channels/ChannelsPage.tsx:325
 msgid "Icon"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:166
+#: src/pages/settings/XmlTvSettingsPage.tsx:169
 msgid "If enabled, TV show episodes will use the poster of their show, instead of the individual episode poster."
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: src/components/smart_collections/CreateSmartCollectionDialog.tsx:162
 #: src/components/smart_collections/EditSmartCollectionDialog.tsx:108
 #: src/components/smart_collections/SmartCollectionsTable.tsx:59
-#: src/pages/channels/ChannelsPage.tsx:338
+#: src/pages/channels/ChannelsPage.tsx:348
 #: src/pages/library/CustomShowsPage.tsx:146
 #: src/pages/library/FillerListsPage.tsx:162
 #: src/pages/settings/MediaSourceSettingsPage.tsx:82
@@ -2608,7 +2608,7 @@ msgstr ""
 #: src/hooks/useRouteName.ts:51
 #: src/hooks/useRouteName.ts:113
 #: src/hooks/useRouteName.ts:125
-#: src/pages/channels/ChannelsPage.tsx:574
+#: src/pages/channels/ChannelsPage.tsx:599
 #: src/pages/library/CustomShowsPage.tsx:223
 #: src/pages/library/FillerListsPage.tsx:237
 msgid "New"
@@ -2656,7 +2656,7 @@ msgid "Next Scheduled Execution"
 msgstr ""
 
 #: src/pages/channels/ChannelsPage.tsx:273
-#: src/pages/channels/ChannelsPage.tsx:404
+#: src/pages/channels/ChannelsPage.tsx:414
 msgid "No active sessions"
 msgstr ""
 
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Now Playing:"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:332
+#: src/pages/channels/ChannelsPage.tsx:342
 msgid "Number"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:127
+#: src/pages/settings/XmlTvSettingsPage.tsx:130
 msgid "Number of hours to include in the XMLTV file"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "On-Demand channels resume from where you left off. Programming is paused when the channel is not streaming.<0/><1>NOTE:</1> While the channel is inactive, the TV Guide for the channel will be empty."
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:366
+#: src/pages/channels/ChannelsPage.tsx:376
 msgid "On-Demand?"
 msgstr ""
 
@@ -3109,8 +3109,8 @@ msgstr ""
 msgid "Refresh Preview"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:134
 #: src/pages/settings/XmlTvSettingsPage.tsx:137
+#: src/pages/settings/XmlTvSettingsPage.tsx:140
 msgid "Refresh Timer (Hours)"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 #: src/pages/settings/FeaturesSettingsPage.tsx:162
 #: src/pages/settings/FfmpegSettingsPage.tsx:407
 #: src/pages/settings/HdhrSettingsPage.tsx:142
-#: src/pages/settings/XmlTvSettingsPage.tsx:209
+#: src/pages/settings/XmlTvSettingsPage.tsx:212
 msgid "Reset Changes"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgid "Restore default logo"
 msgstr ""
 
 #: src/pages/settings/HdhrSettingsPage.tsx:129
-#: src/pages/settings/XmlTvSettingsPage.tsx:191
+#: src/pages/settings/XmlTvSettingsPage.tsx:194
 msgid "Restore Default Settings"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 #: src/pages/settings/FfmpegSettingsPage.tsx:417
 #: src/pages/settings/HdhrSettingsPage.tsx:152
 #: src/pages/settings/ScannerSettingsPage.tsx:82
-#: src/pages/settings/XmlTvSettingsPage.tsx:219
+#: src/pages/settings/XmlTvSettingsPage.tsx:222
 msgid "Save"
 msgstr ""
 
@@ -3682,7 +3682,7 @@ msgstr ""
 msgid "Stealth Mode"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:355
+#: src/pages/channels/ChannelsPage.tsx:365
 msgid "Stealth?"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "Tracks"
 msgstr ""
 
-#: src/pages/channels/ChannelsPage.tsx:374
+#: src/pages/channels/ChannelsPage.tsx:384
 #: src/pages/system/TroubleshootPage.tsx:844
 msgid "Transcode Config"
 msgstr ""
@@ -4140,7 +4140,7 @@ msgstr ""
 msgid "Use channel default"
 msgstr ""
 
-#: src/pages/settings/XmlTvSettingsPage.tsx:163
+#: src/pages/settings/XmlTvSettingsPage.tsx:166
 msgid "Use Show Poster"
 msgstr ""
 

--- a/web/src/pages/channels/ChannelsPage.tsx
+++ b/web/src/pages/channels/ChannelsPage.tsx
@@ -1,4 +1,5 @@
 import { betterHumanize } from '@/helpers/dayjs.ts';
+import { invalidateTaggedQueries } from '@/helpers/queryUtil.ts';
 import { useTranscodeConfigs } from '@/hooks/settingsHooks.ts';
 import type { Maybe } from '@/types/util.ts';
 import { Plural, Trans, useLingui } from '@lingui/react/macro';
@@ -114,7 +115,7 @@ export default function ChannelsPage() {
       if (ev.type === 'stream') {
         queryClient
           .invalidateQueries({
-            queryKey: ['channels'],
+            predicate: invalidateTaggedQueries('Channels'),
           })
           .catch(console.error);
       }
@@ -161,7 +162,7 @@ export default function ChannelsPage() {
     ...deleteApiChannelsByIdMutation(),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: ['Channels'],
+        predicate: invalidateTaggedQueries('Channels'),
       });
     },
   });
@@ -290,10 +291,20 @@ export default function ChannelsPage() {
               placement="top"
               title={
                 <Box component="span" sx={{ textAlign: 'center' }}>
-                  <Plural value={sessions.length} one="# session" other="# sessions" />
+                  <Plural
+                    value={sessions.length}
+                    one="# session"
+                    other="# sessions"
+                  />
                   <br />
-                  {totalConnections > 1 && <Trans>{totalConnections} total</Trans>}{' '}
-                  <Plural value={totalConnections} one="# connection" other="# connections" />
+                  {totalConnections > 1 && (
+                    <Trans>{totalConnections} total</Trans>
+                  )}{' '}
+                  <Plural
+                    value={totalConnections}
+                    one="# connection"
+                    other="# connections"
+                  />
                 </Box>
               }
             >
@@ -420,10 +431,20 @@ export default function ChannelsPage() {
         placement="top"
         title={
           <Box component="span" sx={{ textAlign: 'center' }}>
-            <Plural value={sessions.length} one="# session" other="# sessions" />
+            <Plural
+              value={sessions.length}
+              one="# session"
+              other="# sessions"
+            />
             <br />
-            {totalConnections > 1 && <Trans>{totalConnections} total</Trans>}{' '}
-            <Plural value={totalConnections} one="# connection" other="# connections" />
+            {totalConnections > 1 && (
+              <Trans>{totalConnections} total</Trans>
+            )}{' '}
+            <Plural
+              value={totalConnections}
+              one="# connection"
+              other="# connections"
+            />
           </Box>
         }
       >
@@ -489,7 +510,12 @@ export default function ChannelsPage() {
                       Ch {channel.number} · {channel.name}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      <Plural value={channel.programCount} one="# program" other="# programs" /> ·{' '}
+                      <Plural
+                        value={channel.programCount}
+                        one="# program"
+                        other="# programs"
+                      />{' '}
+                      ·{' '}
                       {betterHumanize(dayjs.duration(channel.duration), {
                         style: 'short',
                       })}

--- a/web/src/pages/settings/XmlTvSettingsPage.tsx
+++ b/web/src/pages/settings/XmlTvSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useSettings } from '@/store/settings/selectors.ts';
+import { invalidateTaggedQueries } from '@/helpers/queryUtil.ts';
 import { Trans, useLingui } from '@lingui/react/macro';
 import {
   Box,
@@ -60,7 +61,7 @@ export default function XmlTvSettingsPage() {
       setRestoreTunarrDefaults(false);
       reset(data, { keepValues: true });
       return queryClient.invalidateQueries({
-        queryKey: ['settings', 'xmltv-settings'],
+        predicate: invalidateTaggedQueries('Settings'),
       });
     },
   });
@@ -98,13 +99,16 @@ export default function XmlTvSettingsPage() {
                     You can edit this location in your settings.json within your
                     Tunarr data directory
                     <br />
-                    <strong>NOTE:</strong> When manually adding the XMLTV location
-                    to a client like Plex, do not use this file directly. Instead,
-                    use the generated XMLTV from the Tunarr API endpoint:{' '}
+                    <strong>NOTE:</strong> When manually adding the XMLTV
+                    location to a client like Plex, do not use this file
+                    directly. Instead, use the generated XMLTV from the Tunarr
+                    API endpoint:{' '}
                     {
                       new URL(
                         '/api/xmltv.xml',
-                        isEmpty(backendUri) ? document.location.href : backendUri,
+                        isEmpty(backendUri)
+                          ? document.location.href
+                          : backendUri,
                       ).href
                     }
                   </span>

--- a/web/src/pages/system/SystemDebugPage.tsx
+++ b/web/src/pages/system/SystemDebugPage.tsx
@@ -1,4 +1,9 @@
 import { Trans } from '@lingui/react/macro';
+import { invalidateTaggedQueries } from '@/helpers/queryUtil.ts';
+import {
+  getApiSystemDebugNvidiaQueryKey,
+  getApiSystemDebugVaapiQueryKey,
+} from '@/generated/@tanstack/react-query.gen.ts';
 import { CopyAll, Refresh, Search } from '@mui/icons-material';
 import {
   Box,
@@ -43,8 +48,7 @@ export const SystemDebugPage = () => {
       if (ev.type === 'lifecycle') {
         queryClient
           .invalidateQueries({
-            exact: true,
-            queryKey: ['system', 'debug', 'env'],
+            predicate: invalidateTaggedQueries('System'),
           })
           .catch(console.error);
       }
@@ -74,8 +78,7 @@ export const SystemDebugPage = () => {
     } else {
       queryClient
         .invalidateQueries({
-          exact: true,
-          queryKey: ['system', 'debug', 'nvidia'],
+          queryKey: getApiSystemDebugNvidiaQueryKey(),
         })
         .catch(console.error);
     }
@@ -87,8 +90,7 @@ export const SystemDebugPage = () => {
     } else {
       queryClient
         .invalidateQueries({
-          exact: true,
-          queryKey: ['system', 'debug', 'vaapi'],
+          queryKey: getApiSystemDebugVaapiQueryKey(),
         })
         .catch(console.error);
     }


### PR DESCRIPTION
Sweep **S1** from the frontend audit plan — walk every query key used to *register* a query against every key used to *invalidate* one. Eleven sites, one root cause.

## The bug

Generated hey-api query keys are a **single-element array holding an object**:

```ts
getChannelsQueryKey() // -> [{ _id: 'getChannels', baseURL, tags: ['Channels'] }]
```

TanStack Query matches keys by **structural prefix**. A hand-written string key diverges at element 0 — `'Channels'` (string) vs. the key object — so it matches nothing. `invalidateQueries` resolves successfully, logs nothing, and the cache stays stale.

The give-away is the literal `['Channels']`: **`Channels` is the endpoint tag, not a key segment.** `ChannelDeleteDialog.tsx:40` already did this correctly with `getChannelsQueryKey()`, so the app had two channel-delete paths that behaved differently.

## Sites, and what stayed stale

| Site | User-visible consequence |
| --- | --- |
| `useCreateChannel` | New channel absent from `/channels` until manual refresh |
| `ChannelsPage` (delete) | Deleted row stays on screen |
| `ChannelsPage` (stream events) | Live session counts never update |
| `ChannelNowPlayingCard` | Finished program shown indefinitely |
| `XmlTvSettingsPage` | Settings cache stale after save (masked by a local `reset(data)`) |
| `SystemDebugPage` ×3 | env / nvidia / vaapi checks inert on second click; `staleTime` is 1 hour |
| `TvGuide` | Ignores server xmltv-regeneration events |
| `useUpdateLineup` | Lineup queries missed |
| `useScanNow` | Pre-scan metadata retained after "Scan Now" |

`useScanNow` had **two stacked bugs**: its predicate compared a `Query` instance against a key array (TanStack passes `Query`, not the key), and one operand was `getApiProgramsByIdOptions` — an options object, not a key. Both always false.

`TvGuide` carried a `// Gnarly` comment. The author knew.

## The fix

Categorical events invalidate **by tag** via the existing `invalidateTaggedQueries` helper — what the tags exist for, and what sixteen other call sites already do.

Two sites stay key-scoped deliberately:
- **`ChannelNowPlayingCard`** runs a per-card timer 5s after each program ends. A tag would refetch every channel query for every mounted card.
- **The two debug buttons** each re-run exactly one query.

Both still use generated key factories, so neither can silently miss.

## Picking a tag is not automatically safe

The TV Guide fix nearly went out invalidating the **`Guide`** tag. That tag belongs to `/api/guide/channels`, which the TV Guide page never calls — it renders from `getApiChannelsByIdLineup` / `getApiChannelsAllLineups`, tagged **`Channels`**. That would have replaced one dead invalidation with another.

So the tests are table-driven and pin **every site to the query it must refresh**, driving a real `QueryClient` rather than reimplementing TanStack's matcher:

```ts
await client.invalidateQueries({ queryKey: ['Channels'] });
expect(query.state.isInvalidated).toBe(false);   // the old behaviour, proven dead
```

## Test plan

- [x] 14 new tests, all against a real `QueryClient`
- [x] One test proves the old string key does **not** invalidate the query it names
- [x] Table-driven test pins each of the 9 tag-based sites to its target key(s)
- [x] Now-playing test asserts channel `c1` is invalidated and `c2` is not
- [x] Repo sweep: **0** invalidation-side hand-written string keys remain
- [x] Full preflight green: eslint, commitlint, server typecheck, web build, all tests, lingui

## Not included

Two `queryKey: ['settings', …]` and several `['channels', id, 'programs', …]` keys remain, but those are **registration**-side — hand-rolled queries with hand-rolled keys, consistently matched by `invalidateQueryPrefix`. Different pattern, not dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)