### PR TITLE
fix(meilisearch): make downloaded binary executable by non-root users

### DIFF
--- a/server/scripts/download-meilisearch.ts
+++ b/server/scripts/download-meilisearch.ts
@@ -61,7 +61,9 @@ async function addExecPermission(targetPath: string) {
   try {
     const stat = await fs.stat(targetPath);
     const currentMode = stat.mode;
-    await fs.chmod(targetPath, currentMode | 0o100);
+    // Grant exec to owner, group, and other so the binary is runnable when
+    // the container runs as a non-root user (rootless docker, PUID/PGID, etc).
+    await fs.chmod(targetPath, currentMode | 0o111);
   } catch (e) {
     console.error(e, 'Error while trying to chmod +x meilisearch binary');
   }


### PR DESCRIPTION
addExecPermission was OR-ing the current mode with 0o100, which only sets the owner-exec bit. Downloaded meilisearch binaries landed at 744, so containers running as a non-root user (rootless docker, PUID/PGID, etc) crashed at startup with EACCES on spawn.

Fixes one of the non-root user issues reported in #1523

Testing:
```
  cd server

  # bug
  git checkout main
  rm -f bin/meilisearch bin/meilisearch-linux-x64
  pnpm tsx scripts/download-meilisearch.ts
  ls -l bin/meilisearch    # -> -rwxr--r--  (744)

  # fixed
  git checkout fix/meilisearch-exec-permissions
  rm -f bin/meilisearch bin/meilisearch-linux-x64
  pnpm tsx scripts/download-meilisearch.ts
  ls -l bin/meilisearch    # -> -rwxr-xr-x  (755)
  ```