### PR TITLE
fix(server): skip Jellyfin people with empty or missing names

### DIFF
--- a/server/src/external/jellyfin/JellyfinApiClient.test.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.test.ts
@@ -1,0 +1,76 @@
+import type { JellyfinItem as ApiJellyfinItem } from '@tunarr/types/jellyfin';
+import { describe, expect, it } from 'vitest';
+import { getJellyfinItemPersonMap } from './JellyfinApiClient.js';
+
+const mediaSourceUrl = 'http://jellyfin.example';
+
+type JellyfinPersonInput = NonNullable<ApiJellyfinItem['People']>[number];
+
+function person(
+  partial: Partial<JellyfinPersonInput> & Pick<JellyfinPersonInput, 'Id'>,
+): JellyfinPersonInput {
+  return partial as JellyfinPersonInput;
+}
+
+describe('getJellyfinItemPersonMap', () => {
+  it('omits people with empty, whitespace, or missing names', () => {
+    const mapping = getJellyfinItemPersonMap(
+      {
+        People: [
+          person({
+            Id: '1',
+            Name: 'Alice',
+            Type: 'Actor',
+            Role: 'Hero',
+          }),
+          person({ Id: '2', Name: '', Type: 'Actor' }),
+          person({ Id: '3', Type: 'Actor' }),
+          person({ Id: '4', Name: 'Bob', Type: 'Writer' }),
+          person({ Id: '5', Name: '', Type: 'Writer' }),
+          person({ Id: '6', Name: 'Carol', Type: 'Director' }),
+          person({ Id: '7', Name: '   ', Type: 'Director' }),
+        ],
+      } as ApiJellyfinItem,
+      mediaSourceUrl,
+    );
+
+    expect(mapping.actor).toEqual([
+      {
+        name: 'Alice',
+        role: 'Hero',
+        thumb: `${mediaSourceUrl}/Items/1/Images/Primary`,
+        order: 0,
+      },
+    ]);
+    expect(mapping.writer).toEqual([
+      {
+        name: 'Bob',
+        thumb: `${mediaSourceUrl}/Items/4/Images/Primary`,
+      },
+    ]);
+    expect(mapping.director).toEqual([
+      {
+        name: 'Carol',
+        thumb: `${mediaSourceUrl}/Items/6/Images/Primary`,
+      },
+    ]);
+  });
+
+  it('preserves actor order indexes from the unfiltered people list', () => {
+    const mapping = getJellyfinItemPersonMap(
+      {
+        People: [
+          person({ Id: '1', Name: 'Alice', Type: 'Actor' }),
+          person({ Id: '2', Name: '', Type: 'Actor' }),
+          person({ Id: '3', Name: 'Dave', Type: 'Actor' }),
+        ],
+      } as ApiJellyfinItem,
+      mediaSourceUrl,
+    );
+
+    expect(mapping.actor?.map((actor) => [actor.name, actor.order])).toEqual([
+      ['Alice', 0],
+      ['Dave', 2],
+    ]);
+  });
+});

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -1883,7 +1883,8 @@ type PersonMapping = Partial<{
   director: Director[];
 }>;
 
-function getJellyfinItemPersonMap(
+// Exported for testing only
+export function getJellyfinItemPersonMap(
   item: ApiJellyfinItem,
   mediaSourceUrl: string,
 ): PersonMapping {
@@ -1893,41 +1894,44 @@ function getJellyfinItemPersonMap(
     (people, key) => {
       switch (key) {
         case 'actor':
-          mapping[key] = people.map(
-            (person, idx) =>
-              ({
-                name: person.Name,
-                role: person.Role ?? undefined,
-                thumb: new URL(
-                  `/Items/${person.Id}/Images/Primary`,
-                  mediaSourceUrl,
-                ).href,
-                order: idx,
-              }) satisfies Actor,
+          mapping[key] = seq.collect(people, (person, idx) =>
+            isNonEmptyString(person.Name)
+              ? ({
+                  name: person.Name,
+                  role: person.Role ?? undefined,
+                  thumb: new URL(
+                    `/Items/${person.Id}/Images/Primary`,
+                    mediaSourceUrl,
+                  ).href,
+                  order: idx,
+                } satisfies Actor)
+              : null,
           );
           break;
         case 'writer':
-          mapping[key] = people.map(
-            (person) =>
-              ({
-                name: person.Name,
-                thumb: new URL(
-                  `/Items/${person.Id}/Images/Primary`,
-                  mediaSourceUrl,
-                ).href,
-              }) satisfies Writer,
+          mapping[key] = seq.collect(people, (person) =>
+            isNonEmptyString(person.Name)
+              ? ({
+                  name: person.Name,
+                  thumb: new URL(
+                    `/Items/${person.Id}/Images/Primary`,
+                    mediaSourceUrl,
+                  ).href,
+                } satisfies Writer)
+              : null,
           );
           break;
         case 'director': {
-          mapping[key] = people.map(
-            (person) =>
-              ({
-                name: person.Name,
-                thumb: new URL(
-                  `/Items/${person.Id}/Images/Primary`,
-                  mediaSourceUrl,
-                ).href,
-              }) satisfies Director,
+          mapping[key] = seq.collect(people, (person) =>
+            isNonEmptyString(person.Name)
+              ? ({
+                  name: person.Name,
+                  thumb: new URL(
+                    `/Items/${person.Id}/Images/Primary`,
+                    mediaSourceUrl,
+                  ).href,
+                } satisfies Director)
+              : null,
           );
           return;
         }


### PR DESCRIPTION
Fixes #2028

## Summary
- Mirror Emby's empty-name guard in Jellyfin person mapping for actor, writer, and director
- Drop credits with empty, whitespace, or missing `Name` instead of persisting them
- Export `getJellyfinItemPersonMap` for testing and add unit coverage

## Test plan
- [x] `pnpm test src/external/jellyfin/JellyfinApiClient.test.ts` (server)
- [x] `pnpm typecheck` (server)
- [ ] Reviewer: confirm actor/writer/director paths all use the Emby-style filter
