### PR TITLE
docs: honest chrisbenincasa fork notice for tunarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> jediswimmer fork of [chrisbenincasa/tunarr](https://github.com/chrisbenincasa/tunarr). This clone is behind upstream. Not a Titans Rift product. Install and Docker: follow upstream.
+
+`tunarr · fork of chrisbenincasa/tunarr · jediswimmer`
+
 <p align="center">
   <img src="./design/tunarr-guide.png" alt="Tunarr TV Guide">
 </p>


### PR DESCRIPTION
## Summary

Fork-class README pass for `jediswimmer/tunarr`. Honest upstream. No Titans Rift product claim. No banner seam.

Base: `main`. Draft only. House card t_42c6dd2c. No merge.
