### PR TITLE
fix: stop asyncPool from dropping results that settle together

### DIFF
--- a/server/src/services/PlexItemEnumerator.test.ts
+++ b/server/src/services/PlexItemEnumerator.test.ts
@@ -1,0 +1,78 @@
+import { faker } from '@faker-js/faker';
+import type { MediaSourceId } from '@/db/schema/base.js';
+import type { PlexApiClient } from '@/external/plex/PlexApiClient.js';
+import { tag } from '@tunarr/types';
+import type { Movie } from '@tunarr/types';
+import { map, range } from 'lodash-es';
+import { describe, expect, it, vi } from 'vitest';
+import { PlexHierarchyTraversal } from './PlexItemEnumerator.ts';
+
+const { fakeLogger } = vi.hoisted(() => {
+  const fakeLogger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => fakeLogger,
+  };
+  return { fakeLogger };
+});
+
+vi.mock('@/util/logging/LoggerFactory.js', () => ({
+  LoggerFactory: { child: () => fakeLogger, root: fakeLogger },
+}));
+
+function makeMovie(mediaSourceId: MediaSourceId, libraryId: string): Movie {
+  return {
+    uuid: faker.string.uuid(),
+    sourceType: 'plex',
+    type: 'movie',
+    title: faker.word.words(3),
+    originalTitle: null,
+    sortTitle: faker.word.words(3),
+    year: faker.date.past().getFullYear(),
+    releaseDate: null,
+    releaseDateString: null,
+    rating: null,
+    summary: null,
+    plot: null,
+    tagline: null,
+    identifiers: [],
+    tags: [],
+    createdAt: null,
+    artwork: [],
+    state: 'ok',
+    canonicalId: faker.string.uuid(),
+    externalId: faker.string.alphanumeric(10),
+    mediaSourceId,
+    libraryId,
+    duration: faker.number.int({ min: 60_000, max: 7_200_000 }),
+  };
+}
+
+describe('PlexHierarchyTraversal', () => {
+  describe('expandAncestors', () => {
+    // Regression test for #2038: movies need no ancestor lookups, so every
+    // task settled without I/O and the pool handed back only every third one.
+    it('returns every movie in a playlist-sized batch', async () => {
+      const mediaSourceId = tag<MediaSourceId>(faker.string.uuid());
+      const libraryId = faker.string.uuid();
+      const movies = range(0, 40).map(() =>
+        makeMovie(mediaSourceId, libraryId),
+      );
+
+      const plexClient = {
+        getSeason: vi.fn(),
+        getShow: vi.fn(),
+      } as unknown as PlexApiClient;
+
+      const expanded = await new PlexHierarchyTraversal(
+        plexClient,
+      ).expandAncestors(movies);
+
+      expect(map(expanded, 'externalId')).toEqual(map(movies, 'externalId'));
+    });
+  });
+});

--- a/server/src/util/asyncPool.test.ts
+++ b/server/src/util/asyncPool.test.ts
@@ -70,4 +70,18 @@ describe('asyncPool', () => {
     expect(results).toHaveLength(inputs.length);
     expect(peak).toBe(4);
   });
+
+  it(
+    'runs serially rather than spinning when given a non-positive concurrency',
+    { timeout: 5_000 },
+    async () => {
+      const inputs = range(1, 6);
+
+      const results = await unfurlPool(
+        asyncPool(inputs, (n) => Promise.resolve(n), { concurrency: 0 }),
+      );
+
+      expect(results).toEqual(inputs);
+    },
+  );
 });

--- a/server/src/util/asyncPool.test.ts
+++ b/server/src/util/asyncPool.test.ts
@@ -1,0 +1,73 @@
+import { range } from 'lodash-es';
+import { describe, expect, it, vi } from 'vitest';
+import { asyncPool, unfurlPool } from './asyncPool.ts';
+
+const { fakeLogger } = vi.hoisted(() => {
+  const fakeLogger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => fakeLogger,
+  };
+  return { fakeLogger };
+});
+
+vi.mock('@/util/logging/LoggerFactory.js', () => ({
+  LoggerFactory: { child: () => fakeLogger, root: fakeLogger },
+}));
+
+describe('asyncPool', () => {
+  it('yields a result for every input when tasks settle without I/O', async () => {
+    const inputs = range(1, 41);
+
+    const results = await unfurlPool(
+      asyncPool(inputs, (n) => Promise.resolve(n), { concurrency: 3 }),
+    );
+
+    expect(results.sort((a, b) => a - b)).toEqual(inputs);
+  });
+
+  it('yields a failure result for every task that rejects', async () => {
+    const inputs = range(1, 41);
+
+    const outcomes: number[] = [];
+    for await (const result of asyncPool(
+      inputs,
+      (n) => Promise.reject(new Error(`boom ${n}`)),
+      { concurrency: 3 },
+    )) {
+      expect(result.isFailure()).toBe(true);
+      if (result.isFailure()) {
+        outcomes.push(result.error.input);
+      }
+    }
+
+    expect(outcomes.sort((a, b) => a - b)).toEqual(inputs);
+  });
+
+  it('never runs more tasks at once than the configured concurrency', async () => {
+    const inputs = range(1, 21);
+    let inFlight = 0;
+    let peak = 0;
+
+    const results = await unfurlPool(
+      asyncPool(
+        inputs,
+        async (n) => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          inFlight--;
+          return n;
+        },
+        { concurrency: 4 },
+      ),
+    );
+
+    expect(results).toHaveLength(inputs.length);
+    expect(peak).toBe(4);
+  });
+});

--- a/server/src/util/asyncPool.ts
+++ b/server/src/util/asyncPool.ts
@@ -26,6 +26,9 @@ export async function* asyncPool<T, R>(
   // task that settled in the same tick had its result discarded — with a
   // synchronously-resolving iteratorFn that dropped all but 1 in
   // `concurrency` results.
+  // A non-positive limit would spin the producer loop with nothing in flight
+  // and no await to yield on, starving the event loop entirely.
+  const concurrency = Math.max(1, opts.concurrency);
   const completed: PoolResult[] = [];
   let running = 0;
   let onSettled: (() => void) | undefined;
@@ -81,7 +84,7 @@ export async function* asyncPool<T, R>(
 
   for (const item of iterable) {
     start(item);
-    while (running >= opts.concurrency) {
+    while (running >= concurrency) {
       yield* drain();
     }
   }

--- a/server/src/util/asyncPool.ts
+++ b/server/src/util/asyncPool.ts
@@ -19,35 +19,28 @@ export async function* asyncPool<T, R>(
   iteratorFn: (item: T, iterable: Iterable<T>) => PromiseLike<R> | R,
   opts: AsyncPoolOpts,
 ): AsyncGenerator<Result<WithInput<R, T>, ErrorWithInput<T>>> {
-  const executing = new Set<Promise<readonly [T, Awaited<R>]>>();
+  type PoolResult = Result<WithInput<R, T>, ErrorWithInput<T>>;
 
-  async function consume(): Promise<
-    Result<WithInput<R, T>, ErrorWithInput<T>>
-  > {
-    try {
-      const [input, result] = await Promise.race(executing);
-      return Result.success({
-        result,
-        input,
-      });
-    } catch (e) {
-      return Result.failure(e as ErrorWithInput<T>);
-    }
-  }
+  // Settled tasks buffer their outcome here rather than being observed via
+  // Promise.race. Racing only ever surfaces a single winner, so every other
+  // task that settled in the same tick had its result discarded — with a
+  // synchronously-resolving iteratorFn that dropped all but 1 in
+  // `concurrency` results.
+  const completed: PoolResult[] = [];
+  let running = 0;
+  let onSettled: (() => void) | undefined;
 
-  for (const item of iterable) {
-    // Wrap iteratorFn() in an async fn to ensure we get a promise.
-    // Then expose such promise, so it's possible to later reference and
-    // remove it from the executing pool.
-    const promise = (async () => {
+  const start = (item: T) => {
+    running++;
+    void (async () => {
       try {
-        const r = await iteratorFn(item, iterable);
+        const result = await iteratorFn(item, iterable);
         if (opts.waitAfterEachMs && opts.waitAfterEachMs > 0) {
           await wait(opts.waitAfterEachMs);
         } else if (opts.flushAfterEach) {
           await wait();
         }
-        return [item, r] as const;
+        completed.push(Result.success({ result, input: item }));
       } catch (e) {
         let error: Error;
         if (isError(e)) {
@@ -58,18 +51,43 @@ export async function* asyncPool<T, R>(
           error = new Error(JSON.stringify(e));
         }
 
-        throw new ErrorWithInput(error, item);
+        completed.push(Result.failure(new ErrorWithInput(error, item)));
+      } finally {
+        running--;
+        const notify = onSettled;
+        onSettled = undefined;
+        notify?.();
       }
-    })().finally(() => executing.delete(promise));
+    })();
+  };
 
-    executing.add(promise);
-    if (executing.size >= opts.concurrency) {
-      yield await consume();
+  // Hands back everything buffered so far, waiting for at least one task to
+  // settle if nothing is buffered yet.
+  async function* drain(): AsyncGenerator<PoolResult> {
+    if (completed.length === 0 && running > 0) {
+      await new Promise<void>((resolve) => {
+        onSettled = resolve;
+      });
+    }
+
+    for (
+      let next = completed.shift();
+      next !== undefined;
+      next = completed.shift()
+    ) {
+      yield next;
     }
   }
 
-  while (executing.size) {
-    yield await consume();
+  for (const item of iterable) {
+    start(item);
+    while (running >= opts.concurrency) {
+      yield* drain();
+    }
+  }
+
+  while (running > 0 || completed.length > 0) {
+    yield* drain();
   }
 }
 


### PR DESCRIPTION
Fixes #2038.

## Problem

Plex movie playlists synced into a Custom Show imported only every third item (40 → 14, 19 → 7, at positions 1, 4, 7, …). TV episode playlists synced fine.

The cause is not in the Plex code — it is `asyncPool` in `server/src/util/asyncPool.ts`.

Each task registered `.finally(() => executing.delete(promise))`, removing itself from the in-flight set as soon as it settled, whether or not its result had been handed to the caller. The generator consumed with `await Promise.race(executing)`, which surfaces exactly one winner and discards the rest. So when several in-flight tasks settled before the generator resumed, one result was yielded and the others were silently dropped.

When `iteratorFn` does no I/O, all `concurrency` tasks settle in the same microtask drain, so exactly 1 in `concurrency` results survives.

`PlexHierarchyTraversal.expandAncestors` runs the pool at `concurrency: 3`, and movies take a no-I/O fast path (`Promise.resolve(m)`) because they have no ancestors to look up — hence every third movie. Episodes await real HTTP calls for season/show, settle at different times, and were unaffected.

Rejections were dropped by the same mechanism, so failures could also go unreported.

## Fix

Tasks now push their outcome onto a completion buffer and the generator drains that buffer, instead of relying on `Promise.race` to observe each completion. Concurrency back-pressure and per-task failure isolation are unchanged, as is the public interface.

## Other affected callers

Same helper, same latent bug — all fixed by this change:

- `server/src/tasks/fixers/BackfillProgramExternalIds.ts:132`
- `server/src/db/backup/ArchiveDatabaseBackup.ts:210`
- `server/src/db/channel/LineupRepository.ts:251`
- `server/src/services/PlexItemEnumerator.ts:67`

## Test plan

Written test-first; each test was confirmed failing against the previous implementation before the fix.

- [x] `asyncPool` yields a result for every input when tasks settle without I/O — was 14/40, now 40/40
- [x] `asyncPool` yields a failure result for every rejecting task — was 14/40, now 40/40
- [x] `asyncPool` never exceeds the configured concurrency
- [x] Regression test for #2038: `PlexHierarchyTraversal.expandAncestors` returns all 40 movies in a playlist-sized batch, in order (verified failing with 14 wrong items against the pre-fix pool)
- [x] Full server suite: 1158 passed, 2 skipped
- [x] `pnpm turbo typecheck` clean
- [x] `pnpm lint-changed` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)