### PR TITLE
fix: stop unfurlPool from swallowing failed tasks

### DIFF
--- a/server/src/services/PlexItemEnumerator.ts
+++ b/server/src/services/PlexItemEnumerator.ts
@@ -1,16 +1,8 @@
 import type { PlexApiClient } from '@/external/plex/PlexApiClient.js';
-import { flatMapAsyncSeq } from '@/util/index.js';
 import type { Logger } from '@/util/logging/LoggerFactory.js';
 import { LoggerFactory } from '@/util/logging/LoggerFactory.js';
 import { isNonEmptyString } from '@tunarr/shared/util';
-import type { ProgramLike } from '@tunarr/types';
-import {
-  isTerminalItemType,
-  type Library,
-  type ProgramOrFolder,
-  type TerminalProgram,
-} from '@tunarr/types';
-import { flatten, flattenDeep, map, uniqBy } from 'lodash-es';
+import type { ProgramLike, TerminalProgram } from '@tunarr/types';
 import { match, P } from 'ts-pattern';
 import { asyncPool, unfurlPool } from '../util/asyncPool.ts';
 
@@ -20,60 +12,6 @@ export class PlexHierarchyTraversal {
   });
 
   constructor(private plex: PlexApiClient) {}
-
-  async expandDescendants(initialItems: (ProgramOrFolder | Library)[]) {
-    this.#logger.debug(
-      'enumerating items: %O',
-      map(initialItems, (item) => item.externalId),
-    );
-    const allItems = await flatMapAsyncSeq(initialItems, (item) =>
-      this.expandItemDescendants(item),
-    );
-    return uniqBy(allItems, (item) => item.externalId);
-  }
-
-  async expandItemDescendants(
-    item: ProgramOrFolder | Library,
-    parent?: ProgramOrFolder | Library,
-    acc: TerminalProgram[] = [],
-  ): Promise<TerminalProgram[]> {
-    if (isTerminalItemType(item)) {
-      if ((item.duration ?? 0) <= 0) {
-        return acc;
-      }
-
-      if (item.type === 'episode' && parent?.type === 'season') {
-        item.season = parent;
-      } else if (item.type === 'track' && parent?.type === 'album') {
-        item.album = parent;
-      }
-
-      acc.push(item);
-      return acc;
-    } else {
-      if (item.type === 'season' && parent?.type === 'show') {
-        item.show = parent;
-      }
-
-      const parentType = match(item.type)
-        .returnType<'item' | 'collection' | 'playlist'>()
-        .with('collection', () => 'collection')
-        .with('playlist', () => 'playlist')
-        .with(P._, () => 'item')
-        .exhaustive();
-      return this.plex
-        .getItemChildren(item.externalId, parentType)
-        .then(async (result) => {
-          const pool = asyncPool(
-            result.getOrThrow(),
-            (nextItem) => this.expandItemDescendants(nextItem, item, acc),
-            { concurrency: 3 },
-          );
-          return flatten(await unfurlPool(pool));
-        })
-        .then((allResults) => flattenDeep(allResults));
-    }
-  }
 
   async expandAncestors(items: TerminalProgram[]): Promise<TerminalProgram[]> {
     const seenItems = new Map<string, ProgramLike>();

--- a/server/src/util/asyncPool.test.ts
+++ b/server/src/util/asyncPool.test.ts
@@ -19,6 +19,43 @@ vi.mock('@/util/logging/LoggerFactory.js', () => ({
   LoggerFactory: { child: () => fakeLogger, root: fakeLogger },
 }));
 
+describe('unfurlPool', () => {
+  it('rejects instead of returning a short list when a task fails', async () => {
+    const inputs = range(1, 11);
+
+    await expect(
+      unfurlPool(
+        asyncPool(
+          inputs,
+          (n) =>
+            n === 4 ? Promise.reject(new Error('boom')) : Promise.resolve(n),
+          { concurrency: 3 },
+        ),
+      ),
+    ).rejects.toThrow(/1 of 10/);
+  });
+});
+
+describe('unfurlPool ordering', () => {
+  it('returns results in input order, not completion order', async () => {
+    const inputs = range(1, 7);
+
+    const results = await unfurlPool(
+      asyncPool(
+        inputs,
+        async (n) => {
+          // Later inputs finish first.
+          await new Promise((resolve) => setTimeout(resolve, (7 - n) * 5));
+          return n;
+        },
+        { concurrency: 6 },
+      ),
+    );
+
+    expect(results).toEqual(inputs);
+  });
+});
+
 describe('asyncPool', () => {
   it('yields a result for every input when tasks settle without I/O', async () => {
     const inputs = range(1, 41);

--- a/server/src/util/asyncPool.ts
+++ b/server/src/util/asyncPool.ts
@@ -1,8 +1,7 @@
-import { isError, isString } from 'lodash-es';
+import { isError, isString, sortBy } from 'lodash-es';
 import { WrappedError } from '../types/errors.ts';
 import { Result } from '../types/result.ts';
 import { wait } from './index.js';
-import { LoggerFactory } from './logging/LoggerFactory.js';
 
 type AsyncPoolOpts = {
   concurrency: number;
@@ -21,19 +20,20 @@ export async function* asyncPool<T, R>(
 ): AsyncGenerator<Result<WithInput<R, T>, ErrorWithInput<T>>> {
   type PoolResult = Result<WithInput<R, T>, ErrorWithInput<T>>;
 
+  // A non-positive limit would spin the producer loop with nothing in flight
+  // and no await to yield on, starving the event loop entirely.
+  const concurrency = Math.max(1, opts.concurrency);
+
   // Settled tasks buffer their outcome here rather than being observed via
   // Promise.race. Racing only ever surfaces a single winner, so every other
   // task that settled in the same tick had its result discarded — with a
   // synchronously-resolving iteratorFn that dropped all but 1 in
   // `concurrency` results.
-  // A non-positive limit would spin the producer loop with nothing in flight
-  // and no await to yield on, starving the event loop entirely.
-  const concurrency = Math.max(1, opts.concurrency);
   const completed: PoolResult[] = [];
   let running = 0;
   let onSettled: (() => void) | undefined;
 
-  const start = (item: T) => {
+  const start = (item: T, index: number) => {
     running++;
     void (async () => {
       try {
@@ -43,7 +43,7 @@ export async function* asyncPool<T, R>(
         } else if (opts.flushAfterEach) {
           await wait();
         }
-        completed.push(Result.success({ result, input: item }));
+        completed.push(Result.success({ result, input: item, index }));
       } catch (e) {
         let error: Error;
         if (isError(e)) {
@@ -82,8 +82,9 @@ export async function* asyncPool<T, R>(
     }
   }
 
+  let index = 0;
   for (const item of iterable) {
-    start(item);
+    start(item, index++);
     while (running >= concurrency) {
       yield* drain();
     }
@@ -94,21 +95,35 @@ export async function* asyncPool<T, R>(
   }
 }
 
+// Collects an entire pool into an array. Rejects if any task failed: a short
+// array is indistinguishable from a genuinely short one, and callers such as
+// custom show sync overwrite their contents with whatever comes back, so a
+// swallowed failure silently destroys programming. Callers that want to
+// tolerate individual failures should iterate the pool directly.
 export async function unfurlPool<T, R>(
   poolGen: AsyncGenerator<Result<WithInput<R, T>, ErrorWithInput<T>>>,
 ) {
-  const results: R[] = [];
+  const collected: WithInput<R, T>[] = [];
+  const failures: ErrorWithInput<T>[] = [];
+  let total = 0;
+
   for await (const result of poolGen) {
+    total++;
     if (result.isFailure()) {
-      LoggerFactory.root.error(
-        result.error,
-        'Error processing async pool task',
-      );
+      failures.push(result.error);
     } else {
-      results.push(result.get().result);
+      collected.push(result.get());
     }
   }
-  return results;
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} of ${total} async pool task(s) failed`,
+    );
+  }
+
+  return sortBy(collected, (item) => item.index).map((item) => item.result);
 }
 
 class ErrorWithInput<In> extends WrappedError {
@@ -123,6 +138,9 @@ class ErrorWithInput<In> extends WrappedError {
 type WithInput<R, In> = {
   result: R;
   input: In;
+  // Position of `input` in the source iterable. Results are yielded in
+  // completion order; this is what lets a caller recover the input order.
+  index: number;
 };
 
 // type Result<In, R> = Success<R, In> | Failure<In>;


### PR DESCRIPTION
Stacked on #2039 — it contains that PR's two commits until #2039 merges. Review only `2efee98`.

## Problem

`unfurlPool` logged each failed task and dropped it, returning a short array that callers cannot distinguish from a genuinely short one. `CustomShowSyncService.syncShow` passes that array straight to `upsertCustomShowContent`, which **replaces** the show's contents and is guarded only against the empty case — so a single failed task silently deletes programs from a user's custom show.

That is the same harm as #2038, and it quietly undoes the guarantee `PlexApiClient.getItemChildren` makes one layer down, where a failed page fails the whole listing rather than returning a truncated one (its comment says exactly why: "Custom show sync overwrites its contents with what it gets back, so a truncated result destroys programming").

## Changes

- **`unfurlPool` rejects on failure.** It now throws an `AggregateError` naming the failed inputs instead of logging and dropping them. Callers that want to tolerate individual failures iterate the pool directly, as the three other call sites already do.
- **Results come back in input order.** `asyncPool` yields in completion order, so pool results now carry their source index and `unfurlPool` sorts by it. Playlist order is a property custom show sync has already had to repair once (v1.3.9, "ensure synced plex playlists retain original order"). `CustomShowSyncService`'s own defensive re-sort is left in place.
- **Removes dead code.** `PlexHierarchyTraversal.expandDescendants` and `expandItemDescendants` were referenced only by each other.

## Not included

`AbortSignal` support for `asyncPool`. Breaking out of the loop leaves in-flight tasks running detached (I measured 4 tasks started for 2 consumed at concurrency 3), and long pools such as library scans cannot be cancelled. That is a feature rather than a fix, so by the branching convention it belongs on `dev` — happy to open it there.

## Test plan

Written test-first; both new tests were confirmed failing before the change.

- [x] `unfurlPool` rejects instead of returning a short list when a task fails — previously returned 9 of 10 silently
- [x] `unfurlPool` returns results in input order, not completion order — previously returned them reversed
- [x] Existing `CustomShowSyncService` sync and playlist-ordering tests still pass
- [x] Full server suite: 1227 passed, 2 skipped
- [x] `pnpm turbo typecheck` clean
- [x] `pnpm lint-changed` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)