### PR TITLE
fix: use shared language matching in the troubleshoot report

### DIFF
--- a/server/src/ffmpeg/StreamSelectionEvaluator.ts
+++ b/server/src/ffmpeg/StreamSelectionEvaluator.ts
@@ -119,7 +119,7 @@ export async function evaluateStreamSelectionProfile(
   };
 }
 
-type LanguageTaggedStream = {
+export type LanguageTaggedStream = {
   language?: string;
   languageCodeISO6391?: string;
   languageCodeISO6392?: string;
@@ -134,7 +134,7 @@ type LanguageTaggedStream = {
  * the two ISO 639-2 code sets are interchangeable — a stored preference of
  * "ger" must match a stream that Jellyfin or ffprobe tagged "deu".
  */
-function streamMatchesLanguage(
+export function streamMatchesLanguage(
   stream: LanguageTaggedStream,
   language: string,
 ): boolean {

--- a/server/src/services/TroubleshootService.test.ts
+++ b/server/src/services/TroubleshootService.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { SubtitleStreamDetails } from '../stream/types.ts';
+import { findSubtitleForLanguages } from './TroubleshootService.ts';
+
+function makeSubtitle(
+  index: number,
+  languageCodeISO6392: string,
+): SubtitleStreamDetails {
+  return {
+    type: 'embedded',
+    codec: 'subrip',
+    index,
+    default: false,
+    forced: false,
+    sdh: false,
+    languageCodeISO6392,
+  };
+}
+
+// The troubleshoot report is the tool users copy into bug reports, so its
+// subtitle matching has to agree with what playback actually picks. It used to
+// compare codes as raw strings while the stream selector normalized them.
+// Regression test for https://github.com/chrisbenincasa/tunarr/issues/1960
+describe('findSubtitleForLanguages', () => {
+  it('matches a bibliographic request against a terminological stream', () => {
+    const match = findSubtitleForLanguages(
+      [makeSubtitle(1, 'deu'), makeSubtitle(2, 'eng')],
+      ['ger'],
+    );
+
+    expect(match?.stream.index).toBe(1);
+    expect(match?.language).toBe('ger');
+  });
+
+  it('matches a terminological request against a bibliographic stream', () => {
+    const match = findSubtitleForLanguages(
+      [makeSubtitle(1, 'ger'), makeSubtitle(2, 'eng')],
+      ['deu'],
+    );
+
+    expect(match?.stream.index).toBe(1);
+  });
+
+  it('honors request order', () => {
+    const match = findSubtitleForLanguages(
+      [makeSubtitle(1, 'deu'), makeSubtitle(2, 'eng')],
+      ['eng', 'ger'],
+    );
+
+    expect(match?.stream.index).toBe(2);
+    expect(match?.language).toBe('eng');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(
+      findSubtitleForLanguages([makeSubtitle(1, 'eng')], ['ger']),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when there are no subtitle streams', () => {
+    expect(findSubtitleForLanguages(undefined, ['ger'])).toBeUndefined();
+    expect(findSubtitleForLanguages([], ['ger'])).toBeUndefined();
+  });
+});

--- a/server/src/services/TroubleshootService.ts
+++ b/server/src/services/TroubleshootService.ts
@@ -1,9 +1,11 @@
 import type { IProgramDB } from '@/db/interfaces/IProgramDB.js';
 
 import type { StreamLineupItem } from '@/db/derived_types/StreamLineup.js';
+import type { LanguageTaggedStream } from '@/ffmpeg/StreamSelectionEvaluator.js';
 import {
   buildCelContext,
   resolveAudioAction,
+  streamMatchesLanguage,
 } from '@/ffmpeg/StreamSelectionEvaluator.js';
 import {
   defaultHlsOptions,
@@ -48,6 +50,33 @@ import { CelEvaluationService } from './CelEvaluationService.js';
 import { StreamSelectionProfileResolver } from './StreamSelectionProfileResolver.js';
 
 dayjs.extend(duration);
+
+/**
+ * Find the first subtitle stream matching any of the requested languages, in
+ * preference order, along with the language that matched.
+ *
+ * The troubleshoot report must agree with what playback would actually pick,
+ * so this uses the same matching the stream selector does.
+ */
+export function findSubtitleForLanguages<T extends LanguageTaggedStream>(
+  subtitleStreams: T[] | undefined,
+  languages: string[],
+): { stream: T; language: string } | undefined {
+  if (!subtitleStreams) {
+    return undefined;
+  }
+
+  for (const language of languages) {
+    const stream = subtitleStreams.find((s) =>
+      streamMatchesLanguage(s, language),
+    );
+    if (stream) {
+      return { stream, language };
+    }
+  }
+
+  return undefined;
+}
 
 @injectable()
 export class TroubleshootService {
@@ -311,21 +340,13 @@ export class TroubleshootService {
             } else {
               selectedSubtitle = null;
               subtitleReason = `No subtitle found for languages: ${rule.subtitleAction.languages.join(', ')}`;
-              if (subtitleStreams) {
-                for (const lang of rule.subtitleAction.languages) {
-                  const langLower = lang.toLowerCase();
-                  const found = subtitleStreams.find(
-                    (s) =>
-                      s.languageCodeISO6392?.toLowerCase() === langLower ||
-                      s.languageCodeISO6391?.toLowerCase() === langLower ||
-                      s.language?.toLowerCase() === langLower,
-                  );
-                  if (found) {
-                    selectedSubtitle = found;
-                    subtitleReason = `Matched language: ${lang}`;
-                    break;
-                  }
-                }
+              const match = findSubtitleForLanguages(
+                subtitleStreams,
+                rule.subtitleAction.languages,
+              );
+              if (match) {
+                selectedSubtitle = match.stream;
+                subtitleReason = `Matched language: ${match.language}`;
               }
             }
           }

--- a/web/src/pages/settings/FfmpegSettingsPage.tsx
+++ b/web/src/pages/settings/FfmpegSettingsPage.tsx
@@ -221,17 +221,23 @@ export default function FfmpegSettingsPage() {
                   handleFfmpegLogChange(e.target.value)
                 }
               >
-                <MenuItem value="disable"><Trans>Disabled</Trans></MenuItem>
-                <MenuItem value="console"><Trans>Console</Trans></MenuItem>
-                <MenuItem value="file"><Trans>File</Trans></MenuItem>
+                <MenuItem value="disable">
+                  <Trans>Disabled</Trans>
+                </MenuItem>
+                <MenuItem value="console">
+                  <Trans>Console</Trans>
+                </MenuItem>
+                <MenuItem value="file">
+                  <Trans>File</Trans>
+                </MenuItem>
               </Select>
 
               <FormHelperText>
                 <Trans>
                   Enable ffmpeg logging to different sinks. Outputting to a file
                   will create a new log file for every spawned ffmpeg process in
-                  the Tunarr log directory. These files are automatically cleaned
-                  up by a background process.
+                  the Tunarr log directory. These files are automatically
+                  cleaned up by a background process.
                 </Trans>
               </FormHelperText>
             </FormControl>
@@ -297,8 +303,8 @@ export default function FfmpegSettingsPage() {
           />
           <FormHelperText>
             <Trans>
-              Channels configured to use the HLS Direct stream mode will output in
-              the selected container format.
+              Channels configured to use the HLS Direct stream mode will output
+              in the selected container format.
             </Trans>
           </FormHelperText>
         </FormControl>
@@ -318,9 +324,10 @@ export default function FfmpegSettingsPage() {
                       directory (but not intermediate directories) if it doesn't
                       exist.
                       <br />
-                      Changing this field will only affect new sessions. Existing
-                      sessions will continue writing to the previous setting, but
-                      will clean out segments when the segment ends.
+                      Changing this field will only affect new sessions.
+                      Existing sessions will continue writing to the previous
+                      setting, but will clean out segments when the segment
+                      ends.
                       <br />
                       When unset, Tunarr will write segments to its current
                       working directory.
@@ -339,7 +346,9 @@ export default function FfmpegSettingsPage() {
       </Typography>
       <Stack spacing={3} sx={{ mb: 2 }}>
         <Box>
-          <Typography variant="h6"><Trans>Subtitles</Trans></Typography>
+          <Typography variant="h6">
+            <Trans>Subtitles</Trans>
+          </Typography>
           <FormControl fullWidth>
             <Controller
               control={control}
@@ -355,8 +364,8 @@ export default function FfmpegSettingsPage() {
             <FormHelperText>
               <Trans>
                 Enabling embedded subtitle extaction will periodically scan your
-                upcoming programming for embedded text-based subtitle streams and
-                extract them to a local cache. This is necessary in order to
+                upcoming programming for embedded text-based subtitle streams
+                and extract them to a local cache. This is necessary in order to
                 enable subtitle burning for text-based subtitles which are not
                 external streams.
               </Trans>
@@ -386,7 +395,9 @@ export default function FfmpegSettingsPage() {
             render={({ field, fieldState: { error } }) => (
               <LanguagePreferencesList
                 preferences={
-                  field.value ?? [{ iso6391: 'en', displayName: 'English' }]
+                  field.value ?? [
+                    { iso6391: 'en', iso6392: 'eng', displayName: 'English' },
+                  ]
                 }
                 onChange={field.onChange}
                 error={error}


### PR DESCRIPTION
Stacked on #2041 — it depends on `LanguageService.codesMatch` and `streamMatchesLanguage` from that branch. **Retarget to `main` once #2041 merges.**

Refs #1960, #2026

## Troubleshoot subtitle matching

The troubleshoot simulator resolves audio through the stream selector (`TroubleshootService.ts:300` → `resolveAudioAction`) but re-implemented subtitle language matching inline with raw string comparison:

```ts
s.languageCodeISO6392?.toLowerCase() === langLower ||
s.languageCodeISO6391?.toLowerCase() === langLower ||
s.language?.toLowerCase() === langLower
```

Once #2041 taught the selector to treat the two ISO 639-2 code sets as equivalent, the two halves disagreed. The report would say `No subtitle found for languages: ger` for a file that playback selects a German subtitle for — audio correct, subtitles wrong, in the same report.

That's worse than a normal display bug: the troubleshoot report is what users paste into issues, and **#1960 was diagnosed from one**. A diagnostic that disagrees with the engine sends reporters and maintainers down the wrong path.

Extracted the lookup into `findSubtitleForLanguages` and routed it through the selector's `streamMatchesLanguage`, now exported. That removes the third copy of this matching logic rather than adding a fourth.

## FFmpeg settings fallback

`FfmpegSettingsPage.tsx:389` fell back to `[{ iso6391: 'en', displayName: 'English' }]`, missing `iso6392` — which `LanguagePreferenceSchema` requires (`z.string().length(3)`). The fallback produced a value that would fail server-side validation. Added the missing code.

## Test plan

- [x] New `TroubleshootService.test.ts` covers both code-set directions, request ordering, and the empty/undefined cases
- [x] **Verified RED first** — extracted the function with its original raw-comparison logic, confirmed 2 failures, then swapped in the shared matcher
- [x] `pnpm turbo typecheck` clean
- [x] `pnpm lint-changed` clean
- [x] `pnpm turbo test` — 1324 server tests, 90 web tests, all passing

## Deliberately not included

Found in the same sweep, left out to keep this reviewable — happy to file these as issues:

1. **Meilisearch language filtering is exact-match on unnormalized values** (`MeilisearchService.ts:1669-1685`). Because `PlexApiClient.ts:2116,2156,2196`, `JellyfinApiClient.ts:1238,1258` and `EmbyApiClient.ts:1292,1310` persist provider codes raw while `FfprobeStreamDetails.ts:113,141` normalizes to `/T`, the index holds a **mix of code sets that varies by media source**. `audio_language = deu` matches local files and misses Jellyfin ones. The facet endpoint lists `ger` and `deu` separately with separate counts, and saved smart collections inherit it. Needs index-time normalization plus a reindex, so it's a real design decision rather than a patch.
2. **Nothing normalizes on write**, which is the systemic root of the above. Note `ProgramMinter.ts:327` writes sidecar subtitles already normalized to `/T` while `:309` writes embedded ones raw — so the *same program* can hold two code sets. Fixing this properly needs a backfill.
3. **`SubtitleStreamPicker` still skips the language check entirely when `languageCodeISO6392` is absent**, so an untagged stream matches any requested language. That's the second half of #2026 and a behavior change on its own.
4. **`ChannelSubtitlePreferencesTable` passes `values={[]}` and never dedupes**, so any language can be added twice. Pre-existing and not code-set-specific.
5. **`languageCodeISO6391` is never assigned anywhere in the server** — declared in `stream/types.ts:54,71` and read in five places as a `??` fallback, but no code writes it. The ISO 639-1 branches are dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)