### PR TITLE
fix(server): correct copy-paste media source names in error messages

### DIFF
--- a/server/src/api/embyApi.ts
+++ b/server/src/api/embyApi.ts
@@ -233,7 +233,7 @@ export const embyApiRouter: RouterPluginCallback = (fastify, _, done) => {
       return res
         .status(400)
         .send(
-          `Media source with ID = ${req.params.mediaSourceId} is not a Emby server.`,
+          `Media source with ID = ${req.params.mediaSourceId} is not an Emby server.`,
         );
     }
 

--- a/server/src/api/plexApi.ts
+++ b/server/src/api/plexApi.ts
@@ -371,7 +371,7 @@ export const plexApiRouter: RouterPluginAsyncCallback = async (fastify, _) => {
       return res
         .status(400)
         .send(
-          `Media source with ID = ${req.params.mediaSourceId} is not a Jellyfin server.`,
+          `Media source with ID = ${req.params.mediaSourceId} is not a Plex server.`,
         );
     }
 

--- a/server/src/external/MediaSourceApiFactory.ts
+++ b/server/src/external/MediaSourceApiFactory.ts
@@ -114,7 +114,7 @@ export class MediaSourceApiFactory {
         .catch((e) => {
           this.logger.error(
             e,
-            'Error updating Jellyfin media source user info',
+            'Error updating Emby media source user info',
           );
         });
     }


### PR DESCRIPTION
Fixes #2031

Copy-paste error messages name the wrong media source in three places. Control flow is unaffected — only the message text changed:

- **`server/src/api/plexApi.ts`** (`withPlexMediaSource`): the 400 said *"is not a Jellyfin server"* when the source is not Plex. Now says **Plex**.
- **`server/src/external/MediaSourceApiFactory.ts`** (`getEmbyApiClient`): the `.catch()` logged *"Error updating Jellyfin media source user info"* inside the Emby branch. Now logs **Emby**.
- **`server/src/api/embyApi.ts`** (`withEmbyMediaSource`): the 400 read *"is not a Emby server"*. Now reads **"is not an Emby server"** (grammar).

Each guard/factory now names its own media source type, mirroring `jellyfinApi.ts` which already said "Jellyfin". No tests reference these strings. Diff is 3 lines, message-text only.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Reviewed the three call sites on `main`; each message is now consistent with the media source type its guard/factory checks. No test asserts these strings, so no test changes required.