### PR TITLE
fix(build): restore the pnpm overrides dropped by the workspace move

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
       "prettier --write",
       "eslint --fix --no-warn-ignored"
     ]
-  },
-  "resolutions": {
-    "conventional-changelog-conventionalcommits": "^9.0.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ patchedDependencies:
   kysely: "patches/kysely.patch"
 
 overrides:
+  conventional-changelog-conventionalcommits: "^9.0.0"
   eslint: "catalog:"
   "@types/node": "22.10.7"
 


### PR DESCRIPTION
Every CI job is failing at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

## Cause

`d8fd6938` ("build: move pnpm config from package.json to pnpm-workspace.yaml") moved `patchedDependencies`, `overrides` and `onlyBuiltDependencies` out of the `pnpm` block in `package.json` and into `pnpm-workspace.yaml`. It left the separate `resolutions` field behind in `package.json`.

pnpm treats `resolutions` as a source of overrides, and **it does not merge with the `overrides` block in `pnpm-workspace.yaml` — it replaces it.**

So the effective override set collapsed from three entries to one:

| | before `d8fd6938` | after |
|---|---|---|
| `conventional-changelog-conventionalcommits` | `^9.0.0` | `^9.0.0` |
| `eslint` | `9.39.2` | **dropped** |
| `@types/node` | `22.10.7` | **dropped** |

`pnpm-lock.yaml` still records all three, hence the mismatch. The `patchedDependencies` and `onlyBuiltDependencies` moves were fine — those *are* read from `pnpm-workspace.yaml`. Only `overrides` was shadowed.

Worth noting the second-order effect: the eslint and `@types/node` pins have been silently inactive since 2026-08-26, not merely mismatched.

## Fix

Move the third override into `pnpm-workspace.yaml` alongside the other two, and delete the now-redundant `resolutions` field, so the workspace file is the single source of overrides.

```yaml
overrides:
  conventional-changelog-conventionalcommits: "^9.0.0"
  eslint: "catalog:"
  "@types/node": "22.10.7"
```

## Verification

Run in a clean git worktree, so no pre-existing `node_modules` could mask the result:

- `66f468da` (the commit before the move) — `--frozen-lockfile` **passes**
- `main` (`0cbe55e7`) — **fails** with the error above
- this branch — `--frozen-lockfile` **passes**, and **`pnpm-lock.yaml` is byte-identical afterwards**, so no dependency version changes

Also confirmed along the way that `eslint: "catalog:"` does resolve correctly to `9.39.2` from `pnpm-workspace.yaml`; the catalog protocol was not the problem.

An intermediate attempt that only added the missing override while leaving `resolutions` in place still failed — which is what pinned the cause on the shadowing rather than on a merely incomplete move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
