### PR TITLE
fix(scanner): honor pathFilter in other-video, music-video and music-artist scans

### DIFF
--- a/server/src/services/scanner/MediaSourceMusicArtistScanner.ts
+++ b/server/src/services/scanner/MediaSourceMusicArtistScanner.ts
@@ -5,7 +5,14 @@ import type {
   Season,
   Show,
 } from '@tunarr/types';
-import { differenceWith, flatten, head, round, values } from 'lodash-es';
+import {
+  differenceWith,
+  flatten,
+  head,
+  isEmpty,
+  round,
+  values,
+} from 'lodash-es';
 import type { GetProgramGroupingById } from '../../commands/GetProgramGroupingById.ts';
 import type { ProgramGroupingMinter } from '../../db/converters/ProgramGroupingMinter.ts';
 import type { ProgramDaoMinter } from '../../db/converters/ProgramMinter.ts';
@@ -152,7 +159,7 @@ export abstract class MediaSourceMusicArtistScanner<
   ): Promise<void> {
     this.mediaSourceProgressService.scanStarted(context.library.uuid);
 
-    const { library } = context;
+    const { library, pathFilter } = context;
     const existingArtists =
       await this.programDB.getExistingProgramGroupingDetails(
         library.uuid,
@@ -166,6 +173,10 @@ export abstract class MediaSourceMusicArtistScanner<
     for await (const artist of this.getArtists(library.externalKey, context)) {
       if (this.state(library.uuid) === 'canceled') {
         return;
+      }
+
+      if (isNonEmptyString(pathFilter) && artist.externalId !== pathFilter) {
+        continue;
       }
 
       seenArtists.add(artist.externalId);
@@ -202,51 +213,53 @@ export abstract class MediaSourceMusicArtistScanner<
       }
     }
 
-    const missingArtists = differenceWith(
-      values(existingArtists),
-      [...seenArtists.values()],
-      (existing, seen) => {
-        return existing.externalKey === seen;
-      },
-    );
+    if (isEmpty(context.pathFilter)) {
+      const missingArtists = differenceWith(
+        values(existingArtists),
+        [...seenArtists.values()],
+        (existing, seen) => {
+          return existing.externalKey === seen;
+        },
+      );
 
-    const missingAlbums = flatten(
-      await Promise.all(
-        missingArtists.map((show) =>
-          this.programDB.getChildren(show.uuid, ProgramGroupingType.Artist),
-        ),
-      ),
-    );
-
-    const missingTracks = flatten(
-      await Promise.all(
-        missingArtists.map((show) =>
-          this.programDB.getProgramGroupingDescendants(
-            show.uuid,
-            ProgramGroupingType.Artist,
+      const missingAlbums = flatten(
+        await Promise.all(
+          missingArtists.map((show) =>
+            this.programDB.getChildren(show.uuid, ProgramGroupingType.Artist),
           ),
         ),
-      ),
-    );
+      );
 
-    const missingAlbumIds = missingAlbums.flatMap((album) =>
-      album.results.map((a) => a.uuid),
-    );
-    await this.programDB.updateGroupingsState(missingAlbumIds, 'missing');
+      const missingTracks = flatten(
+        await Promise.all(
+          missingArtists.map((show) =>
+            this.programDB.getProgramGroupingDescendants(
+              show.uuid,
+              ProgramGroupingType.Artist,
+            ),
+          ),
+        ),
+      );
 
-    const missingTrackIds = missingTracks.map((track) => track.uuid);
-    await this.programDB.updateProgramsState(missingTrackIds, 'missing');
+      const missingAlbumIds = missingAlbums.flatMap((album) =>
+        album.results.map((a) => a.uuid),
+      );
+      await this.programDB.updateGroupingsState(missingAlbumIds, 'missing');
 
-    // Mark programs we didn't find as missing in the search index.
-    await this.searchService.updatePrograms(
-      missingAlbumIds
-        .concat(missingTrackIds)
-        .concat(missingArtists.map((artist) => artist.uuid))
-        .map((id) => ({
-          id,
-          state: 'missing',
-        })),
-    );
+      const missingTrackIds = missingTracks.map((track) => track.uuid);
+      await this.programDB.updateProgramsState(missingTrackIds, 'missing');
+
+      // Mark programs we didn't find as missing in the search index.
+      await this.searchService.updatePrograms(
+        missingAlbumIds
+          .concat(missingTrackIds)
+          .concat(missingArtists.map((artist) => artist.uuid))
+          .map((id) => ({
+            id,
+            state: 'missing',
+          })),
+      );
+    }
 
     this.mediaSourceProgressService.scanEnded(library.uuid);
   }

--- a/server/src/services/scanner/MediaSourceMusicVideoScanner.ts
+++ b/server/src/services/scanner/MediaSourceMusicVideoScanner.ts
@@ -1,5 +1,6 @@
 import type { MusicVideo } from '@tunarr/types';
-import { differenceWith, head, round, values } from 'lodash-es';
+import { isNonEmptyString } from '@tunarr/shared/util';
+import { differenceWith, head, isEmpty, round, values } from 'lodash-es';
 import type { ProgramDaoMinter } from '../../db/converters/ProgramMinter.ts';
 import type {
   IProgramDB,
@@ -97,7 +98,7 @@ export abstract class MediaSourceMusicVideoScanner<
   ): Promise<void> {
     this.mediaSourceProgressService.scanStarted(context.library.uuid);
 
-    const { library } = context;
+    const { library, pathFilter } = context;
 
     const existingPrograms =
       await this.programDB.getProgramInfoForMediaSourceLibrary(
@@ -113,6 +114,10 @@ export abstract class MediaSourceMusicVideoScanner<
       for await (const video of this.getVideos(library.externalKey, context)) {
         if (this.state(library.uuid) === 'canceled') {
           return;
+        }
+
+        if (isNonEmptyString(pathFilter) && video.externalId !== pathFilter) {
+          continue;
         }
 
         const externalKey = video.externalId;
@@ -133,22 +138,24 @@ export abstract class MediaSourceMusicVideoScanner<
         );
       }
 
-      const missingVideos = differenceWith(
-        values(existingPrograms),
-        [...seenVideos.values()],
-        (existing, seen) => existing.externalKey === seen,
-      );
+      if (isEmpty(context.pathFilter)) {
+        const missingVideos = differenceWith(
+          values(existingPrograms),
+          [...seenVideos.values()],
+          (existing, seen) => existing.externalKey === seen,
+        );
 
-      await this.programDB.updateProgramsState(
-        missingVideos.map((ep) => ep.uuid),
-        'missing',
-      );
-      await this.searchService.updatePrograms(
-        missingVideos.map((ep) => ({
-          id: ep.uuid,
-          state: 'missing',
-        })),
-      );
+        await this.programDB.updateProgramsState(
+          missingVideos.map((ep) => ep.uuid),
+          'missing',
+        );
+        await this.searchService.updatePrograms(
+          missingVideos.map((ep) => ({
+            id: ep.uuid,
+            state: 'missing',
+          })),
+        );
+      }
 
       this.logger.debug('Completed scanning library %s', context.library.uuid);
     } finally {

--- a/server/src/services/scanner/MediaSourceOtherVideoScanner.test.ts
+++ b/server/src/services/scanner/MediaSourceOtherVideoScanner.test.ts
@@ -1,0 +1,156 @@
+import type { IProgramDB } from '../../db/interfaces/IProgramDB.ts';
+import type { MediaSourceDB } from '../../db/mediaSourceDB.ts';
+import type { MediaSourceOrm } from '../../db/schema/MediaSource.ts';
+import type { MediaSourceLibrary } from '../../db/schema/MediaSourceLibrary.ts';
+import { ProgramType } from '../../db/schema/Program.ts';
+import type { MediaSourceApiClient } from '../../external/MediaSourceApiClient.ts';
+import type { MeilisearchService } from '../MeilisearchService.ts';
+import { describe, expect, test, vi } from 'vitest';
+import type { OtherVideo } from '../../types/Media.ts';
+import type { ScanContext } from './MediaSourceScanner.ts';
+import { MediaSourceOtherVideoScanner } from './MediaSourceOtherVideoScanner.ts';
+import type { MediaSourceProgressService } from './MediaSourceProgressService.ts';
+
+type MockApiClient = MediaSourceApiClient;
+
+class TestOtherVideoScanner extends MediaSourceOtherVideoScanner<
+  'jellyfin',
+  MockApiClient,
+  OtherVideo
+> {
+  readonly type = 'other_videos' as const;
+  readonly mediaSourceType = 'jellyfin' as const;
+
+  getApiClient = vi
+    .fn<() => Promise<MockApiClient>>()
+    .mockResolvedValue({} as MockApiClient);
+  getLibrarySize = vi.fn().mockResolvedValue(0);
+  getSubtitles = vi.fn();
+  getVideos = vi.fn<() => AsyncIterable<OtherVideo>>();
+
+  scanSingleInternal = vi
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined);
+
+  constructor(
+    mediaSourceDB: MediaSourceDB,
+    programDB: IProgramDB,
+    searchService: MeilisearchService,
+    progress: MediaSourceProgressService,
+  ) {
+    super(
+      mediaSourceDB,
+      programDB,
+      searchService,
+      progress,
+      {} as never,
+      {} as never,
+    );
+  }
+
+  exposeScanInternal(ctx: ScanContext<MockApiClient>): Promise<void> {
+    return this.scanInternal(ctx);
+  }
+}
+
+function makeLibrary(): MediaSourceLibrary {
+  return {
+    uuid: 'lib1',
+    name: 'Library',
+    mediaSourceId: 'ms1',
+    externalKey: 'ext1',
+    enabled: true,
+  } as MediaSourceLibrary;
+}
+
+function makeContext(
+  scanner: TestOtherVideoScanner,
+): ScanContext<MockApiClient> {
+  return {
+    library: makeLibrary(),
+    mediaSource: {} as MediaSourceOrm,
+    force: false,
+    apiClient: {} as MockApiClient,
+    scannedEntities: 0,
+    totalEntities: 0,
+  };
+}
+
+function makeProgressService(): MediaSourceProgressService {
+  return {
+    scanStarted: vi.fn(),
+    scanProgress: vi.fn(),
+    scanEnded: vi.fn(),
+  } as unknown as MediaSourceProgressService;
+}
+
+function makeSut() {
+  const programDB = {
+    getProgramInfoForMediaSourceLibrary: vi.fn().mockResolvedValue({
+      // An item already persisted but NOT seen during this scan: would be
+      // marked missing unless a pathFilter narrows the scan.
+      ghost: {
+        uuid: 'ghost-uuid',
+        canonicalId: null,
+        libraryId: null,
+        externalKey: 'ghost',
+      },
+    }),
+    updateProgramsState: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IProgramDB;
+
+  const searchService = {
+    updatePrograms: vi.fn().mockResolvedValue(undefined),
+  } as unknown as MeilisearchService;
+
+  const progress = makeProgressService();
+  const scanner = new TestOtherVideoScanner(
+    {} as MediaSourceDB,
+    programDB,
+    searchService,
+    progress,
+  );
+
+  return { scanner, programDB, searchService, progress };
+}
+
+describe('MediaSourceOtherVideoScanner.pathFilter', () => {
+  test('a pathFilter narrows the scan to the single matching item', async () => {
+    const { scanner, programDB } = makeSut();
+    scanner.getVideos.mockImplementation(async function* () {
+      yield { externalId: 'target' } as OtherVideo;
+      yield { externalId: 'other' } as OtherVideo;
+    });
+
+    await scanner.exposeScanInternal({
+      ...makeContext(scanner),
+      pathFilter: 'target',
+    });
+
+    // Only the matching item is processed...
+    expect(scanner.scanSingleInternal).toHaveBeenCalledTimes(1);
+    expect(
+      (scanner.scanSingleInternal.mock.calls[0]?.[1] as OtherVideo).externalId,
+    ).toBe('target');
+    // ...and the mark-missing pass is skipped entirely (the ghost item that
+    // wasn't seen must not be marked missing during a targeted scan).
+    expect(programDB.updateProgramsState).not.toHaveBeenCalled();
+  });
+
+  test('without a pathFilter every item is scanned and misses are marked', async () => {
+    const { scanner, programDB } = makeSut();
+    scanner.getVideos.mockImplementation(async function* () {
+      yield { externalId: 'target' } as OtherVideo;
+      yield { externalId: 'other' } as OtherVideo;
+    });
+
+    await scanner.exposeScanInternal(makeContext(scanner));
+
+    expect(scanner.scanSingleInternal).toHaveBeenCalledTimes(2);
+    // The ghost item was persisted before but never seen -> marked missing.
+    expect(programDB.updateProgramsState).toHaveBeenCalledWith(
+      ['ghost-uuid'],
+      'missing',
+    );
+  });
+});

--- a/server/src/services/scanner/MediaSourceOtherVideoScanner.ts
+++ b/server/src/services/scanner/MediaSourceOtherVideoScanner.ts
@@ -1,4 +1,5 @@
-import { differenceWith, head, round, values } from 'lodash-es';
+import { isNonEmptyString } from '@tunarr/shared/util';
+import { differenceWith, head, isEmpty, round, values } from 'lodash-es';
 import type { ProgramDaoMinter } from '../../db/converters/ProgramMinter.ts';
 import type {
   IProgramDB,
@@ -96,7 +97,7 @@ export abstract class MediaSourceOtherVideoScanner<
   ): Promise<void> {
     this.mediaSourceProgressService.scanStarted(context.library.uuid);
 
-    const { library } = context;
+    const { library, pathFilter } = context;
 
     const existingPrograms =
       await this.programDB.getProgramInfoForMediaSourceLibrary(
@@ -112,6 +113,10 @@ export abstract class MediaSourceOtherVideoScanner<
       for await (const video of this.getVideos(library.externalKey, context)) {
         if (this.state(library.uuid) === 'canceled') {
           return;
+        }
+
+        if (isNonEmptyString(pathFilter) && video.externalId !== pathFilter) {
+          continue;
         }
 
         const externalKey = video.externalId;
@@ -132,22 +137,24 @@ export abstract class MediaSourceOtherVideoScanner<
         );
       }
 
-      const missingVideos = differenceWith(
-        values(existingPrograms),
-        [...seenVideos.values()],
-        (existing, seen) => existing.externalKey === seen,
-      );
+      if (isEmpty(context.pathFilter)) {
+        const missingVideos = differenceWith(
+          values(existingPrograms),
+          [...seenVideos.values()],
+          (existing, seen) => existing.externalKey === seen,
+        );
 
-      await this.programDB.updateProgramsState(
-        missingVideos.map((ep) => ep.uuid),
-        'missing',
-      );
-      await this.searchService.updatePrograms(
-        missingVideos.map((ep) => ({
-          id: ep.uuid,
-          state: 'missing',
-        })),
-      );
+        await this.programDB.updateProgramsState(
+          missingVideos.map((ep) => ep.uuid),
+          'missing',
+        );
+        await this.searchService.updatePrograms(
+          missingVideos.map((ep) => ({
+            id: ep.uuid,
+            state: 'missing',
+          })),
+        );
+      }
 
       this.logger.debug('Completed scanning library %s', context.library.uuid);
     } finally {


### PR DESCRIPTION
Fixes #2027

The OtherVideo, MusicVideo and MusicArtist library scanners never referenced `ScanContext.pathFilter`, so a targeted single-item scan re-walked the entire library instead of narrowing to the one requested item. The Movie/TvShow scanners already honor it — they skip non-matching items and guard the mark-missing pass with `if (isEmpty(context.pathFilter))`.

This ports that pattern to the three scanners:
- `MediaSourceOtherVideoScanner` / `MediaSourceMusicVideoScanner` (near-identical linear scans): skip a video whose `externalId` doesn't match `pathFilter`, and skip the whole mark-missing pass when a filter is set.
- `MediaSourceMusicArtistScanner` (artist → album → track walk): skip non-matching artists and guard the mark-missing pass the same way.

The scan narrows to the requested item, so a targeted scan no longer reprocesses the whole library (the mark-missing diff stays correct because it's suppressed when a filter is active).

Regression test (`MediaSourceOtherVideoScanner.test.ts`): with `pathFilter` set, only the matching item is processed and nothing is marked missing; without it, every item is scanned and the unseen persisted item is marked missing. Verified RED before the fix, GREEN after.

- [x] `vitest run src/services/scanner/MediaSourceOtherVideoScanner.test.ts` passes
- [x] `pnpm lint-changed` clean
- [x] server `tsgo` typecheck clean
- [x] prettier clean
