### PR TITLE
fix(api): validate and sanitize slot groups on the save programming path

### DIFF
--- a/server/src/api/channelsApi.ts
+++ b/server/src/api/channelsApi.ts
@@ -536,6 +536,7 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
         body: UpdateChannelProgrammingRequestSchema,
         response: {
           200: CondensedChannelProgrammingSchema,
+          400: z.string(),
           404: z.void(),
           500: z.void(),
           501: z.void(),
@@ -547,9 +548,46 @@ export const channelsApi: RouterPluginAsyncCallback = async (fastify) => {
         return res.status(404).send();
       }
 
+      // The schedule-time-slots / schedule-slots preview endpoints validate
+      // slot groups, but this save path persisted whatever schedule it was
+      // given verbatim. Run the same validation here and persist the
+      // sanitized slots (linkMode stripped from slots without an
+      // iterationGroup) so an invalid or unsanitized group can't be saved
+      // and then regenerated badly by RegenerateChannelLineupCommand.
+      let programmingRequest = req.body;
+      if (req.body.type === 'time') {
+        const groupValidation = validateSlotGroups(req.body.schedule.slots, {
+          scheduleType: 'time',
+        });
+        if (!groupValidation.valid) {
+          return res.status(400).send(groupValidation.errors.join('; '));
+        }
+        programmingRequest = {
+          ...req.body,
+          schedule: {
+            ...req.body.schedule,
+            slots: groupValidation.sanitizedSlots,
+          },
+        };
+      } else if (req.body.type === 'random') {
+        const groupValidation = validateSlotGroups(req.body.schedule.slots, {
+          scheduleType: 'random',
+        });
+        if (!groupValidation.valid) {
+          return res.status(400).send(groupValidation.errors.join('; '));
+        }
+        programmingRequest = {
+          ...req.body,
+          schedule: {
+            ...req.body.schedule,
+            slots: groupValidation.sanitizedSlots,
+          },
+        };
+      }
+
       const result = await req.serverCtx.channelDB.updateLineup(
         req.params.id,
-        req.body,
+        programmingRequest,
       );
 
       if (isNil(result)) {

--- a/server/tests/channelProgrammingValidation.test.ts
+++ b/server/tests/channelProgrammingValidation.test.ts
@@ -1,0 +1,113 @@
+import { SaveableChannel } from '@tunarr/types';
+import { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { v4 } from 'uuid';
+import { container } from '../src/container.ts';
+import { ChannelDB } from '../src/db/ChannelDB.ts';
+import { TranscodeConfigDB } from '../src/db/TranscodeConfigDB.ts';
+import { KEYS } from '../src/types/inject.ts';
+import { getAvailablePort } from '../src/util/net.ts';
+import { initTestApp } from './testServer.js';
+
+let app: FastifyInstance;
+let validTranscodeConfigId: string;
+
+const NON_EXISTENT_UUID = '00000000-0000-0000-0000-000000000000';
+
+function makeChannelPayload(
+  transcodeConfigId: string,
+): Partial<SaveableChannel> {
+  return {
+    name: 'Test Channel',
+    number: 8001,
+    duration: 60000,
+    groupTitle: 'test',
+    guideMinimumDuration: 30000,
+    icon: {
+      path: '',
+      width: 0,
+      duration: 0,
+      position: 'bottom-right',
+    },
+    id: NON_EXISTENT_UUID,
+    startTime: 0,
+    stealth: false,
+    offline: { mode: 'pic' },
+    streamMode: 'hls',
+    transcodeConfigId,
+    disableFillerOverlay: false,
+    subtitlesEnabled: false,
+  };
+}
+
+beforeAll(async () => {
+  app = await initTestApp(await getAvailablePort());
+  const transcodeConfigDB = container.get(TranscodeConfigDB);
+  const defaultConfig = await transcodeConfigDB.getDefaultConfig();
+  if (!defaultConfig) {
+    throw new Error('Default transcode config not found after bootstrap');
+  }
+  validTranscodeConfigId = defaultConfig.uuid;
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+async function createChannel(): Promise<string> {
+  const channelDB = container.get<ChannelDB>(KEYS.ChannelDB);
+  const result = await channelDB.saveChannel({
+    ...makeChannelPayload(validTranscodeConfigId),
+    name: 'Programming Validation Channel',
+  } as SaveableChannel);
+  return result.channel.uuid;
+}
+
+describe('POST /channels/:id/programming - slot group validation on the save path', () => {
+  test('rejects a schedule whose slots share an iterationGroup with mismatched ordering', async () => {
+    const channelId = await createChannel();
+    const groupId = v4();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/channels/${channelId}/programming`,
+      payload: {
+        type: 'time',
+        programs: [],
+        schedule: {
+          type: 'time',
+          flexPreference: 'distribute',
+          latenessMs: 0,
+          maxDays: 1,
+          padMs: 0,
+          period: 'day',
+          timeZoneOffset: 0,
+          slots: [
+            {
+              type: 'movie',
+              id: v4(),
+              startTime: 0,
+              order: 'next',
+              direction: 'asc',
+              iterationGroup: groupId,
+            },
+            {
+              type: 'movie',
+              id: v4(),
+              startTime: 0,
+              order: 'shuffle',
+              direction: 'asc',
+              iterationGroup: groupId,
+            },
+          ],
+        },
+      },
+    });
+
+    // The two slots share an iterationGroup but disagree on ordering — the
+    // schedule must be rejected on the save path just like the preview
+    // endpoints reject it, instead of being persisted and regenerated badly.
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain('mismatched orderings');
+  });
+});


### PR DESCRIPTION
Fixes #2023

`validateSlotGroups` ran on the two schedule **preview** endpoints but never on the **save** path (`POST /channels/:id/programming`), so a mismatched slot group could be persisted verbatim and then regenerated badly by `RegenerateChannelLineupCommand`. The sanitization (stripping `linkMode` from slots that have no `iterationGroup`) also never reached persistence.

This runs the same validation + sanitization in the save handler — before `updateLineup` — returning 400 with the validation errors for an invalid group and persisting the sanitized slots otherwise, matching what the schedule-time-slots / schedule-slots preview endpoints already do. `scheduleType` is derived from the body via separate `time`/`random` branches so the slot arrays stay homogeneous.

Regression test (`tests/channelProgrammingValidation.test.ts`): POSTs a time schedule whose two slots share an `iterationGroup` but disagree on ordering → asserted 400 with "mismatched orderings" (previously this returned 200 and persisted). Verified RED before the fix, GREEN after.

- [x] `vitest run tests/channelProgrammingValidation.test.ts` passes
- [x] `pnpm lint-changed` clean
- [x] server `tsgo` typecheck clean
- [x] prettier clean
