### PR TITLE
fix(tasks): don't pause on-demand channels with zero sessions

### DIFF
--- a/server/src/tasks/OnDemandChannelStateTask.test.ts
+++ b/server/src/tasks/OnDemandChannelStateTask.test.ts
@@ -1,0 +1,77 @@
+import type { IChannelDB } from '@/db/interfaces/IChannelDB.ts';
+import type { OnDemandChannelService } from '@/services/OnDemandChannelService.js';
+import type { SessionManager } from '@/stream/SessionManager.js';
+import { describe, expect, test, vi } from 'vitest';
+
+// OnDemandChannelStateTask imports OnDemandChannelService (and transitively
+// SessionManager) through Inversify bindings that only resolve inside a booted
+// container. Mock the DI classes before importing the task, mirroring
+// SessionManager.test.ts.
+vi.mock('@/services/OnDemandChannelService.js', () => ({
+  OnDemandChannelService: class {},
+}));
+vi.mock('@/services/EventService.js', () => ({
+  EventService: class {},
+}));
+
+import { OnDemandChannelStateTask } from './OnDemandChannelStateTask.ts';
+
+function makeSut(sessionConnections: number[]) {
+  const channelDB = {
+    loadAllLineupConfigs: vi.fn().mockResolvedValue({
+      cfg1: { channel: { uuid: 'ch1' } },
+    }),
+  } as unknown as IChannelDB;
+
+  const onDemandService = {
+    pauseChannel: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OnDemandChannelService;
+
+  const sessionManager = {
+    getAllSessionsForChannel: vi.fn().mockReturnValue(
+      sessionConnections.map((count) => ({
+        numConnections: () => count,
+      })),
+    ),
+  } as unknown as SessionManager;
+
+  const task = new OnDemandChannelStateTask(
+    channelDB,
+    onDemandService,
+    sessionManager,
+  );
+
+  return { task, onDemandService, sessionManager };
+}
+
+describe('OnDemandChannelStateTask', () => {
+  test('does not pause a channel with zero sessions', async () => {
+    const { task, onDemandService } = makeSut([]);
+
+    await task.run(undefined);
+
+    // lodash `every([])` returns true, so without the length guard this
+    // would call pauseChannel on every tick for a channel with no sessions.
+    expect(onDemandService.pauseChannel).not.toHaveBeenCalled();
+  });
+
+  test('pauses a channel whose sessions are all idle', async () => {
+    const { task, onDemandService } = makeSut([0, 0]);
+
+    await task.run(undefined);
+
+    expect(onDemandService.pauseChannel).toHaveBeenCalledTimes(1);
+    expect(onDemandService.pauseChannel).toHaveBeenCalledWith(
+      'ch1',
+      expect.any(Number),
+    );
+  });
+
+  test('does not pause a channel with an active session', async () => {
+    const { task, onDemandService } = makeSut([1, 0]);
+
+    await task.run(undefined);
+
+    expect(onDemandService.pauseChannel).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/tasks/OnDemandChannelStateTask.ts
+++ b/server/src/tasks/OnDemandChannelStateTask.ts
@@ -44,6 +44,7 @@ export class OnDemandChannelStateTask extends SimpleTask {
         channel.uuid,
       );
       if (
+        allChannelSessions.length > 0 &&
         every(allChannelSessions, (session) => session.numConnections() === 0)
       ) {
         this.onDemandService.pauseChannel(channel.uuid, stopTime).catch((e) => {


### PR DESCRIPTION
Fixes #2025

`OnDemandChannelStateTask` calls `pauseChannel` when every session for a channel has zero connections. With **no** sessions at all, lodash `every([])` returns `true`, so a channel with zero sessions (and, per the unresolved `TODO`, non-on-demand channels too) got `pauseChannel` invoked on **every tick** — idle work on the pause/scheduler path.

The fix guards the condition on `allChannelSessions.length > 0`, so a channel with no sessions is left alone. Two further inconsistencies the issue lists (raw vs external connection counting, and the resume path bypass) are deliberately out of scope here — they're noted as follow-ups in the issue.

Regression test (`OnDemandChannelStateTask.test.ts`): zero sessions → `pauseChannel` not called (RED before the fix, GREEN after); all-idle sessions → paused; an active session → not paused.
- [x] `vitest run src/tasks/OnDemandChannelStateTask.test.ts` passes (3)
- [x] `pnpm lint-changed --branch` clean
- [x] server `tsgo` typecheck clean
- [x] prettier clean
