### PR TITLE
fix(ffmpeg): stabilize peak luminance in VAAPI/CPU tonemap filters

### DIFF
--- a/server/src/ffmpeg/builder/filter/TonemapFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/TonemapFilter.test.ts
@@ -27,7 +27,7 @@ describe('TonemapFilter', () => {
 
     expect(filter.filter).to.eq(
       'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,' +
-        'tonemap=tonemap=hable:desat=0,' +
+        'tonemap=tonemap=hable:desat=0:peak=1000,' +
         'zscale=t=bt709:m=bt709:r=tv,format=yuv420p',
     );
   });
@@ -46,7 +46,7 @@ describe('TonemapFilter', () => {
     expect(filter.filter).to.eq(
       'hwdownload,format=p010le|nv12,' +
         'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,' +
-        'tonemap=tonemap=hable:desat=0,' +
+        'tonemap=tonemap=hable:desat=0:peak=1000,' +
         'zscale=t=bt709:m=bt709:r=tv,format=yuv420p',
     );
   });

--- a/server/src/ffmpeg/builder/filter/TonemapFilter.ts
+++ b/server/src/ffmpeg/builder/filter/TonemapFilter.ts
@@ -1,5 +1,6 @@
 import { FilterOption } from '@/ffmpeg/builder/filter/FilterOption.js';
 import { PixelFormatYuv420P } from '@/ffmpeg/builder/format/PixelFormat.js';
+import { DefaultTonemapPeakNits } from '@/ffmpeg/builder/options/KnownFfmpegOptions.js';
 import type { FrameState } from '@/ffmpeg/builder/state/FrameState.js';
 import { FrameDataLocation } from '@/ffmpeg/builder/types.js';
 import { ColorFormat } from '../format/ColorFormat.ts';
@@ -15,7 +16,7 @@ export class TonemapFilter extends FilterOption {
     const transfer = this.currentState.colorFormat?.colorTransfer;
     // DV Profile 5 may have `color_transfer = null/unknown` explicitly specify so zscale does not incorrectly convert PQ when color transfer is unknown
     const tinParam = transfer ? `:tin=${transfer}` : '';
-    const tonemap = `zscale=t=linear${tinParam}:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p`;
+    const tonemap = `zscale=t=linear${tinParam}:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0:peak=${DefaultTonemapPeakNits},zscale=t=bt709:m=bt709:r=tv,format=yuv420p`;
     return this.currentState.frameDataLocation === FrameDataLocation.Hardware
       ? `hwdownload,format=p010le|nv12,${tonemap}`
       : tonemap;

--- a/server/src/ffmpeg/builder/filter/opencl/TonemapOpenclFilter.test.ts
+++ b/server/src/ffmpeg/builder/filter/opencl/TonemapOpenclFilter.test.ts
@@ -26,7 +26,7 @@ describe('TonemapOpenclFilter', () => {
     const filter = new TonemapOpenclFilter(currentState);
 
     expect(filter.filter).to.eq(
-      'hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1',
+      'hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:peak=1000:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1',
     );
   });
 
@@ -42,7 +42,7 @@ describe('TonemapOpenclFilter', () => {
     const filter = new TonemapOpenclFilter(currentState);
 
     expect(filter.filter).to.eq(
-      'format=vaapi|nv12|p010le,hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1',
+      'format=vaapi|nv12|p010le,hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:peak=1000:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1',
     );
   });
 

--- a/server/src/ffmpeg/builder/filter/opencl/TonemapOpenclFilter.ts
+++ b/server/src/ffmpeg/builder/filter/opencl/TonemapOpenclFilter.ts
@@ -3,6 +3,7 @@ import {
   PixelFormatNv12,
   PixelFormatUnknown,
 } from '@/ffmpeg/builder/format/PixelFormat.js';
+import { DefaultTonemapPeakNits } from '@/ffmpeg/builder/options/KnownFfmpegOptions.js';
 import type { FrameState } from '@/ffmpeg/builder/state/FrameState.js';
 import { FrameDataLocation } from '@/ffmpeg/builder/types.js';
 import { ColorFormat } from '../../format/ColorFormat.ts';
@@ -13,8 +14,7 @@ export class TonemapOpenclFilter extends FilterOption {
   }
 
   public get filter(): string {
-    const tonemap =
-      'hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1';
+    const tonemap = `hwmap=derive_device=opencl,tonemap_opencl=tonemap=hable:desat=0:peak=${DefaultTonemapPeakNits}:t=bt709:m=bt709:p=bt709:format=nv12,hwmap=derive_device=vaapi:reverse=1`;
     return this.currentState.frameDataLocation === FrameDataLocation.Hardware
       ? tonemap
       : `format=vaapi|nv12|p010le,${tonemap}`;

--- a/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
+++ b/server/src/ffmpeg/builder/options/KnownFfmpegOptions.ts
@@ -3,6 +3,16 @@ export const KnownFfmpegOptions = {
   GpuCopy: 'gpu_copy',
 } as const;
 
+// Fixed reference peak (nits) used by tonemap filters that support a
+// `peak` override. Without this, ffmpeg re-derives the peak from each
+// frame's mastering-display/CLL side data, which can change scene-to-scene
+// on some HDR10 encodes and cause the tone curve to visibly re-anchor at
+// cuts. A static value trades per-title accuracy for a stable image.
+// TODO: derive this per-title from probed mastering-display/CLL metadata
+// (not currently captured by ffprobe parsing) and fall back to this
+// constant when absent.
+export const DefaultTonemapPeakNits = 1000;
+
 export const KnownFfmpegFilters = {
   ScaleNpp: 'scale_npp',
   ScaleCuda: 'scale_cuda',


### PR DESCRIPTION
Set a fixed peak instead of letting ffmpeg re-derive it from each frame's mastering-display/CLL side data, which caused visible brightness pumping at scene cuts on the VAAPI (tonemap_opencl) and CPU tonemap fallback paths.