### PR TITLE
fix(hls): don't refresh heartbeat on playlist-only polls (#2045)

### DIFF
--- a/server/src/api/streamApi-heartbeat.test.ts
+++ b/server/src/api/streamApi-heartbeat.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from 'vitest';
+import { shouldRefreshHeartbeatForFragment } from './streamApi.js';
+
+vi.mock('../container.js', () => ({ container: { get: vi.fn() } }));
+vi.mock('@/stream/VideoStream.js', () => ({ VideoStream: class {} }));
+
+// Note: this unit test locks the heartbeat-gating invariant that is the fix
+// for issue #2045 — a playlist-only poll must not keep a client's session
+// "alive", or its pinned _minByIp segment entry would hold the HLS playlist
+// window open for every other viewer.
+
+describe('shouldRefreshHeartbeatForFragment', () => {
+  test('a variant-playlist poll for HLS stream modes does NOT refresh the heartbeat', () => {
+    expect(shouldRefreshHeartbeatForFragment('stream.m3u8', 'hls')).toBe(
+      false,
+    );
+    expect(shouldRefreshHeartbeatForFragment('stream.m3u8', 'hls_direct_v2')).toBe(
+      false,
+    );
+  });
+
+  test('a segment request DOES refresh the heartbeat', () => {
+    expect(shouldRefreshHeartbeatForFragment('data000010.ts', 'hls')).toBe(
+      true,
+    );
+    expect(shouldRefreshHeartbeatForFragment('data000010.ts', 'hls_direct_v2')).toBe(
+      true,
+    );
+  });
+
+  test('a subtitle request DOES refresh the heartbeat', () => {
+    expect(shouldRefreshHeartbeatForFragment('fileSequence.vtt', 'hls')).toBe(
+      true,
+    );
+  });
+
+  test('a non-HLS session type serves the playlist normally (no gating)', () => {
+    // hls_slower has no stream.m3u8 play- poll (it serves the master via a
+    // separate route), so its fragment requests keep the heartbeat as before.
+    expect(shouldRefreshHeartbeatForFragment('stream.m3u8', 'hls_slower')).toBe(
+      true,
+    );
+    expect(
+      shouldRefreshHeartbeatForFragment('data000010.ts', 'hls_slower'),
+    ).toBe(true);
+  });
+});

--- a/server/src/api/streamApi.ts
+++ b/server/src/api/streamApi.ts
@@ -36,6 +36,29 @@ export function injectTimestampMap(vttContent: string): string {
   );
 }
 
+/**
+ * Whether a fragment-route request should refresh the session heartbeat for
+ * its client IP.
+ *
+ * A poll of the variant playlist (`stream.m3u8`) for the HLS stream modes is
+ * NOT a sign the client is consuming media: a paused player / backgrounded tab
+ * keeps the manifest alive without ever requesting a new segment. If that poll
+ * refreshed the heartbeat, such a client would stay "alive" indefinitely while
+ * its `_minByIp` entry stayed pinned at its last (low) requested segment —
+ * holding the playlist window open for every other viewer (issue #2045). So a
+ * playlist poll must NOT refresh the heartbeat; segment / subtitle / other
+ * file requests do.
+ */
+export function shouldRefreshHeartbeatForFragment(
+  file: string,
+  sessionType: string,
+): boolean {
+  const isHlsPlaylistPoll =
+    file === 'stream.m3u8' &&
+    (sessionType === 'hls' || sessionType === 'hls_direct_v2');
+  return !isHlsPlaylistPoll;
+}
+
 export const streamApi: RouterPluginAsyncCallback = async (fastify) => {
   const logger = LoggerFactory.child({
     caller: import.meta,
@@ -303,7 +326,12 @@ export const streamApi: RouterPluginAsyncCallback = async (fastify) => {
           userAgent: req.headers['user-agent'],
         });
       }
-      session.recordHeartbeat(req.ip);
+
+      // A playlist-only poll must not keep the client "alive" — see
+      // shouldRefreshHeartbeatForFragment (issue #2045).
+      if (shouldRefreshHeartbeatForFragment(req.params.file, req.params.sessionType)) {
+        session.recordHeartbeat(req.ip);
+      }
 
       if (
         req.params.file === 'stream.m3u8' &&


### PR DESCRIPTION
Fixes #2045

## Problem

On a channel with more than one viewer, the HLS playlist window can stop advancing for everyone once a client stops requesting segments — a paused player, a backgrounded tab, a device that went to sleep. The departed client's last-requested (low/old) segment keeps holding the window open for every other viewer.

## Root cause

In the fragment route (`server/src/api/streamApi.ts`), `session.recordHeartbeat(req.ip)` ran for **every** file request — including a poll of the variant playlist (`stream.m3u8`). But the playlist poll takes an early return *before* `onSegmentRequested` is ever called (the fragment route only updates `_minByIp` when segments are actually requested).

So a client that only polls `stream.m3u8` (paused player / backgrounded tab keeps the manifest alive) stays "alive" forever — heartbeat fresh, never stale-cleaned — while its `_minByIp` entry stays pinned at its last requested segment. `minSegmentRequested` then anchors the playlist window there for all viewers.

## Fix

Extract an `shouldRefreshHeartbeatForFragment` helper: a variant-playlist poll in the HLS modes (`stream.m3u8` × `hls`/`hls_direct_v2`) does **not** refresh the heartbeat; segment, subtitle and other file requests do. A playlist-only client now goes stale after `stalenessMs`, `removeStaleConnections` drops it, and its pinned `_minByIp` entry is released — so the window resumes advancing for the surviving viewers.

A client actively watching keeps refreshing its heartbeat via its (continuous) segment requests; the master-playlist handshake is untouched. Semantics: *heartbeat = actively consuming media segments*, a manifest-only poller is idle.

## Test

- `server/src/api/streamApi-heartbeat.test.ts` (4 cases): locks the invariant — `stream.m3u8 × hls/hls_direct_v2` → no heartbeat; segments/subtitles/`hls_slower` → heartbeat. Verified **RED** against current `main` and **GREEN** with the fix.
- `vitest run src/api` — 18 tests pass.
- `pnpm lint-changed` clean.

## Note for reviewers

Happy to switch to the alternative approach (re-anchoring `_minByIp` on playlist poll instead of dropping the connection) if you'd prefer it over a disconnect-after-`stalenessMs`.
