### PR TITLE
fix(deps): bump @fastify/static to 10.1.3 to clear 5 security advisories (#2056)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
         specifier: ^9.0.3
         version: 9.2.1
       '@fastify/static':
-        specifier: ^8.2.0
-        version: 8.3.0
+        specifier: ^10.1.3
+        version: 10.1.3
       '@fastify/swagger':
         specifier: ^9.5.1
         version: 9.5.1
@@ -2055,8 +2055,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@8.3.0':
-    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+  '@fastify/static@10.1.3':
+    resolution: {integrity: sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==}
 
   '@fastify/swagger@9.5.1':
     resolution: {integrity: sha512-EGjYLA7vDmCPK7XViAYMF6y4+K3XUy5soVTVxsyXolNe/Svb4nFQxvtuQvvoQb2Gzc9pxiF3+ZQN/iZDHhKtTg==}
@@ -5043,9 +5043,9 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -5980,6 +5980,9 @@ packages:
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
 
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
+
   fastify-print-routes@3.2.0:
     resolution: {integrity: sha512-vbNliaT+SlZlH9sPYR1FYe3AJptbadf20/SjmramOxoeS6fdrAkMQu0H0/ZENaU4ruBlxCrUs0hUfV2J0dGyZw==}
     engines: {node: '>= 18.18.0'}
@@ -6285,6 +6288,10 @@ packages:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -7457,6 +7464,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -8041,6 +8052,10 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -11087,14 +11102,15 @@ snapshots:
       http-errors: 2.0.0
       mime: 3.0.0
 
-  '@fastify/static@8.3.0':
+  '@fastify/static@10.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.0
+      '@fastify/error': 4.2.0
       '@fastify/send': 4.1.0
-      content-disposition: 0.5.4
-      fastify-plugin: 5.0.1
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
       fastq: 1.17.1
-      glob: 11.0.0
+      glob: 13.0.6
 
   '@fastify/swagger@9.5.1':
     dependencies:
@@ -14261,9 +14277,7 @@ snapshots:
 
   consola@3.4.2: {}
 
-  content-disposition@0.5.4:
-    dependencies:
-      safe-buffer: 5.2.1
+  content-disposition@2.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -15368,6 +15382,8 @@ snapshots:
 
   fastify-plugin@5.0.1: {}
 
+  fastify-plugin@6.0.0: {}
+
   fastify-print-routes@3.2.0:
     dependencies:
       acquerello: 2.0.8
@@ -15747,6 +15763,12 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -16866,6 +16888,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minipass@7.1.3: {}
+
   minizlib@2.1.2:
     dependencies:
       minipass: 3.3.6
@@ -17495,6 +17519,11 @@ snapshots:
     dependencies:
       lru-cache: 11.0.1
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.3
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "@fastify/cors": "^10.1.0",
     "@fastify/error": "^4.2.0",
     "@fastify/multipart": "^9.0.3",
-    "@fastify/static": "^8.2.0",
+    "@fastify/static": "^10.1.3",
     "@fastify/swagger": "^9.5.1",
     "@iptv/xmltv": "^1.0.1",
     "@logdna/tail-file": "^4.0.2",

--- a/server/tests/fastify-static-serving.test.ts
+++ b/server/tests/fastify-static-serving.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { getAvailablePort } from '../src/util/net.ts';
+import { initTestApp } from './testServer.ts';
+
+// Manual-test-equivalent pass for the @fastify/static bump (#2056): boot the
+// real app once and hit every static-serving surface, proving 10.1.3 serves
+// files exactly as 8.3.0 did (root+prefix, decorateReply, sendFile, serve:true
+// and serve:false registrations).
+
+describe('static file serving after @fastify/static bump (#2056)', () => {
+  let app: Awaited<ReturnType<typeof initTestApp>>;
+
+  beforeAll(async () => {
+    // One boot per process — fastify-graceful-shutdown registers a global
+    // SIGINT handler, so a second boot in the same process conflicts.
+    app = await initTestApp(await getAvailablePort());
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  test('app boots and /favicon.svg is served via reply.sendFile', async () => {
+    const res = await app.inject('/favicon.svg');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image/svg');
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('/favicon.ico is served via reply.sendFile', async () => {
+    const res = await app.inject('/favicon.ico');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image');
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('root+prefix registration still serves under /images/', async () => {
+    const res = await app.inject('/images/favicon.svg');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image/svg');
+  });
+
+  test('an unknown asset under a served root returns 404, not a crash', async () => {
+    const res = await app.inject('/images/definitely-missing-asset.svg');
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('the legacy stream catch-all registration is still mounted', async () => {
+    // /streams/ is the legacy @fastify/static catch-all (serve:true,
+    // decorateReply:true). A missing file must 404 cleanly — proving the
+    // registration itself mounted without throwing under 10.1.3.
+    const res = await app.inject('/streams/definitely-missing.ts');
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
Fixes #2056

Bump `@fastify/static` from `^8.2.0` (resolving **8.3.0**) to `^10.1.3`, which clears all five security advisories in the issue:

| Advisory | Severity | Cleared in |
|---|---|---|
| GHSA-83w8-p2f5-377r (non-leading `..` / `%2E%2E`) | high | 10.1.1 |
| GHSA-423g-23ch-w7c6 (`.` and `//` segments) | high | 10.1.3 |
| GHSA-8pvw-jcv7-9cmj (non-canonical paths) | medium | 10.1.2 |
| GHSA-x428-ghpx-8j92 (`%2F` separators) | medium | 9.1.1 |
| GHSA-pr96-94w5-mx2h (directory listing) | medium | 9.1.1 |

## Validation

- **Registry options compatible**: all four `@fastify/static` registrations use only options still supported in 10.1.3 (`root`, `prefix`, `serve: false`, `decorateReply`, `reply.sendFile`) — confirmed against the installed package source.
- **App boots**: `nativePlayback.test.ts` + `channels.test.ts` (full `initTestApp` boot, which registers every static route) — 10/10 pass with 10.1.3 installed.
- **Lockfile**: minimal — only `@fastify/static` 8.3.0→10.1.3 plus its direct transitives (`content-disposition` 2.0.1, `glob` 13).
- `pnpm audit` no longer reports the five advisories (only an unrelated transitive `glob>minimatch>brace-expansion` path remains, not part of this issue).

## Note

As the issue notes, the five advisories aren't exploitable in Tunarr's current config (no `allowedPath`/`list`/route-based guards). This is a code-health bump to remove known-high CVEs and stay on a maintained major line.
