### PR TITLE
fix(server): honor --log_level/-v CLI flags in the logger

### DIFF
--- a/server/src/cli/types.ts
+++ b/server/src/cli/types.ts
@@ -1,7 +1,7 @@
 import type { LogLevels } from '@/util/logging/LoggerFactory.js';
 
 export type GlobalArgsType = {
-  log_level: LogLevels;
+  log_level: LogLevels | undefined;
   verbose: number;
   database: string;
 };

--- a/server/src/globals.ts
+++ b/server/src/globals.ts
@@ -29,7 +29,7 @@ let _serverOptions: ServerOptions | undefined;
 
 // Can overrwrite global options! Used only for tests!
 export const setGlobalOptionsUnchecked = (runtimeOptions: GlobalArgsType) => {
-  let logLevel: LogLevels = runtimeOptions.log_level;
+  let logLevel: LogLevels | undefined = runtimeOptions.log_level;
   if (!isUndefined(runtimeOptions.verbose) && runtimeOptions.verbose > 0) {
     const level = Math.max(runtimeOptions.verbose, 4);
     const levelKey = findKey(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,10 +3,7 @@ dotenv.config({ debug: false, quiet: true, ignore: ['MISSING_ENV_FILE'] });
 
 import { bootstrapTunarr } from '@/bootstrap.js';
 import { setGlobalOptions } from '@/globals.js';
-import {
-  getDefaultDatabaseDirectory,
-  getDefaultLogLevel,
-} from '@/util/defaults.js';
+import { getDefaultDatabaseDirectory } from '@/util/defaults.js';
 import type { LogLevels } from '@/util/logging/LoggerFactory.js';
 import { ValidLogLevels } from '@/util/logging/LoggerFactory.js';
 import { getTunarrVersion } from '@/util/version.js';
@@ -54,7 +51,7 @@ yargs(hideBin(process.argv))
   .option('log_level', {
     type: 'string',
     choices: ValidLogLevels,
-    default: getDefaultLogLevel(),
+    default: undefined,
     coerce(arg) {
       return arg as LogLevels;
     },

--- a/server/src/util/logging/LoggerFactory.test.ts
+++ b/server/src/util/logging/LoggerFactory.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBaseLogLevel } from './LoggerFactory.ts';
+
+/**
+ * Regression for #1992 — `--log_level`/`-v` had no effect on the running
+ * server: the CLI flags were resolved into `globalOptions().log_level` by
+ * `setGlobalOptionsUnchecked` but the logger only consulted settings/env and
+ * never honored it. The base level resolution now gives explicit CLI flags
+ * top priority, falling back to env (when enabled) then settings.
+ */
+describe('resolveBaseLogLevel (#1992)', () => {
+  it('honors an explicit --log_level flag over env and settings', () => {
+    expect(
+      resolveBaseLogLevel({
+        cliLogLevel: 'debug',
+        envLogLevel: 'warn',
+        useEnvVarLevel: true,
+        settingsLogLevel: 'error',
+      }),
+    ).toEqual({ source: 'cli', level: 'debug' });
+  });
+
+  it('honors -v/--verbose (as debug) when log_level is not set', () => {
+    // verbose resolves to 'debug' in setGlobalOptionsUnchecked, so it arrives
+    // here as cliLogLevel === 'debug'.
+    expect(
+      resolveBaseLogLevel({
+        cliLogLevel: 'debug',
+        envLogLevel: undefined,
+        useEnvVarLevel: true,
+        settingsLogLevel: 'info',
+      }),
+    ).toEqual({ source: 'cli', level: 'debug' });
+  });
+
+  it('does not clobber settings when no flag was passed and env is off', () => {
+    // yargs default is now undefined, so the flag "not passed" is a real
+    // signal: with useEnvVarLevel off, the saved settings level must win.
+    expect(
+      resolveBaseLogLevel({
+        cliLogLevel: undefined,
+        envLogLevel: 'debug',
+        useEnvVarLevel: false,
+        settingsLogLevel: 'info',
+      }),
+    ).toEqual({ source: 'settings', level: 'info' });
+  });
+
+  it('falls back to env when enabled and no CLI flag was passed', () => {
+    expect(
+      resolveBaseLogLevel({
+        cliLogLevel: undefined,
+        envLogLevel: 'trace',
+        useEnvVarLevel: true,
+        settingsLogLevel: 'info',
+      }),
+    ).toEqual({ source: 'env', level: 'trace' });
+  });
+});

--- a/server/src/util/logging/LoggerFactory.ts
+++ b/server/src/util/logging/LoggerFactory.ts
@@ -1,4 +1,5 @@
 import type { SettingsDB } from '@/db/SettingsDB.js';
+import { globalOptions } from '@/globals.js';
 import type { Maybe, TupleToUnion } from '@/types/util.js';
 import { getDefaultLogLevel } from '@/util/defaults.js';
 import { inConstArr, isNonEmptyString, isTest } from '@/util/index.js';
@@ -230,16 +231,26 @@ class LoggerFactoryImpl {
 
   private get logLevel(): {
     level: LogLevels;
-    source: 'env' | 'settings';
+    source: 'cli' | 'env' | 'settings';
   } {
-    if (this.settingsDB?.systemSettings().logging.useEnvVarLevel) {
-      const envLevel = getEnvironmentLogLevel();
-      if (!isUndefined(envLevel)) {
-        return { source: 'env', level: envLevel };
-      }
+    // The CLI flags are honored via globalOptions().log_level, which is
+    // undefined unless --log_level/-v was passed (see setGlobalOptionsUnchecked)
+    // so a yargs default never clobbers a saved settings.json level (#1992).
+    let cliLogLevel: LogLevels | undefined;
+    try {
+      cliLogLevel = globalOptions().log_level;
+    } catch {
+      // globalOptions() throws before setGlobalOptions() runs (logger is
+      // constructed at import); fall through to settings/env in that window.
+      cliLogLevel = undefined;
     }
 
-    return { level: this.systemSettingsLogLevel, source: 'settings' };
+    return resolveBaseLogLevel({
+      cliLogLevel,
+      envLogLevel: getEnvironmentLogLevel(),
+      useEnvVarLevel: this.settingsDB?.systemSettings().logging.useEnvVarLevel,
+      settingsLogLevel: this.systemSettingsLogLevel,
+    });
   }
 
   private get perCategoryLogLevel(): Record<string, LogLevels> {
@@ -331,5 +342,30 @@ class LoggerFactoryImpl {
 }
 
 export const LoggerFactory = new LoggerFactoryImpl();
+
+/**
+ * Pure resolution of the base log level, in priority order. The CLI flags
+ * (`--log_level` / `-v`) are the most explicit override; `cliLogLevel` is the
+ * value in `globalOptions().log_level`, which is `undefined` when neither flag
+ * was passed (so a yargs default never clobbers settings). Env applies only
+ * when the `useEnvVarLevel` setting is on; otherwise settings win.
+ */
+export function resolveBaseLogLevel(p: {
+  cliLogLevel: LogLevels | undefined;
+  envLogLevel: Maybe<LogLevels>;
+  useEnvVarLevel: boolean | undefined;
+  settingsLogLevel: LogLevels;
+}): { level: LogLevels; source: 'cli' | 'env' | 'settings' } {
+  if (!isUndefined(p.cliLogLevel)) {
+    return { source: 'cli', level: p.cliLogLevel };
+  }
+  if (p.useEnvVarLevel) {
+    const envLevel = p.envLogLevel;
+    if (!isUndefined(envLevel)) {
+      return { source: 'env', level: envLevel };
+    }
+  }
+  return { source: 'settings', level: p.settingsLogLevel };
+}
 
 export const RootLogger = LoggerFactory.root;


### PR DESCRIPTION
## Summary
`--log_level`/`-v` were resolved into `globalOptions().log_level` by `setGlobalOptionsUnchecked`, but `LoggerFactory.logLevel` only consulted settings/env — so the CLI flags never reached the running logger. This honors an explicitly-passed flag.

## Approach
- Make the yargs `log_level` default `undefined` so an explicit flag stays distinguishable from a default (otherwise honoring `globalOptions().log_level` would clobber a saved `settings.json` level).
- Extract a pure `resolveBaseLogLevel({cliLogLevel, envLogLevel, useEnvVarLevel, settingsLogLevel})` giving an explicit CLI flag top priority, then env (when `useEnvVarLevel` is on), then settings.
- `LoggerFactory.logLevel` now calls it; the `globalOptions()` read is guarded for the pre-`setGlobalOptions` import window.

## Test
`server/src/util/logging/LoggerFactory.test.ts` — 4 unit tests covering priority + the no-clobber-when-flag-absent case.

Fixes #1992