### PR TITLE
fix(plex): invalidate canonical items when Plex labels change

### DIFF
--- a/server/src/services/PlexMediaCanonicalizers.test.ts
+++ b/server/src/services/PlexMediaCanonicalizers.test.ts
@@ -212,6 +212,25 @@ describe('PlexMediaCanonicalizer - movie', () => {
     );
   });
 
+  it('changes id when a label is added', () => {
+    expect(canonicalizer.getCanonicalId(baseMovie)).not.toBe(
+      canonicalizer.getCanonicalId({
+        ...baseMovie,
+        Label: [{ tag: 'Favorites' }],
+      }),
+    );
+  });
+
+  it('changes id when a label tag changes', () => {
+    const labeled = { ...baseMovie, Label: [{ tag: 'Favorites' }] };
+    expect(canonicalizer.getCanonicalId(labeled)).not.toBe(
+      canonicalizer.getCanonicalId({
+        ...labeled,
+        Label: [{ tag: 'Watch Later' }],
+      }),
+    );
+  });
+
   it('changes id when a second media entry is added', () => {
     const secondMedia: PlexMediaDescription = {
       id: 20,
@@ -348,6 +367,15 @@ describe('PlexMediaCanonicalizer - show', () => {
       canonicalizer.getCanonicalId({
         ...baseShow,
         Collection: [{ tag: 'Collection X' }, { tag: 'Collection Y' }],
+      }),
+    );
+  });
+
+  it('changes id when a label is added', () => {
+    expect(canonicalizer.getCanonicalId(baseShow)).not.toBe(
+      canonicalizer.getCanonicalId({
+        ...baseShow,
+        Label: [{ tag: 'Favorites' }],
       }),
     );
   });
@@ -849,6 +877,25 @@ describe('PlexMediaCanonicalizer - episode', () => {
         ...baseEpisode,
         Director: [],
         Role: [{ tag: 'X' }],
+      }),
+    );
+  });
+
+  it('changes id when a label is added', () => {
+    expect(canonicalizer.getCanonicalId(baseEpisode)).not.toBe(
+      canonicalizer.getCanonicalId({
+        ...baseEpisode,
+        Label: [{ tag: 'Favorites' }],
+      }),
+    );
+  });
+
+  it('changes id when a label tag changes', () => {
+    const labeled = { ...baseEpisode, Label: [{ tag: 'Favorites' }] };
+    expect(canonicalizer.getCanonicalId(labeled)).not.toBe(
+      canonicalizer.getCanonicalId({
+        ...labeled,
+        Label: [{ tag: 'Watch Later' }],
       }),
     );
   });

--- a/server/src/services/PlexMediaCanonicalizers.ts
+++ b/server/src/services/PlexMediaCanonicalizers.ts
@@ -39,6 +39,23 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
     }
   }
 
+  /**
+   * Fold an array of Plex tags (e.g. `Label`) into the content hash. Labels are
+   * editable per-item in Plex without touching title/dates/media, so they must
+   * participate in the hash or a label-only change would not trigger a
+   * re-canonicalization (#2021).
+   */
+  private hashPlexTags(
+    hash: crypto.Hash,
+    key: string,
+    tags?: readonly { tag: string }[],
+  ) {
+    for (const tag of tags ?? []) {
+      hash.update(key);
+      hash.update(tag.tag);
+    }
+  }
+
   private canonicalizePlexMovie(plexMovie: PlexMovie): string {
     const hash = crypto.createHash('sha1');
     hash.update(plexMovie.key);
@@ -59,6 +76,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
       }
     }
 
+    this.hashPlexTags(hash, 'label', plexMovie.Label);
+
     return hash.digest('base64');
   }
 
@@ -77,6 +96,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
       hash.update('collection');
       hash.update(collection.tag);
     }
+
+    this.hashPlexTags(hash, 'label', plexShow.Label);
 
     return hash.digest('base64');
   }
@@ -104,6 +125,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
     if (isNonEmptyString(plexSeason.thumb)) {
       hash.update(plexSeason.thumb);
     }
+
+    this.hashPlexTags(hash, 'label', plexSeason.Label);
 
     return hash.digest('base64');
   }
@@ -154,6 +177,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
       hash.update(role.tag);
     }
 
+    this.hashPlexTags(hash, 'label', plexEpisode.Label);
+
     return hash.digest('base64');
   }
 
@@ -185,6 +210,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
       (g) => hash.update(g.tag),
     );
 
+    this.hashPlexTags(hash, 'label', plexArtist.Label);
+
     return hash.digest('base64');
   }
 
@@ -207,6 +234,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
     plexAlbum.Genre?.toSorted((a, b) => a.tag.localeCompare(b.tag)).forEach(
       (g) => hash.update(g.tag),
     );
+
+    this.hashPlexTags(hash, 'label', plexAlbum.Label);
 
     return hash.digest('base64');
   }
@@ -246,6 +275,8 @@ export class PlexMediaCanonicalizer implements Canonicalizer<PlexMedia> {
     seq.collect(compact(flatten([plexMusicTrack.Guid])), (keyVal) => {
       hash.update(keyVal.id);
     });
+
+    this.hashPlexTags(hash, 'label', plexMusicTrack.Label);
 
     return hash.digest('base64');
   }


### PR DESCRIPTION
## Summary
The Plex content-hash canonicalizers (movie, show, season, episode, artist, album, track) folded `key`/`title`/`addedAt`/`updatedAt` and media/tag fields into the sha1, but never `Label`. Editing an item's labels in Plex updates `updatedAt`? — no: in practice a pure label edit doesn't surface as a content change here, so the canonical id stays identical and the item is never re-canonicalized (stale pick/modification). This makes label changes participate in the hash so they invalidate items (#2021).

## Changes
- New private `hashPlexTags(hash, key, tags)` helper.
- Call it with `'label'` for `Label` on all seven item canonicalizers.

## Test
`PlexMediaCanonicalizers.test.ts` — added "changes id when a label is added" / "changes id when a label tag changes" for movie, show and episode. 134 tests pass, no tsc errors.

Fixes #2021