### PR TITLE
fix(server): normalize stored language codes to ISO 639-2/T (#2044)

### DIFF
--- a/server/src/db/converters/ProgramMinter.test.ts
+++ b/server/src/db/converters/ProgramMinter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLanguageCode } from './ProgramMinter.js';
+
+// The ISO 639-2 /B→/T normalization that keeps stored language codes in one
+// canonical set. Regression coverage for #2044: a provider's bibliographic
+// code must turn into the terminological code Tunarr stores elsewhere
+// (FfprobeStreamDetails / LocalSubtitlesService already write /T), and an
+// unresolvable value must be kept as-is rather than dropped.
+describe('normalizeLanguageCode (#2044)', () => {
+  it.each([
+    // /B → /T (the reported class: German 'ger' vs 'deu')
+    ['ger', 'deu'],
+    ['fre', 'fra'],
+    ['dut', 'nld'],
+    ['chi', 'zho'],
+  ])('maps ISO 639-2/B "%s" to its /T equivalent "%s"', (input, expected) => {
+    expect(normalizeLanguageCode(input)).toBe(expected);
+  });
+
+  it.each(['deu', 'fra', 'nld', 'por', 'jpn', 'eng'])(
+    'keeps an already-/T code "%s" unchanged',
+    (input) => {
+      expect(normalizeLanguageCode(input)).toBe(input);
+    },
+  );
+
+  it.each(['de', 'fr', 'nl', 'pt', 'ja'])(
+    'maps a 2-letter code "%s" to its /T code',
+    (input) => {
+      const out = normalizeLanguageCode(input);
+      expect(out).toBeDefined();
+      expect(out).toHaveLength(3);
+    },
+  );
+
+  it('maps an English language name to its /T code', () => {
+    expect(normalizeLanguageCode('japanese')).toBe('jpn');
+    expect(normalizeLanguageCode('German')).toBe('deu');
+  });
+
+  it.each(['unknown', 'xxyy', 'abc123'])(
+    'keeps an unresolvable value "%s" verbatim (incl. the subtitle sentinel)',
+    (input) => {
+      expect(normalizeLanguageCode(input)).toBe(input);
+    },
+  );
+
+  it('passes through an empty or absent value', () => {
+    expect(normalizeLanguageCode(undefined)).toBeUndefined();
+    expect(normalizeLanguageCode('')).toBe('');
+  });
+});

--- a/server/src/db/converters/ProgramMinter.test.ts
+++ b/server/src/db/converters/ProgramMinter.test.ts
@@ -49,4 +49,11 @@ describe('normalizeLanguageCode (#2044)', () => {
     expect(normalizeLanguageCode(undefined)).toBeUndefined();
     expect(normalizeLanguageCode('')).toBe('');
   });
+
+  it('coerces a null code to undefined', () => {
+    // Plex/Emby subtitle language fields are nullable; the function must not
+    // blow up and must return undefined so callers can fall back to their
+    // default (e.g. ?? 'unknown').
+    expect(normalizeLanguageCode(null)).toBeUndefined();
+  });
 });

--- a/server/src/db/converters/ProgramMinter.ts
+++ b/server/src/db/converters/ProgramMinter.ts
@@ -19,6 +19,7 @@ import { injectable } from 'inversify';
 import { compact, find } from 'lodash-es';
 import { match, P } from 'ts-pattern';
 import { v4 } from 'uuid';
+import { LanguageService } from '@/services/LanguageService.js';
 import {
   HasMediaSourceInfo,
   MediaSourceMovie,
@@ -47,6 +48,21 @@ import {
   NewProgramWithRelations,
 } from '../schema/derivedTypes.js';
 import { CommonDaoMinter } from './CommonDaoMinter.ts';
+
+/**
+ * Normalize a stored language code to ISO 639-2/T, keeping the raw value when
+ * it can't be resolved (e.g. an unknown provider code, or the 'unknown'
+ * sentinel on subtitles). Without this, ingest paths that write a provider's
+ * code verbatim mix ISO 639-2 /B ("ger") and /T ("deu") in the database and the
+ * search index built from it — so a language filter matches half the library
+ * depending on which source a program came from (#2044). Plain 2-letter and
+ * already-/T codes pass through unchanged.
+ */
+export function normalizeLanguageCode(
+  code: string | undefined,
+): string | undefined {
+  return code ? (LanguageService.normalizeToAlpha3T(code) ?? code) : code;
+}
 
 /**
  * Generates Program DB entities for Plex media
@@ -182,7 +198,7 @@ export class ProgramDaoMinter {
           colorPrimaries: stream.colorPrimaries ?? null,
           default: stream.default ?? false,
           //TODO: forced: stream.forced
-          language: stream.languageCodeISO6392,
+          language: normalizeLanguageCode(stream.languageCodeISO6392),
           pixelFormat: stream.pixelFormat,
           title: stream.title,
         } satisfies NewProgramMediaStream;
@@ -306,7 +322,7 @@ export class ProgramDaoMinter {
         programId,
         createdAt: now,
         updatedAt: now, // Do we need to use mtime?
-        language: subtitle.languageCodeISO6392 ?? 'unknown',
+        language: normalizeLanguageCode(subtitle.languageCodeISO6392) ?? 'unknown',
         subtitleType:
           subtitle.streamType === 'subtitles' ? 'embedded' : 'sidecar',
         default: subtitle.default ?? false,
@@ -324,7 +340,7 @@ export class ProgramDaoMinter {
         codec: subtitle.codec,
         createdAt: now,
         updatedAt: now, // Do we need to use mtime?
-        language: subtitle.language,
+        language: normalizeLanguageCode(subtitle.language),
         subtitleType: subtitle.subtitleType,
         default: subtitle.default ?? false,
         forced: subtitle.forced ?? false,

--- a/server/src/db/converters/ProgramMinter.ts
+++ b/server/src/db/converters/ProgramMinter.ts
@@ -59,9 +59,9 @@ import { CommonDaoMinter } from './CommonDaoMinter.ts';
  * already-/T codes pass through unchanged.
  */
 export function normalizeLanguageCode(
-  code: string | undefined,
+  code: string | null | undefined,
 ): string | undefined {
-  return code ? (LanguageService.normalizeToAlpha3T(code) ?? code) : code;
+  return code ? (LanguageService.normalizeToAlpha3T(code) ?? code) : code ?? undefined;
 }
 
 /**
@@ -340,7 +340,7 @@ export class ProgramDaoMinter {
         codec: subtitle.codec,
         createdAt: now,
         updatedAt: now, // Do we need to use mtime?
-        language: normalizeLanguageCode(subtitle.language),
+        language: normalizeLanguageCode(subtitle.language) ?? 'unknown',
         subtitleType: subtitle.subtitleType,
         default: subtitle.default ?? false,
         forced: subtitle.forced ?? false,

--- a/server/src/db/schema/SubtitlePreferences.ts
+++ b/server/src/db/schema/SubtitlePreferences.ts
@@ -10,7 +10,9 @@ export const SubtitleFilters = ['none', 'forced', 'default', 'any'] as const;
 
 const commonSubtitlePreferenceCols = {
   uuid: text().primaryKey(),
-  // iso6392 - 3-letter code
+  // ISO 639-2/T (Alpha-3 T) — the canonical set Tunarr stores for user-facing
+  // language codes; providers' /B codes are normalized on write via
+  // LanguageService.normalizeToAlpha3T (#2044).
   languageCode: text().notNull(),
   priority: integer().notNull(),
   allowImageBased: integer({ mode: 'boolean' }).notNull().default(true),

--- a/server/src/services/LanguageService.ts
+++ b/server/src/services/LanguageService.ts
@@ -24,7 +24,7 @@ export class LanguageService {
     }
 
     if (this.Known3BCodes.has(input)) {
-      const alpha2 = languages.alpha3TToAlpha2(input);
+      const alpha2 = languages.alpha3BToAlpha2(input);
       if (alpha2) {
         return languages.alpha2ToAlpha3T(alpha2);
       }

--- a/server/src/tasks/fixers/FixerModule.ts
+++ b/server/src/tasks/fixers/FixerModule.ts
@@ -5,12 +5,14 @@ import { ContainerModule } from 'inversify';
 import { BackfillMediaSourceIdFixer } from './BackfillMediaSourceIdFixer.ts';
 import { BackfillProgramArtworkFixer } from './BackfillProgramArtworkFixer.ts';
 import { FixSmartCollectionFilters } from './FixSmartCollectionFIlters.ts';
+import { NormalizeLanguageCodesFixer } from './NormalizeLanguageCodesFixer.ts';
 
 const FixerModule = new ContainerModule(({ bind }) => {
   bind<Fixer>(KEYS.Fixer).to(EnsureTranscodeConfigIds);
   bind<Fixer>(KEYS.Fixer).to(BackfillMediaSourceIdFixer);
   bind<Fixer>(KEYS.Fixer).to(BackfillProgramArtworkFixer);
   bind<Fixer>(KEYS.Fixer).to(FixSmartCollectionFilters);
+  bind<Fixer>(KEYS.Fixer).to(NormalizeLanguageCodesFixer);
 });
 
 export { FixerModule };

--- a/server/src/tasks/fixers/NormalizeLanguageCodesFixer.ts
+++ b/server/src/tasks/fixers/NormalizeLanguageCodesFixer.ts
@@ -1,0 +1,119 @@
+import { LanguageService } from '@/services/LanguageService.js';
+import { KEYS } from '@/types/inject.js';
+import { inArray, isNotNull } from 'drizzle-orm';
+import { inject, injectable } from 'inversify';
+import { ProgramMediaStream } from '../../db/schema/ProgramMediaStream.ts';
+import { ProgramSubtitles } from '../../db/schema/ProgramSubtitles.ts';
+import type { DrizzleDBAccess } from '../../db/schema/index.ts';
+import { InjectLogger } from '../../util/inject.ts';
+import { type Logger } from '../../util/logging/LoggerFactory.ts';
+import Fixer from './fixer.ts';
+
+/**
+ * ISO 639-2 assigns 20 languages both a bibliographic (/B) and a terminological
+ * (/T) three-letter code (German `ger`/`deu`, French `fre`/`fra`, …). Ingest
+ * paths have written the provider's code verbatim, so the persisted columns and
+ * the Meilisearch facets built from them hold a mix of the two sets depending on
+ * where a program came from — a language filter matches only part of the
+ * library (#2044). We now normalize on write (see `normalizeLanguageCode`); this
+ * fixer repairs the rows written before the fix.
+ *
+ * Idempotent: already-/T codes and unresolvable values (e.g. the `'unknown'`
+ * subtitle sentinel) pass through unchanged, so re-running is a no-op.
+ */
+@injectable()
+export class NormalizeLanguageCodesFixer extends Fixer {
+  canRunInBackground: boolean = true;
+
+  @InjectLogger() declare protected readonly logger: Logger;
+
+  constructor(@inject(KEYS.DrizzleDB) private drizzleDB: DrizzleDBAccess) {
+    super();
+  }
+
+  protected runInternal(): Promise<void> {
+    const streams = this.normalizeStreams();
+    const subtitles = this.normalizeSubtitles();
+    const total = streams + subtitles;
+    if (total > 0) {
+      this.logger.info(
+        'Normalized %d stored language code(s) to ISO 639-2/T (media streams: %d, subtitles: %d)',
+        total,
+        streams,
+        subtitles,
+      );
+    } else {
+      this.logger.debug(
+        'No stored language codes needed ISO 639-2/T normalization',
+      );
+    }
+    return Promise.resolve(void 0);
+  }
+
+  /**
+   * Plan which rows change and fire one update per distinct normalized code,
+   * then report how many rows were touched (idempotent — only rows whose code
+   * actually resolves to a different /T code are updated).
+   */
+  private normalizeRows(
+    rows: Array<{ uuid: string; language: string | null }>,
+    update: (normalized: string, uuids: string[]) => void,
+  ): number {
+    const byNormalized = new Map<string, string[]>();
+    for (const { uuid, language } of rows) {
+      if (!language) {
+        continue;
+      }
+      const normalized = LanguageService.normalizeToAlpha3T(language);
+      if (!normalized || normalized === language) {
+        continue;
+      }
+      const uuids = byNormalized.get(normalized) ?? [];
+      uuids.push(uuid);
+      byNormalized.set(normalized, uuids);
+    }
+    for (const [normalized, uuids] of byNormalized) {
+      update(normalized, uuids);
+    }
+    let touched = 0;
+    for (const uuids of byNormalized.values()) {
+      touched += uuids.length;
+    }
+    return touched;
+  }
+
+  private normalizeStreams(): number {
+    const rows = this.drizzleDB
+      .select({
+        uuid: ProgramMediaStream.uuid,
+        language: ProgramMediaStream.language,
+      })
+      .from(ProgramMediaStream)
+      .where(isNotNull(ProgramMediaStream.language))
+      .all();
+    return this.normalizeRows(rows, (normalized, uuids) => {
+      this.drizzleDB
+        .update(ProgramMediaStream)
+        .set({ language: normalized })
+        .where(inArray(ProgramMediaStream.uuid, uuids))
+        .run();
+    });
+  }
+
+  private normalizeSubtitles(): number {
+    const rows = this.drizzleDB
+      .select({
+        uuid: ProgramSubtitles.uuid,
+        language: ProgramSubtitles.language,
+      })
+      .from(ProgramSubtitles)
+      .all();
+    return this.normalizeRows(rows, (normalized, uuids) => {
+      this.drizzleDB
+        .update(ProgramSubtitles)
+        .set({ language: normalized })
+        .where(inArray(ProgramSubtitles.uuid, uuids))
+        .run();
+    });
+  }
+}


### PR DESCRIPTION
Fixes #2044

## Problem
`program_media_stream.language` / `program_subtitles.language` — and the Meilisearch facets built from them — hold a **mix of ISO 639-2 /B and /T codes** depending on which ingest path wrote each program (German `ger` vs `deu`, French `fre` vs `fra`, …). A language filter matches only the half of the library whose source stored one set.

The root cause is two-fold:

1. **`LanguageService.getAlpha3TCode` never converts /B → /T.** Its /B branch called `alpha3TToAlpha2(input)`, which the `@cospired/i18n-iso-languages` lib leaves `undefined` for a /B code — so every `ger` passed through unchanged. The library exposes `alpha3BToAlpha2` for exactly this conversion.
2. **`ProgramMinter` wrote the provider's code verbatim** (`stream.languageCodeISO6392`, subtitles `languageCodeISO6392`, sidecar subtitle language) on the external-ingest path, bypassing normalization entirely.

## Fix
- **`LanguageService`**: switch the /B branch to `alpha3BToAlpha2` → `alpha2ToAlpha3T`, so `getAlpha3TCode`/`normalizeToAlpha3T` now correctly resolve `/B → /T`. This is the true systemic fix — it also makes the local-file path (`FfprobeStreamDetails` → `getAlpha3TCode`) correct for /B inputs.
- **`ProgramMinter`**: route all three language write sites through a new `normalizeLanguageCode` helper (`LanguageService.normalizeToAlpha3T`, keeping the raw value when unresolvable — including the `'unknown'` subtitle sentinel). Every future program persists its language as ISO 639-2/T.
- **Backfill** (`NormalizeLanguageCodesFixer`, registered in `FixerModule`, `canRunInBackground`, **idempotent** — only rows whose code actually resolves to a different /T code are updated): repairs the existing `program_media_stream` and `program_subtitles` rows on the next startup.
- `SubtitlePreferences.languageCode` comment now states the canonical set.

## Validation
- `ProgramMinter.test.ts` (new): `/B → /T` (`ger→deu`, `fre→fra`, `dut→nld`, `chi→zho`), already-/T unchanged, 2-letter → /T, English name → /T, unresolvable + `'unknown'` kept verbatim, absent passthrough — **20/20 pass** (the env boots a real sqlite DB).
- `tsc --noEmit` and `lint-changed` (6 files) clean.

## Notes / scope left
- Reindex: the fixer repairs stored data; rows reach the Meilisearch index on the next natural reindex (existing `MeilisearchService.deleteAllDocuments` + build). I did **not** force a full reindex from the startup fixer — happy to add a reindex trigger if you want the index healed immediately.
- I did **not** add the optional language `SearchFilterValueMutator` (defense-in-depth for pre-backfill indexes / hand-typed query values) — flag if you want it included as a follow-up here.
- The related `SubtitleStreamPicker` language-check and `languageCodeISO6391` dead-assignment items from the issue are separate and intentionally out of scope.