### PR TITLE
fix(external): round Jellyfin/Emby RunTimeTicks durations to integer ms (#2032)

### DIFF
--- a/server/src/external/emby/EmbyApiClient.ts
+++ b/server/src/external/emby/EmbyApiClient.ts
@@ -1221,7 +1221,7 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: movie.RunTimeTicks / 10_000,
+      duration: Math.round(movie.RunTimeTicks / 10_000),
       externalId: movie.Id,
       artwork: compact([
         this.embyArtworkProjection('poster', movie, 'Primary'),
@@ -1566,7 +1566,7 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
         episode,
         this.options.mediaSource.uuid,
       ),
-      duration: episode.RunTimeTicks / 10_000,
+      duration: Math.round(episode.RunTimeTicks / 10_000),
       artwork: compact([
         this.embyArtworkProjection('poster', episode, 'Primary'),
         this.embyArtworkProjection('banner', episode, 'Banner'),
@@ -1736,7 +1736,7 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
               }
             : null,
         ) ?? [],
-      duration: track.RunTimeTicks / 10_000,
+      duration: Math.round(track.RunTimeTicks / 10_000),
       externalId: track.Id,
       artwork: compact([
         this.embyArtworkProjection('poster', track, 'Primary'),
@@ -1808,7 +1808,7 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: video.RunTimeTicks / 10_000,
+      duration: Math.round(video.RunTimeTicks / 10_000),
       externalId: video.Id,
       artwork: compact([
         this.embyArtworkProjection('poster', video, 'Primary'),
@@ -1880,7 +1880,7 @@ export class EmbyApiClient extends MediaSourceApiClient<EmbyItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: video.RunTimeTicks / 10_000,
+      duration: Math.round(video.RunTimeTicks / 10_000),
       externalId: video.Id,
       artwork: compact([
         this.embyArtworkProjection('poster', video, 'Primary'),

--- a/server/src/external/jellyfin/JellyfinApiClient.ts
+++ b/server/src/external/jellyfin/JellyfinApiClient.ts
@@ -1161,7 +1161,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: movie.RunTimeTicks / 10_000,
+      duration: Math.round(movie.RunTimeTicks / 10_000),
       externalId: movie.Id,
       artwork: compact([
         this.jellyfinArtworkProjection('poster', movie, 'Primary'),
@@ -1540,7 +1540,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
         episode,
         this.options.mediaSource.uuid,
       ),
-      duration: episode.RunTimeTicks / 10_000,
+      duration: Math.round(episode.RunTimeTicks / 10_000),
       artwork: compact([
         this.jellyfinArtworkProjection('poster', episode, 'Primary'),
         this.jellyfinArtworkProjection('banner', episode, 'Banner'),
@@ -1710,7 +1710,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
               }
             : null,
         ) ?? [],
-      duration: track.RunTimeTicks / 10_000,
+      duration: Math.round(track.RunTimeTicks / 10_000),
       externalId: track.Id,
       artwork: compact([
         this.jellyfinArtworkProjection('poster', track, 'Primary'),
@@ -1786,7 +1786,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: video.RunTimeTicks / 10_000,
+      duration: Math.round(video.RunTimeTicks / 10_000),
       externalId: video.Id,
       artwork: compact([
         this.jellyfinArtworkProjection('poster', video, 'Primary'),
@@ -1858,7 +1858,7 @@ export class JellyfinApiClient extends MediaSourceApiClient<JellyfinItemTypes> {
       ),
       mediaSourceId: this.options.mediaSource.uuid,
       libraryId: '', // We can't know this at this point...
-      duration: video.RunTimeTicks / 10_000,
+      duration: Math.round(video.RunTimeTicks / 10_000),
       externalId: video.Id,
       artwork: compact([
         this.jellyfinArtworkProjection('poster', video, 'Primary'),


### PR DESCRIPTION
Fixes #2032

## Problem
Jellyfin and Emby report durations as `RunTimeTicks` (100-ns units). Ten item-canonicalization sites divided by `10_000` **without rounding**, so any `RunTimeTicks` that is not a multiple of 10,000 produced a fractional-millisecond value. SQLite stores that as a `REAL` in `Program.duration` despite the column being declared `integer().notNull()` — a silent schema violation that then propagates into `lineupItem.durationMs` and `sum(durationMs)` → `channel.duration`. Plex is unaffected (integer ms).

The two same-file sites that already guarded this used `Math.ceil` — good evidence the fractional case is real, the guard was just never applied to the item-canonicalization paths.

## Fix
`Math.round(RunTimeTicks / 10_000)` at all **10 unrounded sites** (Jellyfin: `JellyfinApiClient.ts` movie/episode/track/2× video; Emby: `EmbyApiClient.ts` same five shapes, same order). Nearest-ms rounding recovers the true duration for real media (sub-ms inflation from `Math.ceil` serves no purpose).

`channel.duration` write sites and `syncChannelDuration` are deliberately untouched, per the issue: rounding there would be reverted by the raw-sum write-back.

## Validation
- `tsc` clean on both changed files (after building `@tunarr/types` + `@tunarr/shared`)
- Existing `JellyfinApiClient` test: **2/2 passed** (Emby has no dedicated unit test; both files are the same shape)
- `lint-changed` clean, `prettier --check` clean
- No un-rounded `duration: X.RunTimeTicks / 10_000` site remains in either file (10/10 verified)