### PR TITLE
fix(scheduling): build a filler iterator per list *and* order

### DIFF
--- a/server/src/services/scheduling/TimeSlotService.test.ts
+++ b/server/src/services/scheduling/TimeSlotService.test.ts
@@ -8,9 +8,11 @@ import { createFakeProgramOrm } from '../../testing/fakes/entityCreators.ts';
 import { groupByUniq } from '../../util/index.ts';
 import type { SlotSchedulerProgram } from './slotSchedulerUtil.js';
 import {
+  createFillerIterators,
   createProgramMap,
   createSlotIterators,
   deduplicateSlotIds,
+  getFillerIteratorsForSlot,
 } from './slotSchedulerUtil.js';
 import { scheduleTimeSlots } from './TimeSlotService.ts';
 import { MersenneTwister19937, Random } from 'random-js';
@@ -635,6 +637,71 @@ describe('createSlotIterators unit', () => {
 
     // Rerun now sees ep3 from fresh buffer
     expect(itRerun.current(state)?.id).toBe('ep3');
+  });
+
+  test('one filler list at two orders builds an iterator for each', () => {
+    const fillerListId = randomUUID();
+    const fillerPrograms: SlotSchedulerProgram[] = Array.from(
+      { length: 6 },
+      (_, i) => ({
+        ...createFakeProgramOrm({
+          uuid: `bumper-${i}`,
+          title: `Bumper ${i}`,
+          type: 'movie',
+          duration: 2 * 60 * 1000,
+        }),
+        parentFillerLists: [fillerListId],
+        parentCustomShows: [],
+        parentSmartCollections: [],
+      }),
+    );
+
+    const uniformSlot = {
+      id: randomUUID(),
+      startTime: 0,
+      type: 'show' as const,
+      showId: 'show1',
+      order: 'next' as const,
+      direction: 'asc' as const,
+      seasonFilter: [],
+      filler: [
+        {
+          types: ['tail' as const],
+          fillerListId,
+          fillerOrder: 'uniform' as const,
+        },
+      ],
+    };
+    const weightedSlot = {
+      ...uniformSlot,
+      id: randomUUID(),
+      startTime: 12 * 60 * 60 * 1000,
+      showId: 'show2',
+      filler: [
+        {
+          types: ['tail' as const],
+          fillerListId,
+          fillerOrder: 'shuffle_prefer_short' as const,
+        },
+      ],
+    };
+
+    const random = new Random(MersenneTwister19937.seed(42));
+    const iterators = createFillerIterators(
+      [uniformSlot, weightedSlot],
+      createProgramMap(fillerPrograms),
+      random,
+    );
+
+    expect(Object.keys(iterators)).toHaveLength(2);
+    expect(
+      Object.keys(getFillerIteratorsForSlot(uniformSlot, iterators, new Set())),
+    ).toEqual([fillerListId]);
+    expect(
+      Object.keys(
+        getFillerIteratorsForSlot(weightedSlot, iterators, new Set()),
+      ),
+    ).toEqual([fillerListId]);
   });
 });
 

--- a/server/src/services/scheduling/slotSchedulerUtil.ts
+++ b/server/src/services/scheduling/slotSchedulerUtil.ts
@@ -220,9 +220,13 @@ export function createFillerIterators(
   programBySlotType: ProgramMapping,
   random: Random,
 ): Partial<Record<SlotIteratorKey, ProgramIterator<FillerProgram>>> {
+  // Iterators are keyed by list *and* order, so a list referenced at two
+  // different orders needs one iterator per order. Deduping on the list id
+  // alone leaves the second order without an iterator, and slots using it
+  // silently get no filler.
   const slotFiller = uniqBy(
     slots.filter(slotHasFiller).flatMap((slot) => slot.filler ?? []),
-    ({ fillerListId }) => fillerListId,
+    ({ fillerListId, fillerOrder }) => `${fillerListId}_${fillerOrder}`,
   );
 
   const fillerIterators: Partial<


### PR DESCRIPTION
## Problem

`createFillerIterators` deduped slot filler definitions by `fillerListId` alone:

```ts
const slotFiller = uniqBy(
  slots.filter(slotHasFiller).flatMap((slot) => slot.filler ?? []),
  ({ fillerListId }) => fillerListId,
);
```

But it registers each iterator under `filler_<listId>_<order>` (via `slotIteratorKey`), and `getFillerIteratorsForSlot` looks it up by `(fillerListId, fillerOrder)`.

So when one filler list is referenced by two slots at different orders, only the first-seen order gets an iterator built. Every slot using the other order resolves to nothing — no `head`, `pre`, `post` or `tail` filler, no error, no log line. The slot just quietly plays without bumpers.

## Fix

Dedupe on the list id and order together, so each `(list, order)` pair gets its own iterator.

## Test

New unit test in the `createSlotIterators unit` block: two slots pointing at one filler list, one at `uniform` and one at `shuffle_prefer_short`. Asserts two iterators are built and that both slots resolve one.

Verified red before the fix (1 iterator built, expected 2) and green after.

## Checks

- 115 scheduling tests pass
- `pnpm lint-changed` clean
- `pnpm turbo typecheck` clean

Refs #1984 — found while confirming that issue's other reports (items 2–5 there were already fixed by #1985 in v1.3.12; this is a separate path to the same "head/tail filler not appearing" symptom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)