### PR TITLE
fix(hls): serve the live edge so one slow client cannot freeze the pl…

### DIFF
--- a/server/src/api/streamApi.ts
+++ b/server/src/api/streamApi.ts
@@ -324,8 +324,6 @@ export const streamApi: RouterPluginAsyncCallback = async (fastify) => {
           .send(playlist.playlist);
       }
 
-      session.onSegmentRequested(req.ip, req.params.file);
-
       if (req.params.file.endsWith('.vtt')) {
         const filePath = resolve(session.workingDirectory, req.params.file);
         if (!filePath.startsWith(session.workingDirectory + sep)) {

--- a/server/src/api/streamApiHlsConnections.test.ts
+++ b/server/src/api/streamApiHlsConnections.test.ts
@@ -1,11 +1,9 @@
 /**
- * POC: route-level regression test for issue #2045 / PR #2064.
+ * Route-level test for HLS connection registration.
  *
- * Demonstrates, through the *actual* streamApi HTTP routes, that on HLS
- * sessions the connection token registered by both the master-playlist
- * handshake and the fragment route is the client IP (never a UUID), so
- * `BaseHlsSession.removeConnection(token)` deletes the right `_minByIp`
- * entry and stale cleanup releases the playlist window.
+ * On HLS sessions the connection token registered by both the master-playlist
+ * handshake and the fragment route is the client IP, never a UUID. Session
+ * bookkeeping keyed by token and by IP therefore refers to the same thing.
  */
 import type { ChannelOrmWithTranscodeConfig } from '@/db/schema/derivedTypes.js';
 import { Result } from '@/types/result.js';
@@ -28,14 +26,6 @@ import { streamApi } from './streamApi.js';
 
 class TestHlsSession extends BaseHlsSession {
   public readonly sessionType = 'hls' as const;
-
-  get minByIp() {
-    return new Map(this._minByIp);
-  }
-
-  get minSegment() {
-    return this.minSegmentRequested;
-  }
 
   async getMasterPlaylist() {
     return Result.success<string | undefined>('#EXTM3U\n');
@@ -72,7 +62,7 @@ const baseOptions: BaseHlsSessionOptions = {
   stalenessMs: 120_000,
 };
 
-describe('streamApi HLS connection registration (issue #2045 invariant)', () => {
+describe('streamApi HLS connection registration', () => {
   let session: TestHlsSession;
   let app: ReturnType<typeof Fastify>;
   let sessionManager: {
@@ -136,39 +126,30 @@ describe('streamApi HLS connection registration (issue #2045 invariant)', () => 
     expect(Object.keys(session.connections())).toEqual(['203.0.113.10']);
   });
 
-  it('fragment route keys _minByIp and connections by the client IP, and stale cleanup releases the window', async () => {
-    // Client A is an active watcher near the live edge
+  it('fragment route keys connections by the client IP and stale cleanup drops them', async () => {
     await app.inject({
       method: 'GET',
       url: `/stream/channels/${makeChannel().uuid}/hls/data000100.ts`,
       remoteAddress: '203.0.113.10',
     });
-    // Client B requests segment 10 once and departs (PR #2064 scenario)
     await app.inject({
       method: 'GET',
       url: `/stream/channels/${makeChannel().uuid}/hls/data000010.ts`,
       remoteAddress: '203.0.113.20',
     });
 
-    // Invariant: every connection token equals the client IP it was
-    // registered under — a UUID-token connection never appears.
+    // Every connection token equals the client IP it was registered under —
+    // a UUID-token connection never appears on an HLS session.
     for (const [token, conn] of Object.entries(session.connections())) {
       expect(token).toBe(conn.ip);
     }
-    expect(session.minByIp.get('203.0.113.10')).toBe(100);
-    expect(session.minByIp.get('203.0.113.20')).toBe(10);
-    expect(session.minSegment).toBe(10); // window anchored to departed client
 
     // B goes quiet past the staleness window; A keeps heartbeating
     vi.setSystemTime(new Date(Date.now() + 121_000));
     session.recordHeartbeat('203.0.113.10');
     session.removeStaleConnections();
 
-    // B's IP entry is gone and the window advances to A's position.
-    // (This is the exact scenario PR #2064 guards against — it already
-    // behaves correctly through the real routes because token === ip.)
     expect(session.connections()).not.toHaveProperty('203.0.113.20');
-    expect(session.minByIp.has('203.0.113.20')).toBe(false);
-    expect(session.minSegment).toBe(100);
+    expect(session.connections()).toHaveProperty('203.0.113.10');
   });
 });

--- a/server/src/stream/hls/BaseHlsSession.test.ts
+++ b/server/src/stream/hls/BaseHlsSession.test.ts
@@ -10,14 +10,6 @@ import { BaseHlsSession } from './BaseHlsSession.ts';
 class TestHlsSession extends BaseHlsSession {
   public readonly sessionType = 'hls' as const;
 
-  get minByIp() {
-    return new Map(this._minByIp);
-  }
-
-  get minSegment() {
-    return this.minSegmentRequested;
-  }
-
   protected getHlsOptions(): DeepRequired<HlsOptions> {
     return {
       hlsDeleteThreshold: 3,
@@ -65,93 +57,7 @@ describe('BaseHlsSession', () => {
     vi.useRealTimers();
   });
 
-  describe('_minByIp stale connection cleanup', () => {
-    it('tracks segment numbers per IP when onSegmentRequested is called', () => {
-      session.onSegmentRequested('192.168.1.1', 'data000010.ts');
-      session.onSegmentRequested('192.168.1.2', 'data000020.ts');
-
-      expect(session.minByIp.get('192.168.1.1')).toBe(10);
-      expect(session.minByIp.get('192.168.1.2')).toBe(20);
-      expect(session.minSegment).toBe(10);
-    });
-
-    it('removes IP from _minByIp when removeConnection is called explicitly', () => {
-      session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
-      session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));
-      session.onSegmentRequested('192.168.1.1', 'data000010.ts');
-      session.onSegmentRequested('192.168.1.2', 'data000020.ts');
-
-      session.removeConnection('192.168.1.2');
-
-      expect(session.minByIp.has('192.168.1.2')).toBe(false);
-      expect(session.minSegment).toBe(10);
-    });
-
-    it('removes stale IP entries from _minByIp after removeStaleConnections', () => {
-      session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
-      session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));
-      session.onSegmentRequested('192.168.1.1', 'data000010.ts');
-      session.onSegmentRequested('192.168.1.2', 'data000050.ts');
-
-      // Advance time so device 2 is stale (>30s without heartbeat)
-      vi.advanceTimersByTime(31_000);
-      // Keep device 1 alive
-      session.recordHeartbeat('192.168.1.1');
-
-      session.removeStaleConnections();
-
-      expect(session.minByIp.has('192.168.1.2')).toBe(false);
-      expect(session.minByIp.has('192.168.1.1')).toBe(true);
-    });
-
-    it('minSegmentRequested reflects only live connections after stale cleanup — the frozen manifest fix', () => {
-      // Scenario from bug report:
-      // Device 2 is anchored at a low segment, causing the playlist window to freeze
-      session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
-      session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));
-
-      // Both devices request segments; device 2 stops at a low number
-      session.onSegmentRequested('192.168.1.1', 'data000100.ts');
-      session.onSegmentRequested('192.168.1.2', 'data000010.ts');
-
-      // Before stale cleanup: minimum is device 2's old anchored value
-      expect(session.minSegment).toBe(10);
-
-      // Device 2 disconnects (no more heartbeats), device 1 continues
-      vi.advanceTimersByTime(31_000);
-      session.recordHeartbeat('192.168.1.1');
-      session.onSegmentRequested('192.168.1.1', 'data000140.ts');
-
-      session.removeStaleConnections();
-
-      // After cleanup: playlist window is no longer anchored to device 2's old position
-      expect(session.minSegment).toBe(140);
-    });
-
-    it('_minByIp is empty and minSegmentRequested returns 0 when all connections go stale', () => {
-      session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
-      session.onSegmentRequested('192.168.1.1', 'data000010.ts');
-
-      vi.advanceTimersByTime(31_000);
-      session.removeStaleConnections();
-
-      expect(session.minByIp.size).toBe(0);
-      expect(session.minSegment).toBe(0);
-    });
-
-    it('does not affect IPs with no _minByIp entry when connection is removed', () => {
-      session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
-      session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));
-      session.onSegmentRequested('192.168.1.1', 'data000010.ts');
-      // Device 2 connected but never requested a segment (no _minByIp entry)
-
-      session.removeConnection('192.168.1.2');
-
-      // Device 1 is unaffected
-      expect(session.minByIp.get('192.168.1.1')).toBe(10);
-      expect(session.minSegment).toBe(10);
-    });
-
+  describe('session lifecycle', () => {
     it('stop() cancels a pending cleanup timer so it cannot fire on a replacement session', async () => {
       // This test covers the session lifecycle race condition:
       // 1. Session A loses all connections → scheduleCleanup() sets a 15s timer
@@ -181,8 +87,6 @@ describe('BaseHlsSession', () => {
     it('keeps a connection alive if heartbeat is refreshed within staleness window', () => {
       session.addConnection('192.168.1.1', makeConnection('192.168.1.1'));
       session.addConnection('192.168.1.2', makeConnection('192.168.1.2'));
-      session.onSegmentRequested('192.168.1.1', 'data000100.ts');
-      session.onSegmentRequested('192.168.1.2', 'data000050.ts');
 
       // Advance to just before staleness cutoff and refresh both heartbeats
       vi.advanceTimersByTime(20_000);
@@ -192,12 +96,7 @@ describe('BaseHlsSession', () => {
       // Advance again — both still within 30s of their last heartbeat
       vi.advanceTimersByTime(20_000);
 
-      session.removeStaleConnections();
-
-      // Neither entry should be removed
-      expect(session.minByIp.has('192.168.1.1')).toBe(true);
-      expect(session.minByIp.has('192.168.1.2')).toBe(true);
-      expect(session.minSegment).toBe(50);
+      expect(session.removeStaleConnections()).toHaveLength(2);
     });
   });
 });

--- a/server/src/stream/hls/BaseHlsSession.ts
+++ b/server/src/stream/hls/BaseHlsSession.ts
@@ -6,7 +6,7 @@ import { isNonEmptyString } from '@/util/index.js';
 import retry from 'async-retry';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { filter, isError, isNaN, isString, minBy, some } from 'lodash-es';
+import { filter, isError, isString, some } from 'lodash-es';
 import fs from 'node:fs/promises';
 import path, { basename, extname } from 'node:path';
 import type { DeepRequired } from 'ts-essentials';
@@ -32,16 +32,6 @@ export abstract class BaseHlsSession<
   protected _serverPath: string;
 
   protected transcodedUntil?: Dayjs;
-
-  protected _minByIp = new Map<string, number>();
-
-  protected get minSegmentRequested(): number {
-    if (this._minByIp.size === 0) {
-      return 0;
-    }
-
-    return minBy([...this._minByIp.entries()], ([_, seg]) => seg)?.[1] ?? 0;
-  }
 
   constructor(
     channel: ChannelOrmWithTranscodeConfig,
@@ -81,23 +71,6 @@ export abstract class BaseHlsSession<
 
   get serverPath() {
     return this._serverPath;
-  }
-
-  onSegmentRequested(clientIp: string, filename: string) {
-    const base = basename(filename);
-    const matches = base.match(SegmentNameRegex);
-    if (matches && matches.length > 1) {
-      const m = matches[1]!;
-      const parsed = parseInt(m);
-      if (!isNaN(parsed)) {
-        this._minByIp.set(clientIp, parsed);
-      }
-    }
-  }
-
-  override removeConnection(token: string) {
-    super.removeConnection(token);
-    this._minByIp.delete(token);
   }
 
   protected abstract getHlsOptions(): DeepRequired<HlsOptions>;

--- a/server/src/stream/hls/HlsPlaylistMutator.test.ts
+++ b/server/src/stream/hls/HlsPlaylistMutator.test.ts
@@ -482,9 +482,10 @@ describe('HlsPlaylistMutator', () => {
   });
 
   describe('discontinuity sequence calculation', () => {
-    // Playlist: 31 old-program segments (0–30), one DISC, 30 new-program
-    // segments (31–60). Total 61 segments, all numbered with 6 digits.
-    function createTransitionPlaylist(): string[] {
+    // Playlist: 31 old-program segments (0–30), one DISC, then new-program
+    // segments from 31 up to `lastSegment`. The window always ends at the live
+    // edge, so `lastSegment` is what positions it over the boundary.
+    function createTransitionPlaylist(lastSegment = 60): string[] {
       const lines = [
         '#EXTM3U',
         '#EXT-X-VERSION:3',
@@ -500,7 +501,7 @@ describe('HlsPlaylistMutator', () => {
         );
       }
       lines.push('#EXT-X-DISCONTINUITY');
-      for (let i = 31; i <= 60; i++) {
+      for (let i = 31; i <= lastSegment; i++) {
         lines.push(
           '#EXTINF:4.004000,',
           '#EXT-X-PROGRAM-DATE-TIME:2024-10-18T14:02:04.000-0400',
@@ -512,14 +513,12 @@ describe('HlsPlaylistMutator', () => {
 
     const start = dayjs('2024-10-18T14:00:00.000-0400');
 
-    function trimWithSegmentFilter(
-      segmentNumber: number,
-      segmentsToKeepBefore = 10,
-    ) {
+    // Window = the last 20 segments, i.e. [liveEdge - 19, liveEdge].
+    function trimAtLiveEdge(liveEdge: number) {
       return mutator.trimPlaylist(
         start,
-        { type: 'before_segment_number', segmentNumber, segmentsToKeepBefore },
-        createTransitionPlaylist(),
+        undefined,
+        createTransitionPlaylist(liveEdge),
         { ...defaultOpts, maxSegmentsToKeep: 20 },
       );
     }
@@ -535,38 +534,38 @@ describe('HlsPlaylistMutator', () => {
     }
 
     it('DISC in middle of selected window: disc-seq=0, DISC tag emitted', () => {
-      // minSeg = max(25-10, 0) = 15 → filtered segs 15..60 (46 >= 20) → take first 20 = segs 15..34
+      // Live edge 34 → window segs 15..34.
       // DISC between seg30 and seg31; seg31 IS in window → tag emitted, no counting
-      const result = trimWithSegmentFilter(25);
+      const result = trimAtLiveEdge(34);
       expect(discSeq(result.playlist)).toBe(0);
       expect(discTagCount(result.playlist)).toBe(1);
     });
 
     it('DISC immediately before first selected segment: folded into disc-seq, no tag emitted', () => {
-      // minSeg = max(41-10, 0) = 31 → filtered segs 31..60 (30 >= 20) → take first 20 = segs 31..50
+      // Live edge 50 → window segs 31..50.
       // DISC is immediately before seg31 (first selected segment).
       // Since there are no selected segments BEFORE the DISC, it must NOT be
       // emitted as a tag (that would create an empty leading period which
       // breaks Kodi's inputstream.adaptive). Instead it is folded into the
       // discontinuity sequence number.
-      const result = trimWithSegmentFilter(41);
+      const result = trimAtLiveEdge(50);
       expect(discSeq(result.playlist)).toBe(1);
       expect(discTagCount(result.playlist)).toBe(0);
     });
 
     it('DISC before window with a gap: disc-seq=1, DISC tag NOT emitted', () => {
-      // minSeg = max(45-10, 0) = 35 → filtered segs 35..60 (26 >= 20) → take first 20 = segs 35..54
+      // Live edge 54 → window segs 35..54.
       // DISC before seg31; seg31 not in window → DISC counted in sequence, not emitted
-      const result = trimWithSegmentFilter(45);
+      const result = trimAtLiveEdge(54);
       expect(discSeq(result.playlist)).toBe(1);
       expect(discTagCount(result.playlist)).toBe(0);
     });
 
     it('disc-seq is monotonically non-decreasing as the DISC rolls off the window', () => {
-      // Simulates three consecutive playlist polls as the client advances
-      const poll1 = trimWithSegmentFilter(25); // DISC in middle of window
-      const poll2 = trimWithSegmentFilter(41); // DISC before first selected (no segs before it)
-      const poll3 = trimWithSegmentFilter(45); // DISC before window with gap
+      // Simulates three consecutive playlist polls as the live edge advances
+      const poll1 = trimAtLiveEdge(34); // DISC in middle of window
+      const poll2 = trimAtLiveEdge(50); // DISC before first selected (no segs before it)
+      const poll3 = trimAtLiveEdge(54); // DISC before window with gap
 
       const seq1 = discSeq(poll1.playlist);
       const seq2 = discSeq(poll2.playlist);
@@ -585,7 +584,7 @@ describe('HlsPlaylistMutator', () => {
       //   DISC1
       //   prog2: segs 15–29 (15 segs)
       //   DISC2
-      //   prog3: segs 30–60 (31 segs)
+      //   prog3: segs 30–49 (20 segs)
       const lines = [
         '#EXTM3U',
         '#EXT-X-VERSION:3',
@@ -609,7 +608,7 @@ describe('HlsPlaylistMutator', () => {
         );
       }
       lines.push('#EXT-X-DISCONTINUITY');
-      for (let i = 30; i <= 60; i++) {
+      for (let i = 30; i <= 49; i++) {
         lines.push(
           '#EXTINF:4.004000,',
           '#EXT-X-PROGRAM-DATE-TIME:2024-10-18T14:02:00.000-0400',
@@ -617,23 +616,14 @@ describe('HlsPlaylistMutator', () => {
         );
       }
 
-      // minSeg = max(40-10, 0) = 30 → filtered segs 30..60 (31 >= 20) → take first 20 = segs 30..49
+      // Live edge 49 → window segs 30..49.
       // Both DISC1 and DISC2 are before the first selected segment (seg30).
       // Neither has selected segments before it, so both are folded into disc-seq.
-      const result = mutator.trimPlaylist(
-        start,
-        {
-          type: 'before_segment_number',
-          segmentNumber: 40,
-          segmentsToKeepBefore: 10,
-        },
-        lines,
-        {
-          ...defaultOpts,
-          maxSegmentsToKeep: 20,
-          previousDiscontinuitySequence: 1,
-        },
-      );
+      const result = mutator.trimPlaylist(start, undefined, lines, {
+        ...defaultOpts,
+        maxSegmentsToKeep: 20,
+        previousDiscontinuitySequence: 1,
+      });
 
       expect(discSeq(result.playlist)).toBe(2); // DISC1 + DISC2 both counted
       expect(discTagCount(result.playlist)).toBe(0); // no tags emitted
@@ -650,7 +640,7 @@ describe('HlsPlaylistMutator', () => {
     // Simulates a long-running channel: Program A (675 segments ≈ 45min)
     // followed by Program B. The sliding window eventually moves past all
     // of A's segments.
-    function createLongPlaylist(): string[] {
+    function createLongPlaylist(lastSegment = 79): string[] {
       const lines = [
         '#EXTM3U',
         '#EXT-X-VERSION:3',
@@ -667,8 +657,8 @@ describe('HlsPlaylistMutator', () => {
         );
       }
       lines.push('#EXT-X-DISCONTINUITY');
-      // Program B: 30 segments (50-79)
-      for (let i = 50; i < 80; i++) {
+      // Program B: segments 50 up to `lastSegment`
+      for (let i = 50; i <= lastSegment; i++) {
         lines.push(
           '#EXTINF:4.000000,',
           `#EXT-X-PROGRAM-DATE-TIME:2024-10-18T14:03:${String((i - 50) * 4).padStart(2, '0')}.000-0400`,
@@ -678,16 +668,16 @@ describe('HlsPlaylistMutator', () => {
       return lines;
     }
 
-    function trim(segmentNumber: number) {
+    // Window = the last 20 segments, i.e. [liveEdge - 19, liveEdge].
+    function trim(liveEdge: number) {
       return mutator.trimPlaylist(
         start,
+        undefined,
+        createLongPlaylist(liveEdge),
         {
-          type: 'before_segment_number',
-          segmentNumber,
-          segmentsToKeepBefore: 10,
+          ...defaultOpts,
+          maxSegmentsToKeep: 20,
         },
-        createLongPlaylist(),
-        { ...defaultOpts, maxSegmentsToKeep: 20 },
       );
     }
 
@@ -707,8 +697,8 @@ describe('HlsPlaylistMutator', () => {
     }
 
     it('window spanning the boundary: DISC between selected segments is emitted as tag', () => {
-      // Client at seg 45: window includes both A and B segments
-      const result = trim(45);
+      // Live edge 54 → window segs 35..54: includes both A and B segments
+      const result = trim(54);
       expect(discSeq(result.playlist)).toBe(0);
       expect(discTagCount(result.playlist)).toBe(1);
       expect(result.playlist).toContain('data000049.ts'); // last of A
@@ -716,26 +706,26 @@ describe('HlsPlaylistMutator', () => {
     });
 
     it('window just past the boundary: DISC folded into disc-seq, NOT emitted as tag', () => {
-      // Client at seg 60: first selected is seg50 (first of B).
+      // Live edge 69 → window segs 50..69: first selected is seg50 (first of B).
       // The DISC is before seg50 with no selected A segments before it.
       // CRITICAL: must NOT emit DISC tag (would create empty period 0).
-      const result = trim(60);
+      const result = trim(69);
       expect(discSeq(result.playlist)).toBe(1);
       expect(discTagCount(result.playlist)).toBe(0);
       expect(firstSegmentNum(result.playlist)).toBe(50);
     });
 
     it('window well past the boundary: DISC folded into disc-seq', () => {
-      const result = trim(70);
+      const result = trim(79);
       expect(discSeq(result.playlist)).toBe(1);
       expect(discTagCount(result.playlist)).toBe(0);
       expect(firstSegmentNum(result.playlist)).toBe(60);
     });
 
     it('no empty periods across the full transition', () => {
-      // Simulate the full client progression across the program boundary.
+      // Simulate the live edge advancing across the program boundary.
       // At every point, the first period must have at least one segment.
-      const polls = [40, 45, 50, 55, 60, 65, 70];
+      const polls = [49, 54, 59, 64, 69, 74, 79];
       for (const seg of polls) {
         const result = trim(seg);
         const lines = result.playlist.split('\n');
@@ -1056,6 +1046,48 @@ describe('HlsPlaylistMutator', () => {
       // The test file has 2 leading discontinuities in the header — these are
       // FFmpeg artifacts and should be ignored. First item should be a segment.
       expect(parsed[0]?.type).toBe('segment');
+    });
+  });
+  describe('live-edge window (issue #2045)', () => {
+    const mutator = new HlsPlaylistMutator();
+    const start = dayjs('2024-10-18T14:00:00.000-0400');
+    const opts = { ...defaultOpts, maxSegmentsToKeep: 20 };
+
+    function lastSegmentNum(playlist: string): number {
+      const matches = playlist.match(/data(\d{6})\.ts/g) ?? [];
+      const lastMatch = matches[matches.length - 1];
+      return lastMatch ? parseInt(lastMatch.slice(4, 10)) : -1;
+    }
+
+    it('window advances with the live edge as ffmpeg writes segments', () => {
+      for (const total of [200, 220, 260]) {
+        const result = mutator.trimPlaylist(
+          start,
+          undefined,
+          createPlaylist(total),
+          opts,
+        );
+        expect(result.segmentCount).toBe(20);
+        expect(lastSegmentNum(result.playlist)).toBe(total - 1);
+        expect(result.sequence).toBe(total - 20);
+      }
+    });
+
+    it('a client lagging far behind does not hold the window back', () => {
+      // A floor well below the live edge must not anchor the window to it.
+      const lagging = mutator.trimPlaylist(
+        start,
+        {
+          type: 'before_segment_number',
+          segmentNumber: 100,
+          segmentsToKeepBefore: 10,
+        },
+        createPlaylist(260),
+        opts,
+      );
+
+      expect(lastSegmentNum(lagging.playlist)).toBe(259);
+      expect(lagging.sequence).toBe(240);
     });
   });
 });

--- a/server/src/stream/hls/HlsPlaylistMutator.ts
+++ b/server/src/stream/hls/HlsPlaylistMutator.ts
@@ -6,10 +6,10 @@ import {
   filter,
   first,
   isEmpty,
+  isUndefined,
   last,
   nth,
   reject,
-  take,
   takeRight,
   trimEnd,
 } from 'lodash-es';
@@ -45,7 +45,7 @@ export type HlsPlaylistFilterOptions =
 export class HlsPlaylistMutator {
   trimPlaylist(
     start: Dayjs,
-    filter: HlsPlaylistFilterOptions,
+    filter: HlsPlaylistFilterOptions | undefined,
     playlistLines: string[],
     opts: MutateOptions,
   ): TrimPlaylistResult {
@@ -127,7 +127,7 @@ export class HlsPlaylistMutator {
 
   private generatePlaylist(
     items: PlaylistLine[],
-    filterOptions: HlsPlaylistFilterOptions,
+    filterOptions: HlsPlaylistFilterOptions | undefined,
     maxSegmentsToKeep: number,
     targetDuration: number,
     previousDiscontinuitySequence?: number,
@@ -147,41 +147,49 @@ export class HlsPlaylistMutator {
     );
 
     if (allSegments.length > maxSegmentsToKeep) {
-      const filtered = match(filterOptions)
-        .with({ type: 'before_date' }, ({ before }) =>
-          reject(allSegments, (segment) => segment.startTime.isBefore(before)),
-        )
-        .with(
-          {
-            type: 'before_segment_number',
-          },
-          (beforeSeg) => {
-            const minSeg = Math.max(
-              beforeSeg.segmentNumber - beforeSeg.segmentsToKeepBefore,
-              beforeSeg.segmentFloor ?? 0,
-            );
-            return seq.collect(allSegments, (segment) => {
-              const fileName = basename(segment.line);
-              const matches = fileName.match(SegmentNameRegex);
-              if (!matches || matches.length < 2) {
-                return;
-              }
-              const int = parseInt(matches[1]!);
-              if (isNaN(int)) {
-                return;
-              }
-              if (int < minSeg) {
-                return;
-              }
-              return segment;
-            });
-          },
-        )
-        .exhaustive();
+      const filtered = isUndefined(filterOptions)
+        ? allSegments
+        : match(filterOptions)
+            .with({ type: 'before_date' }, ({ before }) =>
+              reject(allSegments, (segment) =>
+                segment.startTime.isBefore(before),
+              ),
+            )
+            .with(
+              {
+                type: 'before_segment_number',
+              },
+              (beforeSeg) => {
+                const minSeg = Math.max(
+                  beforeSeg.segmentNumber - beforeSeg.segmentsToKeepBefore,
+                  beforeSeg.segmentFloor ?? 0,
+                );
+                return seq.collect(allSegments, (segment) => {
+                  const fileName = basename(segment.line);
+                  const matches = fileName.match(SegmentNameRegex);
+                  if (!matches || matches.length < 2) {
+                    return;
+                  }
+                  const int = parseInt(matches[1]!);
+                  if (isNaN(int)) {
+                    return;
+                  }
+                  if (int < minSeg) {
+                    return;
+                  }
+                  return segment;
+                });
+              },
+            )
+            .exhaustive();
 
+      // The window always tracks the live edge; the filter only acts as a
+      // floor. Taking from the front instead anchored the window to the oldest
+      // segment any client still wanted, freezing the playlist for every other
+      // viewer (issue #2045).
       allSegments =
         filtered.length >= maxSegmentsToKeep
-          ? take(filtered, maxSegmentsToKeep)
+          ? takeRight(filtered, maxSegmentsToKeep)
           : takeRight(allSegments, maxSegmentsToKeep);
     }
 

--- a/server/src/stream/hls/HlsSession.ts
+++ b/server/src/stream/hls/HlsSession.ts
@@ -26,7 +26,7 @@ import { filter, isEmpty, last, maxBy, sortBy } from 'lodash-es';
 import fs from 'node:fs/promises';
 import path, { basename, dirname, extname } from 'node:path';
 import type { DeepRequired } from 'ts-essentials';
-import { ProgramStreamFactory } from '../ProgramStreamFactory.ts';
+import type { ProgramStreamFactory } from '../ProgramStreamFactory.ts';
 import type { BaseHlsSessionOptions } from './BaseHlsSession.js';
 import { BaseHlsSession } from './BaseHlsSession.js';
 import { HlsMasterPlaylistMutator } from './HlsMasterPlaylistMutator.js';
@@ -112,12 +112,6 @@ export class HlsSession extends BaseHlsSession<HlsSessionOptions> {
   }
 
   async trimPlaylist(filterOpts?: HlsPlaylistFilterOptions) {
-    filterOpts ??= {
-      type: 'before_segment_number',
-      segmentNumber: this.minSegmentRequested,
-      segmentsToKeepBefore: 10,
-      // segmentFloor: this.#highestDeletedBelow,
-    };
     return Result.attemptAsync(async () => {
       return await this.lock.runExclusive(async () => {
         const playlistLines = await this.readPlaylist();


### PR DESCRIPTION
…aylist

The HLS playlist window was anchored to the lowest segment number any client had requested. HlsPlaylistMutator took the first maxSegmentsToKeep segments from that anchor, so the slowest viewer on a channel decided the window for everyone. A paused player, a backgrounded tab or a departed client held the manifest at its last segment while ffmpeg kept writing; every other viewer drained their buffer and stalled.

The window now always tracks the live edge. A filter, when given, only acts as a floor. A client that falls more than maxSegmentsToKeep behind gets a 404 and re-syncs, which is what live HLS origins do.

This removes the reason to track per-client segment numbers at all, so _minByIp, minSegmentRequested and onSegmentRequested are gone.

Fixes #2045